### PR TITLE
Improve Requiem Patch Sorting

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -12769,6 +12769,37 @@ plugins:
           - lang: es
             str: 'Usar Requiem - Weapon Damage Modifier 2x Vanilla.esp o Requiem - Weapon Damage Modifier 3x Vanilla.esp, no ambos.'
         condition: 'file("Requiem - Weapon Damage Modifier 2x Vanilla.esp")'
+  - name: 'Requiem - NRM Dragonborn.esp'
+    after:
+      - 'Requiem - USKP + UDGP.esp'
+      - 'Requiem - Bring Out Your Dead.esp'
+      - 'Requiem - Hearthfire.esp'
+  - name: 'Requiem - Kryptopyr''s Fixes Reqtified.esp'
+    after:
+      - 'Requiem - USKP + UDGP.esp'
+      - 'Requiem - Bring Out Your Dead.esp'
+      - 'Requiem - Hearthfire.esp'
+      - 'Requiem - Height Adjusted Races with True Giants.esp'
+  - name: 'KFR-Kryptopyr''sFixesReqtified.esp'
+    after:
+      - 'Requiem - USKP + UDGP.esp'
+      - 'Requiem - Bring Out Your Dead.esp'
+      - 'Requiem - Hearthfire.esp'
+      - 'Requiem - Height Adjusted Races with True Giants.esp'
+  - name: 'Requiem - Crafting Overhaul Reqtified.esp'
+    after:
+      - 'Requiem - USKP + UDGP.esp'
+      - 'Requiem - Bring Out Your Dead.esp'
+      - 'Requiem - Hearthfire.esp'
+      - 'Requiem - Height Adjusted Races with True Giants.esp'
+      - 'Requiem - NRM Dragonborn.esp'
+  - name: 'COR-CraftingOverhaulReqtified.esp'
+    after:
+      - 'Requiem - USKP + UDGP.esp'
+      - 'Requiem - Bring Out Your Dead.esp'
+      - 'Requiem - Hearthfire.esp'
+      - 'Requiem - Height Adjusted Races with True Giants.esp'
+      - 'Requiem - NRM Dragonborn.esp'
   - name: 'Skyrim Hardcore Overhaul.esp'
     tag:
       - Delev


### PR DESCRIPTION
Some compatibility patches for Requiem are handled poorly by LOOT. This should force a few patches to follow the load order specified at http://www.nexusmods.com/skyrim/mods/61621