### PR TITLE
Added ITM info

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -31504,6 +31504,39 @@ plugins:
       - crc: 0xb9fc7507
         util: *dirtyUtil
         itm: 10
+      - crc: 0x4321049d
+        util: *dirtyUtil
+        itm: 39
+  - name: 'tos_laintardale_hf.esp'
+    dirty:
+      - crc: 0xe536de07
+        util: *dirtyUtil
+        itm: 13
+  - name: 'SerenityCrewPatch.esp'
+    dirty:
+      - crc: 0x8de14c64
+        util: *dirtyUtil
+        itm: 3
+  - name: 'Morskom.esp'
+    dirty:
+      - crc: 0x700cd98d
+        util: *dirtyUtil
+        itm: 8
+  - name: 'SeaPointSettlement.esp'
+    msg:
+      - type: say
+        content:
+          - lang: en
+            str: 'Do not clean. "Dirty" edits are intentional and required for the mod to function.'
+          - lang: ru
+            str: 'Не очищать. "Грязные" правки оставлены специально и требуются для функционирования мода.'
+          - lang: es
+            str: 'Do not clean. "Dirty" edits are intentional and required for the mod to function.'
+  - name: 'SerenitySeapointPatch.esp'
+    dirty:
+      - crc: 0x74F86411
+        util: *dirtyUtil
+        itm: 4
   - name: 'Ja´dirr + Kharjo Makeover.esp'
     msg:
       - type: say


### PR DESCRIPTION
Added ITM info for Inigo, Morskom, Laintardale HF edition, Serenity Crew
Patch and Serenity SeaPoint Patch. Added a do not clean request to
SeaPoint per author's request.
