### PR TITLE
Removed Warning to require RSkyrimChildren Patch

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -24811,17 +24811,6 @@ plugins:
       - crc: 0xb96f7183
         util: *dirtyUtil
         itm: 6
-  - name: 'RSkyrimChildren.esm'
-    msg:
-      - type: warn
-        condition: 'active("Unofficial Skyrim Patch.esp") and not file("RSChildren_PatchUSKP.esp")'
-        content:
-          - lang: en
-            str: 'The [RSChildren USKP Patch](http://www.nexusmods.com/skyrim/mods/55555/?) is required.'
-          - lang: ru
-            str: '[RSChildren USKP Patch](http://www.nexusmods.com/skyrim/mods/55555/?) требуется.'
-          - lang: es
-            str: 'Se requiere [RSChildren USKP Patch](http://www.nexusmods.com/skyrim/mods/55555/?.'
   - name: 'Killable Children - Quest Important Protected.esp'
     dirty:
       - crc: 0x4231901c


### PR DESCRIPTION
Given the uncertainty about the necessity of the USKP patch for this
mod, might be best to just leave the warning out till we get some
clarification from the author on this. As states here
(http://forums.bethsoft.com/topic/1503686-rel-loot-thread-10/page-7#entry23710051)
there is no conflict between the USKP and this mod, so the purpose of
the compatibility patch is unclear. Additionally, the patch and the main
file's masters' load order is not in agreement, so there is really no
way for LOOT to properly sort these.
