### PR TITLE
Cyclic fix for Perkus Maximus

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -29582,8 +29582,6 @@ plugins:
       - Relev
 
   - name: 'PerkusMaximus_Master.esp'
-    after:
-      - Complete Crafting Overhaul_Remade.esp
     tag:
       - Names
     msg:


### PR DESCRIPTION
Cyclic between Clothing & Clutter Fixes.esp, Complete Crafting Overhaul_Remade.esp, and PerkusMaximus_Master.esp
Perkus Maximus has compatibility patches for both CCF and CCOR so sorting it after CCOR serves no purpose. PerkusMaximus_Master.esp is also technically an esm, so is naturally sorted to the top of the load order.