### PR TITLE
Added RSkyrimChildren Load Conditions

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -97,6 +97,8 @@ plugins:
         itm: 92
   - name: 'Unofficial Skyrim Patch.esp'
     priority: -1999000
+    after:
+      - name: 'RSkyrimChildren.esm'
     msg:
       - type: say
         condition: 'active("Dawnguard.esm") and not file("Unofficial Dawnguard Patch.esp")'
@@ -24811,6 +24813,17 @@ plugins:
       - crc: 0xb96f7183
         util: *dirtyUtil
         itm: 6
+  - name: 'RSkyrimChildren.esm'
+    msg:
+      - type: warn
+        condition: 'active("Unofficial Skyrim Patch.esp") and not file("RSChildren_PatchUSKP.esp")'
+        content:
+          - lang: en
+            str: 'The [RSChildren USKP Patch](http://www.nexusmods.com/skyrim/mods/55555/?) is required.'
+          - lang: ru
+            str: '[RSChildren USKP Patch](http://www.nexusmods.com/skyrim/mods/55555/?) требуется.'
+          - lang: es
+            str: 'Se requiere [RSChildren USKP Patch](http://www.nexusmods.com/skyrim/mods/55555/?.'
   - name: 'Killable Children - Quest Important Protected.esp'
     dirty:
       - crc: 0x4231901c


### PR DESCRIPTION
Realistic Skyrim Children has some odd load conditions, and needs to be
loaded before the USKP (with a compatibility patch after the USKP) in
order to prevent it from interfering with USKP fixes that it didn't
carry over without breaking its functionality.
