### PR TITLE
Load Order Corrections

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -34909,6 +34909,7 @@ plugins:
   - name: 'Change Follower Outfits Redux.esp'
     after:
       - 'Lively Followers.esp'
+      - 'Thieves Guild Followers and Spouses.esp'
     req:
       - name: 'Change Follower Outfits Redux -- Lively Followers Compatability.esp'
         display: '[Lively Followers Compatibility Patch](http://www.nexusmods.com/skyrim/mods/23798/)'
@@ -34925,15 +34926,6 @@ plugins:
       - name: 'Change Follower Outfits Redux -- Dragonborn.esp'
         display: '[Dragonborn Compatibility Patch](http://www.nexusmods.com/skyrim/mods/23798/)'
         condition: 'active("Dragonborn.esm")'
-  - name: 'Change Follower Outfits Redux -- Dawnguard.esp'
-    after:
-      - 'Change Follower Outfits Redux.esp'
-  - name: 'Change Follower Outfits Redux -- Hearthfire.esp'
-    after:
-      - 'Change Follower Outfits Redux.esp'
-  - name: 'Change Follower Outfits Redux -- Dragonborn.esp'
-    after:
-      - 'Change Follower Outfits Redux.esp'
   - name: 'Change Follower Outfits Redux -- USKP 1.2 Farkas Compatability.esp'
     after:
       - 'Change Follower Outfits Redux.esp'


### PR DESCRIPTION
Change Follower Outfit plugins not dependent on master file, removed
load after instructions, added load after for Thieves Guild Followers
and Spouses for compatibility with Change Follower Outfits.
