### PR TITLE
Enable automated testing of masterlist(s)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: ruby
+rvm: 2.1.0
+script: ruby -e "require 'yaml'; YAML.load_file('masterlist.yaml')"


### PR DESCRIPTION
This commit adds a `.travis.yml` file, which tells [Travis](https://travis-ci.org/) how to test the repository. This current setup is _very_ rudimentary and basically just tests whether the YAML of the masterlist parses or not. If it doesn't, it's very unhelpful in pointing out what's going wrong. But hey, at least it's saying that something's gone wrong, hopefully bringing committers' attention to it before users start taking notice. :)

It can be seen "in action" at https://travis-ci.org/Freso/skyrim

If this is something that seems useful, I can go through the other masterlist repositories and make similar Travis configurations for those, and probably for loot/loot as well. However, @WrinklyNinja is the owner of the (organisation of the) repositories, so he will have to go and enable them on the Travis site before they will have an effect.
