### PR TITLE
Add some data for `Immersive detection of NPC.esp`.

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -36355,3 +36355,7 @@ plugins:
   - name: 'Verdant - A Skyrim Grass Plugin.esp'
     after:
       - 'Skyrim Flora Overhaul.esp'
+      
+  - name: 'Immersive detection of NPC.esp'
+    after:
+      - 'Combat Evolved.esp'


### PR DESCRIPTION
"Even though Combat Evolved now includes a minor sneak/stealth overhaul,
players can still use their favorite sneak or stealth overhaul with
Combat Evolved.  Just place it after Combat Evolved in the load order so
it will overwrite most of Combat Evolved sneak settings."