### PR TITLE
Landscape Texture Transition Fix

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -325,6 +325,7 @@ plugins:
         condition: 'version("Unofficial Dawnguard Patch.esp", "2.0", >=)'
       - 'SMPC_DG.esp'
       - 'SCO Winter Landscape Decoloration.esp'
+      - '[JmV]LTTF.esm'
     tag:
       - C.Location
       - Graphics


### PR DESCRIPTION
[Landscape Texture Transition Fix](http://www.nexusmods.com/skyrim/mods/66245/) makes changes that may conflict with the Heartfire DLC. As per the author's suggestion, makes `[JmV]LTTF.esm` load before the DLC.