### PR TITLE
Airborne Perching Birds.

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6409,6 +6409,12 @@ plugins:
   - name: 'SKSE_Athletics.esp'
     req: [ *SKSE ]
   - name: 'skyBirds - Airborne Perching Birds.esp'
+    after:
+      - 'Birds.esp'
+      - 'BirdsHF.esp'
+      - 'Birdsclean.esp'
+      - 'BirdsHFclean.esp'
+      - 'Birdsofskyrim.esp' 
     dirty:
       - crc: 0x131bb61c
         util: *dirtyUtil


### PR DESCRIPTION
"Birds and Flocks" or "Birds and Flocks Hearthfire Edition" - skyBirds fixes script bugs in this mod."

and ...

skyBirds is fully compatible with "Birds of Skyrim", "Birds and Flocks" and "SkyTEST". Please load skyBirds AFTER "Birds of Skyrim" and "Birds and Flocks".

So here are the rules for that.