### PR TITLE
Darkend after AOS

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -12561,7 +12561,7 @@ plugins:
     dirty:
       - crc: 0x17257c94
         util: *dirtyUtil
-        itm: 79
+        itm: 86
         udr: 2
   - name: 'BecomeKingOfRiverHelm.esp'
     msg:
@@ -29872,3 +29872,7 @@ plugins:
 # Load Ordinator after other perk mods so it has precedence.
   - name: 'Ordinator - Perks of Skyrim.esp'
     priority: 1
+  - name: 'Darkend.esp'
+    after:
+      - 'AOS.esp'
+    url: [ 'http://www.nexusmods.com/skyrim/mods/67559' ]


### PR DESCRIPTION
- Added Darkend
- Fixed incorrect ITM count for Beautiful Whiterun

Based on my current load order the only conflict I found with [Darkend](http://www.nexusmods.com/skyrim/mods/67559) was a single sound descriptor record in AOS: 0010D9B5