### PR TITLE
General rules for WAF, RWT, and AOS. Other minor changes too.

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2853,6 +2853,9 @@ plugins:
       - Delev
       - Relev
       - Stats
+  - name: 'Weapons & Armor_TrueOrcish&DaedricWeapons.esp'
+    after:
+      - 'Weapons & Armor Fixes_Remade.esp'
   - name: 'Clothing & Clutter Fixes.esp'
     after:
       - 'Weapons & Armor Fixes_Remade.esp'
@@ -3238,6 +3241,9 @@ plugins:
 # ## MoreSoundOptions.esp
 # ## suggested to load before ADS
   - name: 'AOS.esp'
+    after:
+      - 'WetandCold.esp'
+      - 'RealisticWaterTwo.esp'
     dirty:
       - crc: 0xd88afe72
         util: *dirtyUtil
@@ -12458,6 +12464,7 @@ plugins:
     after:
       - 'Weapons & Armor Fixes_Remade.esp'
       - 'Clothing & Clutter Fixes.esp'
+      - 'aMidianBorn_ContentAddon.esp'
   - name: 'CCO_Frostfall_Patch.esp'
     dirty:
       - crc: 0x7b3ce75d
@@ -35150,6 +35157,9 @@ plugins:
       - crc: 0xad1d1564
         util: *dirtyUtil
         itm: 220
+  - name: 'SkyFalls + SkyMills + DG + DB.esp'
+    after:
+      - 'Distant DetailHF.esp'
   - name: 'SeeEnchs.esp'
     msg:
       - type: say
@@ -35190,6 +35200,13 @@ plugins:
       - 'SkyFalls Dragonborn Small waterfalls.esp'
       - 'SkyFalls Falskaar Small waterfalls.esp'
       - 'SkyFalls DB + FS Small Waterfalls.esp'
+      - 'FarmhouseChimneys.esp'
+      - 'SDO Full-LOD - Waterfall Effects.esp'
+      - 'BirdsHFclean.esp'
+      - 'Point The Way.esp'
+      - 'Book Covers Skyrim.esp'
+      - 'Ducks and Swans.esp'
+      - 'Helgen Reborn.esp'
   - name: 'RealisticWaterTwo - Legendary.esp'
     after:
       - 'SkyFalls + SkyMills.esp'
@@ -35895,21 +35912,21 @@ plugins:
         condition: 'file("Skyrim Performance MOD.esp")'
 ## STEP
   - name: 'STEP Core Patch.esp'
-    priority: 1988000
+    priority: 1980000
     tag:
       - Stats
       - Names
   - name: 'STEP Extended Patch.esp'
-    priority: 1989000
+    priority: 1980000
     tag:
       - Stats
       - Names
       - Delev
       - Relev
   - name: 'STEP Combined Plugin.esp'
-    priority: 1986000
+    priority: 1980000
   - name: 'STEP Combined PluginHF.esp'
-    priority: 1987000
+    priority: 1980000
   - name: 'World_Map_Height_Pitch_Tweak.esp'
     msg:
       - type: say

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2853,9 +2853,6 @@ plugins:
       - Delev
       - Relev
       - Stats
-  - name: 'Weapons & Armor_TrueOrcish&DaedricWeapons.esp'
-    after:
-      - 'Weapons & Armor Fixes_Remade.esp'
   - name: 'Clothing & Clutter Fixes.esp'
     after:
       - 'Weapons & Armor Fixes_Remade.esp'
@@ -25439,6 +25436,8 @@ plugins:
       - Relev
       - Stats
   - name: 'Weapons & Armor_TrueOrcish&DaedricWeapons.esp'
+    after:
+      - 'Weapons & Armor Fixes_Remade.esp'
     tag:
       - Delev
       - Relev


### PR DESCRIPTION
WAF True Orcish/Deadric Weapons patch needed to load after WAF.

RWT loading after most except AOS results in the not needing a patch at
all.  Added some mods it should load after for CELL record conflicts.

AOS should load after RWT which makes the AOS/RWT patch irrelevant. Both
change same thing and AOS should win.

CCOR needs to load after AMB Content Addon.

SkyFalls/Mills needs to load after Distant Detail or some falls will not
show correctly.

Change priority of STEP Patches to match since Sharlikran mentioned that
would be better.