### PR TITLE
Substituted Deleted Navmesh Messages for Nav tags

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -523,23 +523,11 @@ plugins:
           - lang: zh_CN
             str: '这个esm文件会破坏你的游戏。我们强烈建议你使用官方版本的[Unofficial Skyrim Patch](http://www.nexusmods.com/skyrim/mods/19)。不要做任何修改。'
   - name: 'MoT_First_LoadOrder_File_After_Skyrim.esm'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ko
-            str: '이 파일에는 TES5Edit이 자동으로 복구할 수 없는 1개의 삭제된 NavMesh 레코드가 포함되어 있으며 이는 게임에 문제가 발생 할 수도 있습니다. NavMesh의 삭제는 모드 제작자에게 보고해야합니다. [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859)으로 NavMesh의 삭제를 복구하는 방법은 [여기](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html)에 있습니다.'
-          - lang: zh_CN
-            str: '这个文件包含1个已删除的导航记录，TES5Edit无法自动修复，它可能导致你的游戏出现问题。导航缺失应该报告给mod作者。这里有一份使用[TES5Edit](http://www.nexusmods.com/skyrim/mods/25859)修复导航缺失的[教程](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html)。'
     dirty:
       - crc: 0x6d3163ad
         util: *dirtyUtil
         itm: 22
+        nav: 1
   - name: 'Skyrim Project Optimization.esm'
     priority: -1998000
   - name: 'Skyrim Project Optimization - No Homes.esm'
@@ -659,21 +647,12 @@ plugins:
   - name: 'BertsBreezeCellar.v.1.0(esm).esm'
     msg:
       - *obsolete
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 2 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 2 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 2 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: zh_CN
-            str: '这个文件包含2个已删除的导航记录，TES5Edit无法自动修复，它可能导致你的游戏出现问题。导航缺失应该报告给mod作者。这里有一份使用[TES5Edit](http://www.nexusmods.com/skyrim/mods/25859)修复导航缺失的[教程](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html)。'
     dirty:
       - crc: 0x9fd43df3
         util: *dirtyUtil
         itm: 53
         udr: 12
+        nav: 2
   - name: '0001BertsBreezehomeRemodel.V.2(esm).esm'
     dirty:
       - crc: 0xdee46a0b
@@ -701,36 +680,20 @@ plugins:
           - lang: es
             str: 'Obsoleto. Actualizar a la Breezehome_Basement.esp en [Shawks Corner](http://www.nexusmods.com/skyrim/mods/43593).'
   - name: 'Castle Draco Master File Load First.esm'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 28 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 28 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 28 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     tag:
       - Delev
     dirty:
       - crc: 0x39bc4317
         util: *dirtyUtil
         itm: 1451
+        nav: 28
   - name: 'CastleDrakhur_masterfle.esm'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 6 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 6 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 6 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x7bc1ae65
         util: *dirtyUtil
         itm: 23
         udr: 7
+        nav: 6
   - name: 'Celestial-Hairstyles.esm'
     dirty:
       - crc: 0x9e4d41f9
@@ -849,19 +812,11 @@ plugins:
   - name: 'Expanded Towns.*\.esm'
     msg: [ *obsolete ]
   - name: 'ExplorerDungeonPack.esm'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0xf28e0e3c
         util: *dirtyUtil
         itm: 9
+        nav: 1
   - name: 'Extended Colors.esm'
     msg: [ *obsolete ]
   - name: 'Unofficial High Resolution Patch.esp'
@@ -887,15 +842,6 @@ plugins:
         condition: 'many("GuardedHouse(Imperial|Stormcloak)?\.esm")'
         subs: [ 'GuardedHouse .esm file' ]
   - name: 'GuardedHouse.esm'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 2 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 2 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 2 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     tag:
       - Relev
     dirty:
@@ -903,16 +849,8 @@ plugins:
         util: *dirtyUtil
         itm: 475
         udr: 50
+        nav: 2
   - name: 'GuardedHouseImperial.esm'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 2 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 2 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 2 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     tag:
       - Relev
     dirty:
@@ -920,16 +858,8 @@ plugins:
         util: *dirtyUtil
         itm: 469
         udr: 60
+        nav: 2
   - name: 'GuardedHouseStormcloak.esm'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 2 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 2 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 2 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     tag:
       - Relev
     dirty:
@@ -937,6 +867,7 @@ plugins:
         util: *dirtyUtil
         itm: 469
         udr: 58
+        nav: 2
   - name: 'hideout.esm'
     msg:
       - type: warn
@@ -1126,20 +1057,12 @@ plugins:
         util: *dirtyUtil
         itm: 1
   - name: 'motTome2.esm'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 16 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 16 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 16 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x5a0212ce
         util: *dirtyUtil
         itm: 104
         udr: 31
+        nav: 16
   - name: 'MTAutoStorage.esm'
     dirty:
       - crc: 0x7c0f98ca
@@ -1250,51 +1173,27 @@ plugins:
         util: *dirtyUtil
         itm: 17
   - name: 'PrisonUpdate.esm'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 3 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 3 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 3 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x41a40641
         util: *dirtyUtil
         itm: 167
         udr: 77
+        nav: 3
   - name: 'Populated Cities NPCListMaster.esm'
     msg: [ *obsolete ]
   - name: 'Ranger Ridge.esm'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x98145fb5
         util: *dirtyUtil
         itm: 274
+        nav: 1
   - name: 'RiverHelm.esm'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 50 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 50 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 50 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x41b8b722
         util: *dirtyUtil
         itm: 3700
         udr: 192
+        nav: 50
 # ## MOD: S´Drass follower.esm
 # ## Removing the MOD: tag from this seems to cause crashes.
   - name: 'SC_Drow Race.esm'
@@ -1321,19 +1220,11 @@ plugins:
             str: 'FNIS_SexLab_List.txt is not installed. Animations of mod wont be added in the FNIS list and wont be work in game. Before install through Wrye Bash Bain you should choise ''Override Skips'' option for archive of this mod in the ''Installers'' tab.'
         condition: 'not file("meshes\actors\character\animations\SexLab\FNIS_SexLab_List.txt")'
   - name: 'SG_BlacksmithsCavern.esm'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x564d3a3b
         util: *dirtyUtil
         itm: 20
+        nav: 1
   - name: 'Sirenia.esm'
     msg:
       - type: say
@@ -1385,24 +1276,17 @@ plugins:
 # ## SmithBornMaterials.esm
 # ## Must load after SmithBornPerks.esm
   - name: 'Solitude A City Of Trade.esm'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 2 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 2 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 2 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x89696ea3
         util: *dirtyUtil
         itm: 10
         udr: 0
+        nav: 2
       - crc: 0xfb48bbe3
         util: *dirtyUtil
         itm: 9
         udr: 4
+        nav: 2
   - name: 'SpecializedFollowers.esm'
     msg: [ *obsolete ]
   - name: 'SPTDiverseGuardsSkyrimResources.esm'
@@ -1714,48 +1598,14 @@ plugins:
         condition: 'file("SkyRe_Main.esp") or file("SkyRe_Main_NoDawnguard.esp")'
   - name: 'breezehomelightfix.esp'
     msg: [ *AlreadyInUSKP ]
-  - name: 'BreezehomeLadderFix.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 2 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 2 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 2 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-        condition: 'checksum("BreezehomeLadderFixJP.esp",94D3C2C0)'
-      # leave navmesh checksums 7CA22630 in this one given disparity
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 32 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 32 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 32 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-        condition: 'checksum("BreezehomeLadderFixJP.esp",94D3C2C0)'
   - name: 'BreezehomeLadderFixJP.esp'
-    msg:
-      - type: warn
-        condition: 'checksum("BreezehomeLadderFixJP.esp",F2BAA689)'
-        content:
-          - lang: en
-            str: 'This file contains 2 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 2 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 2 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-      - type: warn
-        condition: 'checksum("BreezehomeLadderFixJP.esp",94D3C2C0)'
-      # leave navmesh checksums 7CA22630 in this one given disparity
-        content:
-          - lang: en
-            str: 'This file contains 32 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 32 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 32 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
+    dirty:
+      - crc: 0xF2BAA689
+        util: *dirtyUtil
+        nav: 2
+      - crc: 0x94D3C2C0
+        util: *dirtyUtil
+        nav: 32
     inc:
       - 'BreezehomeLadderFix.esp'
   - name: 'BreezehomeLightingFix.esp'
@@ -3643,20 +3493,12 @@ plugins:
       - 'BabettesFeastBalanced.esp'
       - 'BabettesFeastOverpowered.esp'
   - name: 'Baby Dragons.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 13 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 13 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 13 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0xf1f78cb8
         util: *dirtyUtil
         itm: 104
         udr: 51
+        nav: 13
   - name: 'Back off, [Subject Name Here]!.esp'
     msg:
       - type: warn
@@ -3741,15 +3583,6 @@ plugins:
         itm: 3
         udr: 0
   - name: 'bbLager.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 3 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 3 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 3 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     tag:
       - Delev
       - Relev
@@ -3757,6 +3590,7 @@ plugins:
       - crc: 0x68c5a371
         util: *dirtyUtil
         itm: 30
+        nav: 3
   - name: 'bbLagerLight.esp'
     dirty:
       - crc: 0x7aea5a0a
@@ -5001,19 +4835,11 @@ plugins:
       - name: 'More Craftables.esp'
         display: '[More Craftables](http://www.nexusmods.com/skyrim/mods/799)'
   - name: 'More Escape Passages.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x5e1c828f
         util: *dirtyUtil
         itm: 3
+        nav: 1
   - name: 'More_Hides.esp'
     dirty:
       - crc: 0xc1457e3c
@@ -5209,20 +5035,12 @@ plugins:
         util: *dirtyUtil
         itm: 26
   - name: 'Project-Legacy.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x29a43728
         util: *dirtyUtil
         itm: 21
         udr: 263
+        nav: 1
   - name: 'Prides of Skyrim( weak)?\.esp'
     tag:
       - Relev
@@ -9676,22 +9494,12 @@ plugins:
       - Delev
       - Relev
   - name: 'The_IVth_Legion.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x3008aaa
         util: *dirtyUtil
         itm: 9
         udr: 41
+        nav: 1
   - name: 'tea junkie bow.esp'
     dirty:
       - crc: 0x5ee180c6
@@ -11235,20 +11043,12 @@ plugins:
     tag:
       - Relev
   - name: 'Monster Wars.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 9 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 9 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 9 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0xba316da7
         util: *dirtyUtil
         itm: 302
         udr: 16
+        nav: 9
 # IF VAR(SkyReM) MOD: Reanimate FX.esp
 # As the author suggested
 # SkyRe Section
@@ -12050,21 +11850,12 @@ plugins:
         itm: 10
         udr: 16
   - name: '2013HalloweenOverhaulMod.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 7 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 7 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 7 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-        condition: 'checksum("2013HalloweenOverhaulMod.esp",F2B291D4)'
     dirty:
       - crc: 0xf2b291d4
         util: *dirtyUtil
         itm: 334
         udr: 434
+        nav: 7
   - name: '28 Days and a Bit 5.esp'
     msg:
       - type: error
@@ -12113,32 +11904,16 @@ plugins:
   - name: 'Abadonedshack_0.5b.esp'
     msg: [ *corrupt ]
   - name: 'AdalMatar.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 5 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 5 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 5 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-        condition: 'checksum("AdalMatar.esp",5B12DD15)'
-      - type: say
-        content:
-          - lang: en
-            str: 'V1.1+: This file contains 3 deleted NavMesh records that TES5Edit cannot repair automatically, and which are reported by the mod author to be harmless artifacts from Creation Kit export.'
-          - lang: ru
-            str: 'V1.1+: Содержит 3 удаленных NavMesh записей, которые не могут быть автоматически восстановленны в TES5Edit, и которые, по сообщению автора, были безвредными артефактами, экспортированнымиих Creation Kit.'
-          - lang: es
-            str: 'V1.1+: This file contains 3 deleted NavMesh records that TES5Edit cannot repair automatically, and which are reported by the mod author to be harmless artifacts from Creation Kit export.'
     dirty:
       - crc: 0x5b12dd15
         util: *dirtyUtil
         itm: 183
         udr: 1
+        nav: 5
       - crc: 0xba0c35c4
         util: *dirtyUtil
         itm: 17
+        nav: 3
   - name: 'AdragoniusTower.esp'
     dirty:
       - crc: 0xee105604
@@ -12209,53 +11984,29 @@ plugins:
         util: *dirtyUtil
         itm: 18
   - name: 'akavir_isle.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 3 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 3 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 3 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x49b8685d
         util: *dirtyUtil
         itm: 7
         udr: 17
+        nav: 3
   - name: 'akavirifort.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 12 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 12 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 12 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0xa602daca
         util: *dirtyUtil
         itm: 23
+        nav: 12
   - name: 'AkaviriGuild.esp'
     dirty:
       - crc: 0x3fcf3bc3
         util: *dirtyUtil
         itm: 10
   - name: 'Akry.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x1885d037
         util: *dirtyUtil
         itm: 28
+        nav: 1
   - name: 'alb084ImmersiveFollowers.esp'
     dirty:
       - crc: 0x5be44f8c
@@ -12273,20 +12024,12 @@ plugins:
         itm: 2
         udr: 15
   - name: 'Amberhalls Heartwood Village.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 988 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 988 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 988 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x119ac39e
         util: *dirtyUtil
         itm: 11
         udr: 113
+        nav: 988
   - name: 'AMRetreat.esp'
     dirty:
       - crc: 0x35b13c96
@@ -12334,20 +12077,12 @@ plugins:
         util: *dirtyUtil
         itm: 63
   - name: 'armybasement.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 35 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 35 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 35 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x2eadf762
         util: *dirtyUtil
         itm: 13
         udr: 1
+        nav: 35
   - name: 'arthyngrad sanctum.esp'
     dirty:
       - crc: 0xe6efd739
@@ -12398,34 +12133,18 @@ plugins:
         itm: 116
         udr: 286
   - name: 'B3.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 7 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 7 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 7 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x58681624
         util: *dirtyUtil
         itm: 1
+        nav: 7
   - name: 'B3BH.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 7 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 7 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 7 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0xa4f56ddf
         util: *dirtyUtil
         itm: 29
         udr: 1
+        nav: 7
   - name: 'B3HF.esp'
     dirty:
       - crc: 0x615f79df
@@ -12436,33 +12155,19 @@ plugins:
         itm: 29
         udr: 128
   - name: 'B3HFBH.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 7 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 7 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 7 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x58681624
         util: *dirtyUtil
         itm: 5
         udr: 1
+        nav: 7
   - name: 'WBDen.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 7 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 7удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0xfd50138c
         util: *dirtyUtil
         itm: 29
         udr: 128
+        nav: 7
   - name: 'BankofMarkarth.esp'
     dirty:
       - crc: 0xc79214d7
@@ -12538,20 +12243,12 @@ plugins:
         util: *dirtyUtil
         udr: 22
   - name: 'BeardedClam.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 2 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 2 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 2 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0xa8d641d3
         util: *dirtyUtil
         itm: 144
         udr: 3
+        nav: 2
   - name: 'Beautiful Riften.esp'
     dirty:
       - crc: 0xe56e690b
@@ -12565,53 +12262,28 @@ plugins:
         itm: 86
         udr: 2
   - name: 'BecomeKingOfRiverHelm.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 12 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 12 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 12 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x503c8747
         util: *dirtyUtil
         itm: 60
         udr: 166
+        nav: 12
   - name: 'BertsBreezeCellar(esp.V.1.0).esp'
     msg: [ *obsolete ]
   - name: 'BertsBreezeCellar(esp.V2.0).esp'
-    msg:
-      - *obsolete
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 2 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 2 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 2 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x3edc9220
         util: *dirtyUtil
         itm: 5
         udr: 66
+        nav: 2
   - name: 'BertsBreezeCellar(esp.V3.0).esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 2 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 2 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 2 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x8975b037
         util: *dirtyUtil
         itm: 10
         udr: 195
+        nav: 2
   - name: 'BertsBreezehomeCellar.I.1.3.esp'
     msg:
       - type: warn
@@ -12623,19 +12295,11 @@ plugins:
           - lang: es
             str: 'TES5Edit Msg - The volume for a file has been externally altered so that the opened file is no longer valid (BertsBreezehomeCellar.I.1.3.esp)'
   - name: 'BertsBreezehomeCellar(Grotto).esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 2 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 2 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 2 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x88dc7d3b
         util: *dirtyUtil
         itm: 16
+        nav: 2
   - name: 'BertsBreezehomeGreenhouse.esp'
     dirty:
       - crc: 0x5066da46
@@ -12693,58 +12357,24 @@ plugins:
         util: *dirtyUtil
         itm: 20
   - name: '0001BertsBreezehomeRemodel.V.2(esp.2.0).esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 2 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 2 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 2 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x5aee2d89
         util: *dirtyUtil
         itm: 13
         udr: 1
+        nav: 2
   - name: '0001BertsBreezehomeRemodel.V.2(Grotto).esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0xb7e0e7ab
         util: *dirtyUtil
         itm: 23
+        nav: 1
   - name: '0001BertsBreezehomeRemodel.V.2(LydiaAddon.V.1).esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0xbc3e8547
         util: *dirtyUtil
         itm: 3
-  - name: '0001BertsBreezehomeRemodel.V.2(Spouse).esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
+        nav: 1
   - name: 'betterbreezehome.esp'
     after:
       - 'FalkreathCastle.esp'
@@ -12769,24 +12399,17 @@ plugins:
         itm: 1
         udr: 1
   - name: 'BetterDarkBrotherhood.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 2 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 2 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 2 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x6e40868
         util: *dirtyUtil
         itm: 118
         udr: 27
+        nav: 2
       - crc: 0xe0c083ad
         util: *dirtyUtil
         itm: 149
         udr: 26
+        nav: 2
   - name: 'BetterDGEntrance.esp'
     dirty:
       - crc: 0x2eb928ab
@@ -12826,26 +12449,6 @@ plugins:
       - crc: 0x403c225
         util: *dirtyUtil
         udr: 58
-  - name: 'betterinns.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-  - name: 'bettermorthal.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
   - name: 'BetterRiften.esp'
     dirty:
       - crc: 0x2fccbdac
@@ -12919,35 +12522,19 @@ plugins:
         util: *dirtyUtil
         itm: 3
   - name: 'Bluecreek Estate.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 18 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 18 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 18 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x2a3d0978
         util: *dirtyUtil
         itm: 60
         udr: 81
+        nav: 18
   - name: 'Borderlands.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 34 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 34 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 34 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x44062b91
         util: *dirtyUtil
         itm: 16
         udr: 80
+        nav: 34
   - name: 'breezehome-darkdream.esp'
     msg: [ *obsolete ]
   - name: 'breezehome enhanced.esp'
@@ -12955,18 +12542,11 @@ plugins:
       - type: say
         content: 'Incompatible with: BertsBreezeRemodel'
         condition: 'regex("(0001)?BertsBreezehome.+\.es[pm]")'
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 2 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 2 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 2 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x1f629b97
         util: *dirtyUtil
         itm: 18
+        nav: 2
   - name: 'Breezehomeexpansion-darkdream.esp'
     dirty:
       - crc: 0xa89e0aea
@@ -12975,14 +12555,6 @@ plugins:
         udr: 1
   - name: 'Breezehome_FullyUpgradable.esp'
     msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 2 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 2 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 2 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
       - type: say
         content: 'Incompatible with: BertsBreezeRemodel'
         condition: 'regex("(0001)?BertsBreezehome.+\.es[pm]")'
@@ -12991,6 +12563,7 @@ plugins:
         util: *dirtyUtil
         itm: 22
         udr: 2
+        nav: 2
   - name: 'Breezehome_FullyUpgradable_v.+\.esp'
     msg:
       - type: say
@@ -13019,20 +12592,12 @@ plugins:
     inc:
       - 'Breezehome Mannequins Lite.esp'
   - name: 'Breezehome Nordic House v.3.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 2 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 2 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 2 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x296c53fd
         util: *dirtyUtil
         itm: 16
         udr: 387
+        nav: 2
   - name: 'Breezehome Remodeled Finely.esp'
     msg:
       - type: say
@@ -13082,103 +12647,47 @@ plugins:
       - crc: 0xfb206d13
         util: *dirtyUtil
         udr: 1
-  - name: 'Breezehome_for_Powerusers.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 2 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 2 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 2 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
   - name: 'BreezehomeRenovation(Fem|JP|FemJP|FSW|FSWJP)?\.esp'
     msg:
       - <<: *useOnlyOneX
         condition: 'many("BreezehomeRenovation(Fem|JP|FemJP|FSW|FSWJP)?\.esp")'
         subs: [ 'BreezehomeRenovation .esp file' ]
   - name: 'BreezehomeRenovationFemJP.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x4df14350
         util: *dirtyUtil
         udr: 19
+        nav: 1
   - name: 'BreezehomeRenovationFem.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x5c313e5b
         util: *dirtyUtil
         udr: 19
+        nav: 1
   - name: 'BreezehomeRenovationFSWJP.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1x удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x8e58df5
         util: *dirtyUtil
         udr: 29
+        nav: 1
   - name: 'BreezehomeRenovationFSW.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0xf94b1083
         util: *dirtyUtil
         udr: 29
+        nav: 1
   - name: 'BreezehomeRenovationJP.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x1b7a18af
         util: *dirtyUtil
         udr: 19
+        nav: 1
   - name: 'BreezehomeRenovation.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0xe4af58e1
         util: *dirtyUtil
         udr: 19
+        nav: 1
   - name: 'Breezehome Revised.*\.esp'
     msg:
       - <<: *useOnlyOneX
@@ -13198,20 +12707,12 @@ plugins:
   - name: 'Briar''sEndCourierQuest.esp'
     inc:
       - 'Fleetford.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 3 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 3 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 3 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x30cd77f3
         util: *dirtyUtil
         itm: 48
         udr: 10
+        nav: 3
   - name: 'Briar''sEnd(Instant|Courier|No)Quest\.esp'
     msg:
       - <<: *useOnlyOneX
@@ -13220,37 +12721,21 @@ plugins:
   - name: 'Briar''sEndInstantQuest.esp'
     inc:
       - 'Fleetford.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 3 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 3 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 3 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x3beedc33
         util: *dirtyUtil
         itm: 48
         udr: 10
+        nav: 3
   - name: 'Briar''sEndNoQuest.esp'
     inc:
       - 'Fleetford.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 3 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 3 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 3 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0xdc577da1
         util: *dirtyUtil
         itm: 50
         udr: 10
+        nav: 3
   - name: 'Bridge Farm Hearthfire version.esp'
     inc:
       - 'Bridge Farm.esp'
@@ -13280,26 +12765,6 @@ plugins:
         util: *dirtyUtil
         itm: 167
         udr: 221
-  - name: 'CabinInFalkreath.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-  - name: 'CabinInFalkreathLocks.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
   - name: 'CaethspellCavernPlayerHome.esp'
     dirty:
       - crc: 0x4620ecc
@@ -13308,24 +12773,17 @@ plugins:
   - name: 'CaethspellCavernsPlayerHome.esp'
     msg: [ *obsolete ]
   - name: 'Calavalcave.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 36 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 36 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 36 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x720fa4ce
         util: *dirtyUtil
         itm: 1596
         udr: 1
+        nav: 36
       - crc: 0x9b65d3f8
         util: *dirtyUtil
         itm: 1605
         udr: 1
+        nav: 36
   - name: 'Camps.esp'
     dirty:
       - crc: 0x6f42e236
@@ -13363,20 +12821,12 @@ plugins:
             str: 'Obsoleto. Actualizar a la última versión.'
         condition: 'checksum("Candle Pond Ranch.esp",8B643328)'
   - name: 'Castle Brennenburgh.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0xa1786e09
         util: *dirtyUtil
         itm: 25
         udr: 9
+        nav: 1
   - name: 'CastleDKmaster.esp'
     req:
       - name: 'SkyMoMod.esm'
@@ -13386,51 +12836,27 @@ plugins:
       - name: 'SkyMoMod.esm'
         display: '[Skyrim Monster Mod](http://www.nexusmods.com/skyrim/mods/9694)'
   - name: 'Castle Draco.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 28 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 28 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 28 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     tag:
       - Delev
     dirty:
       - crc: 0x603a5c67
         util: *dirtyUtil
         itm: 1456
+        nav: 28
   - name: 'Castle Draco Lost Paladin Edition.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 28 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 28 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 28 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     tag:
       - Delev
     dirty:
       - crc: 0xeb865d44
         util: *dirtyUtil
         itm: 99
+        nav: 28
   - name: 'Castle Draco - Auto Sorting Room Addon Load After Main Plugin.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 14 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 14 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 14 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0xb676a59e
         util: *dirtyUtil
         itm: 4
+        nav: 14
   - name: 'Castle Draco Support ESP Load Last.esp'
     dirty:
       - crc: 0x7bf398f5
@@ -13443,38 +12869,22 @@ plugins:
         itm: 25
         udr: 9
   - name: 'CastleDrakhur_updatefile.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 7 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 7 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 7 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0xd6ed863c
         util: *dirtyUtil
         itm: 20
         udr: 102
+        nav: 7
   - name: 'CastleGrey.esp'
     inc:
       - 'UFO - Ultimate Follower Overhaul.esp'
   - name: 'Castle Riverwood.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 2 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 2 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 2 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0xa186c265
         util: *dirtyUtil
         itm: 7
         udr: 16
+        nav: 2
   - name: 'Burg Flusswald.esp'
     msg:
       - type: warn
@@ -13486,34 +12896,19 @@ plugins:
           - lang: es
             str: 'Usar Castle Riverwood.esp o Burg Flusswald.esp, no ambos.'
         condition: 'file("Castle Riverwood.esp")'
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 2 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 2 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 2 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x5a7d4171
         util: *dirtyUtil
         itm: 7
         udr: 16
+        nav: 2
   - name: 'Castle Stonespire.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 10 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 10 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 10 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0xd070a4d3
         util: *dirtyUtil
         itm: 37
         udr: 9
+        nav: 10
   - name: 'CastlevaniaDemo.esp'
     msg:
       - type: warn
@@ -13535,35 +12930,17 @@ plugins:
         itm: 66
         udr: 71
   - name: 'Chapels Of Skyrim.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 3 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 3 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 3 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0xe37562fb
         util: *dirtyUtil
         itm: 376
         udr: 53
+        nav: 3
   - name: 'Cheat Shack (All Items!).esp'
     dirty:
       - crc: 0xcbd2da2a
         util: *dirtyUtil
         itm: 15
-  - name: 'ChristmasInSkyrim.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 2 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 2 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 2 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
   - name: 'CGDawnguardReborn.esp'
     dirty:
       - crc: 0x77e90b76
@@ -13681,39 +13058,23 @@ plugins:
         util: *dirtyUtil
         itm: 35
   - name: 'CuilalielHaven.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 2 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 2 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 2 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0xc21288ed
         util: *dirtyUtil
         itm: 34
         udr: 15
+        nav: 2
   - name: 'cryptOfSkaldivar.esp'
     dirty:
       - crc: 0xa9346f91
         util: *dirtyUtil
         itm: 31
   - name: 'ctfdFollower.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x4ff72199
         util: *dirtyUtil
         itm: 49
+        nav: 1
   - name: 'CZHCAD.esp'
     dirty:
       - crc: 0xb3418c2a
@@ -13759,20 +13120,12 @@ plugins:
         itm: 93
         udr: 67
   - name: 'DawnstarMarket.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 2 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 2 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 2 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x13265d73
         util: *dirtyUtil
         itm: 52
         udr: 6
+        nav: 2
   - name: 'dawnstarsanctuaryrespawns.esp'
     dirty:
       - crc: 0x3e24b0cd
@@ -13829,20 +13182,12 @@ plugins:
         util: *dirtyUtil
         itm: 15
   - name: 'df127merchantspack01.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 6 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 6 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 6 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x5d83ebdb
         util: *dirtyUtil
         itm: 186
         udr: 81
+        nav: 6
   - name: 'DJZ Cooking Pots.esp'
     dirty:
       - crc: 0x5321939E
@@ -13913,20 +13258,12 @@ plugins:
         itm: 25
         udr: 21
   - name: 'dovahkiin_mountain_retreat.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0xc4ee86ec
         util: *dirtyUtil
         itm: 2
         udr: 19
+        nav: 1
   - name: 'DovahkiinSpeech - HigherReq.esp'
     msg:
       - type: warn
@@ -14013,16 +13350,6 @@ plugins:
         itm: 15
         udr: 19
   - name: 'DragonmournInn.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 4 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 4 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 4 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-        condition: 'checksum("DragonmournInn.esp",CC0C0DD7)'
     dirty:
       - crc: 0xd167169B
         util: *dirtyUtil
@@ -14032,21 +13359,14 @@ plugins:
         util: *dirtyUtil
         itm: 343
         udr: 19
+        nav: 4
   - name: 'dragonpeaks.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0xc11aeb0a
         util: *dirtyUtil
         itm: 1975
         udr: 701
+        nav: 1
   - name: 'dragonsoulgem.esp'
     dirty:
       - crc: 0xc33c407
@@ -14057,19 +13377,12 @@ plugins:
       - type: error
         content: 'This mod requires DragonsReach_Hideout.esm'
         condition: 'not file("DragonsReach_Hideout.esm")'
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0xf5b9f021
         util: *dirtyUtil
         itm: 11
         udr: 177
+        nav: 1
   - name: 'DragonsReach_Hideout_(Plus|Assassin|Nightingale)\.esp'
     msg:
       - <<: *useOnlyOneX
@@ -14092,20 +13405,12 @@ plugins:
         util: *dirtyUtil
         itm: 4
   - name: 'driftshadetreetops.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x33884d3d
         util: *dirtyUtil
         itm: 1
         udr: 29
+        nav: 1
   - name: 'Druidessentials.esp'
     dirty:
       - crc: 0x7c29eac5
@@ -14202,19 +13507,12 @@ plugins:
           - lang: es
             str: 'Obsoleto. Actualizar a la última versión.'
         condition: 'not checksum("EBM.esp",2CBBAEC7) and not checksum("EBM.esp",ADA00DD0)'
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 3 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 3 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 3 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x2cbbaec7
         util: *dirtyUtil
         itm: 24
         udr: 3
+        nav: 3
   - name: 'Ebon Mine.esp'
     dirty:
       - crc: 0x72885a80
@@ -14227,19 +13525,12 @@ plugins:
         itm: 130
         udr: 181
   - name: 'ElysiumEstate.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-        condition: 'checksum("ElysiumEstate.esp",F0182534)'
     dirty:
       - crc: 0xf0182534
         util: *dirtyUtil
         itm: 3
         udr: 2
+        nav: 1
   - name: 'enchantersbreezehome.esp'
     dirty:
       - crc: 0x64e5e85
@@ -14251,35 +13542,19 @@ plugins:
         util: *dirtyUtil
         itm: 2
   - name: 'EnlargedDwemerStoreRoom.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0xd00304
         util: *dirtyUtil
         itm: 5
         udr: 1
+        nav: 1
   - name: 'EpicBossFight.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 8 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 8 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 8 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0xab83511d
         util: *dirtyUtil
         itm: 56
         udr: 76
+        nav: 8
   - name: 'epiccreaturesskyrim.esp'
     dirty:
       - crc: 0x4dd72040
@@ -14330,21 +13605,12 @@ plugins:
         itm: 12
         udr: 1
   - name: 'fallentreebridges.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 16 deleted NavMesh records that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 16 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 16 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-        condition: 'checksum("fallentreebridges.esp",F7D47176)'
     dirty:
       - crc: 0xf7d47176
         util: *dirtyUtil
         itm: 15
         udr: 0
+        nav: 16
   - name: 'Fantasy Markarth.esp'
     dirty:
       - crc: 0x5794a36f
@@ -14362,68 +13628,37 @@ plugins:
           - lang: es
             str: 'Obsoleto. Actualizar a la última versión, [JobsofSkyrim.esp](http://www.nexusmods.com/skyrim/mods/25020).'
   - name: 'fishchickenlodge.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x226a8a66
         util: *dirtyUtil
         itm: 1
         udr: 5
+        nav: 1
   - name: 'Fjollheimr.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 3 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 3 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 3 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x3870b742
         util: *dirtyUtil
         itm: 38
         udr: 195
+        nav: 3
   - name: 'flaho_shi_eagles_nest_ENG.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x28f58b4e
         util: *dirtyUtil
         udr: 2
+        nav: 1
   - name: 'flaho_shi_wassersturz.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x3fbcf912
         util: *dirtyUtil
         itm: 29
         udr: 6
+        nav: 1
       - crc: 0x4ea6342f
         util: *dirtyUtil
         itm: 22
         udr: 6
+        nav: 1
   - name: 'flame atronach follower.esp'
     dirty:
       - crc: 0x53390fe4
@@ -14519,50 +13754,26 @@ plugins:
         itm: 280
         udr: 53
   - name: 'FortDawnguardEnhanced.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 9 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 9 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 9 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x56c4e14e
         util: *dirtyUtil
         itm: 27
         udr: 102
+        nav: 9
   - name: 'fortheljarchen.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1506 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1506 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1506 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x66467091
         util: *dirtyUtil
         itm: 193
         udr: 419
+        nav: 1506
   - name: 'fortwinstad.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 839 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 839 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 839 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0xe2a7b836
         util: *dirtyUtil
         itm: 368
         udr: 135
+        nav: 839
   - name: 'FourSeasonsInn.esp'
     msg: [ *obsolete ]
   - name: 'FourSeasonsv1.02.esp'
@@ -14597,35 +13808,19 @@ plugins:
         util: *dirtyUtil
         itm: 14
   - name: 'garrettsretreat_v02a.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x9fb00c2c
         util: *dirtyUtil
         itm: 80
         udr: 134
+        nav: 1
   - name: 'Geir Manor.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 3 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 3 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 3 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0xff608082
         util: *dirtyUtil
         itm: 26
         udr: 23
+        nav: 3
   - name: 'GenebrisUnknownCave.esp'
     dirty:
       - crc: 0x882bf0a7
@@ -14638,20 +13833,12 @@ plugins:
         util: *dirtyUtil
         itm: 12
   - name: 'GersillasHouse.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x28ea3ccd
         util: *dirtyUtil
         itm: 13
         udr: 3
+        nav: 1
   - name: 'Gersonia.esp'
     dirty:
       - crc: 0x450d037b
@@ -14832,16 +14019,11 @@ plugins:
         itm: 43
         udr: 9
   - name: 'Hebrock_Der Schatten von Meresis.esp'
+    dirty:
+      - crc: 0x49083650
+        util: *dirtyUtil
+        nav: 21
     msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 21 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 21 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 21 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-        condition: 'checksum("Hebrock_Der Schatten von Meresis.esp",49083650)'
       - type: say
         content:
           - lang: en
@@ -14879,20 +14061,12 @@ plugins:
         itm: 42
         udr: 8
   - name: 'Here There Be Monsters.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 11 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 11 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 11 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x97885c9b
         util: *dirtyUtil
         itm: 95
         udr: 3
+        nav: 11
   - name: 'hideoushobo.esp'
     dirty:
       - crc: 0x1d8eb77f
@@ -14966,39 +14140,25 @@ plugins:
           - lang: es
             str: 'El archivo original fue lanzado antes del Creation Kit (07 Feb. 2012) puedes encontrar un patch de compatibilidad aquí. [Dovahkiin Retreat Continued](http://www.nexusmods.com/skyrim/mods/59522).'
   - name: 'HighlandFarmMilk.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x1258e09a
         util: *dirtyUtil
         itm: 8
+        nav: 1
       - crc: 0xC569164F
         util: *dirtyUtil
         itm: 8
+        nav: 1
       - crc: 0x80057D4B
         util: *dirtyUtil
         itm: 8
+        nav: 1
   - name: 'Courtyard Hjerim.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 2 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 2 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 2 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x89a0eb78
         util: *dirtyUtil
         itm: 2
+        nav: 2
   - name: 'customhjerim.esp'
     dirty:
       - crc: 0xacdbbfd5
@@ -15024,19 +14184,11 @@ plugins:
         itm: 58
         udr: 1
   - name: 'theHoardersHome.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 5 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 5 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 5 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x34949429
         util: *dirtyUtil
         itm: 15
+        nav: 5
   - name: 'HomeSweetStronghold v1.0.0.esp'
     dirty:
       - crc: 0x60fc7aed
@@ -15092,20 +14244,12 @@ plugins:
         itm: 175
         udr: 23
   - name: 'HSFStockade.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x86789101
         util: *dirtyUtil
         itm: 5
         udr: 14
+        nav: 1
   - name: 'Humblespire.esp'
     dirty:
       - crc: 0x9f546d0d
@@ -15146,14 +14290,6 @@ plugins:
       - type: warn
         content:
           - lang: en
-            str: 'This file contains 12 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 12 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 12 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-      - type: warn
-        content:
-          - lang: en
             str: 'Use either ICP Whiterun Exterior.esp or ImmersiveCitiesProjectPart2.esp, not both.'
           - lang: ru
             str: 'Используйте любой, или ICP Whiterun Exterior.esp или ImmersiveCitiesProjectPart2.esp, не оба.'
@@ -15165,21 +14301,14 @@ plugins:
         util: *dirtyUtil
         itm: 21
         udr: 186
+        nav: 12
   - name: 'Imperial Rangers Corps.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 3 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 3 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 3 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0xea73566b
         util: *dirtyUtil
         itm: 42
         udr: 55
+        nav: 3
   - name: 'Immersive Darkwater crossing.esp'
     dirty:
       - crc: 0x7f5941a8
@@ -15238,20 +14367,12 @@ plugins:
         util: *dirtyUtil
         itm: 13
   - name: 'improvedskyforge.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0xfdb929ce
         util: *dirtyUtil
         itm: 7
         udr: 31
+        nav: 1
   - name: 'InfinityHall.esp'
     dirty:
       - crc: 0x1a10446b
@@ -15259,21 +14380,12 @@ plugins:
         itm: 22
         udr: 6
   - name: 'Inns and Taverns.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-        condition: 'checksum("Inns and Taverns.esp",AF369C26)'
     dirty:
       - crc: 0xaf369c26
         util: *dirtyUtil
         itm: 35
         udr: 9
+        nav: 1
       - crc: 0xeeb009c4
         util: *dirtyUtil
         itm: 2
@@ -15339,20 +14451,12 @@ plugins:
         itm: 49
         udr: 3
   - name: 'KingdomOfForsworn.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 6 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 6 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 6 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x7d205f1e
         util: *dirtyUtil
         itm: 83
         udr: 55
+        nav: 6
   - name: 'kittyehdogarmory.esp'
     dirty:
       - crc: 0xe5628eb6
@@ -15393,20 +14497,12 @@ plugins:
         udr: 13
         nav: 2
   - name: 'Lakeshore.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 5 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 5 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 5 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0xc18979b1
         util: *dirtyUtil
         itm: 27
         udr: 9
+        nav: 5
   - name: 'LakeSideHome.esp'
     dirty:
       - crc: 0x22f454f4
@@ -15456,32 +14552,27 @@ plugins:
     inc:
       - 'LB_MuchAdoSnowElves_Quest.esp'
   - name: 'LC_CastleInvasion.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 7 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 7 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 7 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0xcf83a6e2
         util: *dirtyUtil
         itm: 37
         udr: 27
+        nav: 7
       - crc: 0x58DAE5DC
         util: *dirtyUtil
         itm: 37
         udr: 27
+        nav: 7
       - crc: 0x1541E8A9
         util: *dirtyUtil
         itm: 37
         udr: 27
+        nav: 7
       - crc: 0xD6DEF5F8
         util: *dirtyUtil
         itm: 37
         udr: 27
+        nav: 7
   - name: 'LevelersTower.esp'
     dirty:
       - crc: 0x7af4d53a
@@ -15501,19 +14592,12 @@ plugins:
           - lang: es
             str: 'Usar LevelersTower.esp o LevelersTowerRemod.esp, no ambos.'
         condition: 'file("LevelersTower.esp")'
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 2 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 2 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 2 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x5f1fcd8c
         util: *dirtyUtil
         itm: 10
         udr: 5
+        nav: 2
   - name: 'Liberation Beacon.esp'
     dirty:
       - crc: 0xeac2c978
@@ -15547,24 +14631,17 @@ plugins:
         util: *dirtyUtil
         itm: 4
   - name: 'Little Cottage on a Hill.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x4c2646cf
         util: *dirtyUtil
         itm: 20
         udr: 44
+        nav: 1
       - crc: 0xab8573e8
         util: *dirtyUtil
         itm: 19
         udr: 44
+        nav: 1
   - name: 'LittleShrines.esp'
     dirty:
       - crc: 0x16957c35
@@ -15595,23 +14672,21 @@ plugins:
         itm: 6
         udr: 1
   - name: 'Lurking in the shadows.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 9 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 9 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 9 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 9 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-        condition: 'checksum("Lurking in the shadows.esp",F87D7C47) or checksum("Lurking in the shadows.esp",6B78D95F) or checksum("Lurking in the shadows.esp",D8D162D1) or checksum("Lurking in the shadows.esp",6EA53B43)'
     dirty:
       - crc: 0xf87d7c47
         util: *dirtyUtil
         itm: 59
         udr: 53
+        nav: 9
+      - crc: 0x6B78D95F
+        util: *dirtyUtil
+        nav: 9
+      - crc: 0xD8D162D1
+        util: *dirtyUtil
+        nav: 9
+      - crc: 0x6EA53B43
+        util: *dirtyUtil
+        nav: 9
   - name: 'Lyberanthuin Restored.esp'
     dirty:
       - crc: 0x41f211fe
@@ -15736,20 +14811,12 @@ plugins:
         itm: 15
         udr: 1
   - name: 'massive2.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 22 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 22 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 22 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x1fe17273
         util: *dirtyUtil
         itm: 13
         udr: 2
+        nav: 22
   - name: 'MavensLetter.esp'
     dirty:
       - crc: 0x6c5aa0a9
@@ -15791,39 +14858,24 @@ plugins:
         util: *dirtyUtil
         itm: 23
   - name: 'Mini.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x393d1cc9
         util: *dirtyUtil
         itm: 25
         udr: 50
+        nav: 1
       - crc: 0x73908984
         util: *dirtyUtil
         itm: 21
         udr: 50
+        nav: 1
   - name: 'MistTop.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 5 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 5 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 5 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0xbf0a2622
         util: *dirtyUtil
         itm: 37
         udr: 43
+        nav: 5
   - name: 'Mistwatch.esp'
     msg:
       - type: say
@@ -15846,20 +14898,12 @@ plugins:
         itm: 40
         udr: 12
   - name: 'mixwatermill.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 2 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 2 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 2 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0xbeaa858
         util: *dirtyUtil
         itm: 37
         udr: 160
+        nav: 2
   - name: 'MjanasPlayground.esp'
     dirty:
       - crc: 0x34dafcdd
@@ -15881,20 +14925,12 @@ plugins:
         util: *dirtyUtil
         itm: 5
   - name: 'Monastery.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x2d31b659
         util: *dirtyUtil
         itm: 58
         udr: 17
+        nav: 1
   - name: 'monestery.esp'
     msg: [ *obsolete ]
   - name: 'moonpath_questdata.esp'
@@ -15996,20 +15032,12 @@ plugins:
           - lang: es
             str: 'Obsoleto. Actualizar a la última versión, [Forfeoranna Heim](http://www.nexusmods.com/skyrim/mods/13351).'
   - name: 'Nirn Falls Manor.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 17 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 17 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 17 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0xf6d72530
         util: *dirtyUtil
         itm: 55
         udr: 31
+        nav: 17
   - name: 'NoBleakFalls.esp'
     dirty:
       - crc: 0x7d2ad14b
@@ -16026,34 +15054,18 @@ plugins:
         util: *dirtyUtil
         udr: 91
   - name: 'Northern Bathhouses.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 2 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 2 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 2 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0xfbe79f4f
         util: *dirtyUtil
         itm: 96
         udr: 12
+        nav: 2
   - name: 'NorthKeep.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 2 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 2 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 2 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x51a8111e
         util: *dirtyUtil
         itm: 6
+        nav: 2
   - name: 'OBIS.esp'
     tag:
       - Delev
@@ -16112,20 +15124,12 @@ plugins:
         itm: 9
         udr: 166
   - name: 'Overlook Tower - MAINv1.9b.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 3 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 3 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 3 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0xed33f2b1
         util: *dirtyUtil
         itm: 159
         udr: 3
+        nav: 3
   - name: 'Pirate Sharphook.esp'
     dirty:
       - crc: 0x95abd098
@@ -16138,20 +15142,12 @@ plugins:
         util: *dirtyUtil
         itm: 6
   - name: 'Player House.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 6 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 6 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 6 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0xe05a8952
         util: *dirtyUtil
         itm: 23
         udr: 10
+        nav: 6
   - name: 'PrisonUpdate.esp'
     dirty:
       - crc: 0x5251d917
@@ -16165,19 +15161,11 @@ plugins:
         itm: 624
         udr: 1
   - name: 'PrisonAddon2.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x6d8b17b3
         util: *dirtyUtil
         itm: 15
+        nav: 1
   - name: 'PrisonAddon3.esp'
     dirty:
       - crc: 0xa393c5ef
@@ -16213,20 +15201,12 @@ plugins:
         util: *dirtyUtil
         itm: 1
   - name: 'PsijicWatch.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 7 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 7 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 7 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x51d9e771
         util: *dirtyUtil
         itm: 39
         udr: 41
+        nav: 7
   - name: 'PumpingIron.esp'
     req:
       - *SKSE
@@ -16267,35 +15247,19 @@ plugins:
     inc:
       - 'Ramen.esp'
   - name: 'Ranger Ridge.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0xcbb7b1f7
         util: *dirtyUtil
         itm: 120
         udr: 25
+        nav: 1
   - name: 'Ranger''s Valley Lodge.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0xd9adfdf2
         util: *dirtyUtil
         itm: 41
         udr: 33
+        nav: 1
   - name: 'Rashiik.esp'
     msg:
       - type: say
@@ -16334,50 +15298,26 @@ plugins:
         itm: 17
         udr: 9
   - name: 'Reaper''s Landscape - The Dead Forest.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 5 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 5 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 5 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x79dbae41
         util: *dirtyUtil
         itm: 19
         udr: 230
+        nav: 5
   - name: 'RefurbishedBreezehome-2-0.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 137 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 137 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 137 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x33227b6
         util: *dirtyUtil
         itm: 8
         udr: 69
+        nav: 137
   - name: 'RefurbishedBreezehome-2-0 Hearthfire.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 137 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 137 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 137 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x4f38c07a
         util: *dirtyUtil
         itm: 11
         udr: 1
+        nav: 137
   - name: 'Rendspire Palace Reborn.esp'
     dirty:
       - crc: 0x42d8ab34
@@ -16397,35 +15337,19 @@ plugins:
   - name: 'Ridgeview House BETA.esp'
     msg: [ *obsolete ]
   - name: 'Ridgeview House.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 3 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 3 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 3 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x6a8b2287
         util: *dirtyUtil
         itm: 19
         udr: 15
+        nav: 3
   - name: 'RiversideKeep.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 4 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 4 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 4 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0xe612fffa
         util: *dirtyUtil
         itm: 26
         udr: 10
+        nav: 4
   - name: 'riversidelodgesws.esp'
     msg: [ *obsolete ]
   - name: 'RiverWood Dungeons.esp'
@@ -16475,20 +15399,12 @@ plugins:
         udr: 4
   - name: 'ROEBETA.esp'
     req: [ *SKSE ]
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x8880d3d2
         util: *dirtyUtil
         itm: 62
         udr: 10
+        nav: 1
   - name: 'rooq_bathing_twocell.esp'
     dirty:
       - crc: 0x8937ed86
@@ -16569,35 +15485,19 @@ plugins:
         itm: 1
         udr: 1
   - name: 'Sam''s Travelling Caravan.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0xa73b0ad8
         util: *dirtyUtil
         itm: 178
         udr: 1
+        nav: 1
   - name: 'Sanc Castle.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 7 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 7 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 7 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x7c8fb970
         util: *dirtyUtil
         itm: 13
         udr: 73
+        nav: 7
   - name: 'Sanc CastleNoLock.esp'
     msg:
       - type: warn
@@ -16609,19 +15509,12 @@ plugins:
           - lang: es
             str: 'Usar Sanc Castle.esp o Sanc CastleNoLock.esp, no ambos.'
         condition: 'file("Sanc Castle.esp")'
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 7 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 7 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 7 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x2d6eebf5
         util: *dirtyUtil
         itm: 13
         udr: 73
+        nav: 7
   - name: 'SavaGhost''s pack o tests.esp'
     dirty:
       - crc: 0x85934fd3
@@ -16629,19 +15522,11 @@ plugins:
         itm: 39
         udr: 106
   - name: 'Saviik City.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 32 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 32 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 32 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x2a1083e8
         util: *dirtyUtil
         udr: 576
+        nav: 32
   - name: 'Saviors Lodge - Player Home.esp'
     msg:
       - type: warn
@@ -16702,22 +15587,15 @@ plugins:
             str: 'Usar The Secret Room of Breezehome.esp o secretroom-bh-en.esp, no ambos.'
         condition: 'file("The Secret Room of Breezehome.esp")'
   - name: 'SejhPlayerHouses2.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 2 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 2 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 2 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x4c6a97fb
         util: *dirtyUtil
         itm: 19
+        nav: 2
       - crc: 0xe5a350ab
         util: *dirtyUtil
         itm: 16
+        nav: 2
   - name: 'Shack.esp'
     dirty:
       - crc: 0xe0e3cf38
@@ -16815,16 +15693,6 @@ plugins:
       - crc: 0x9e33b059
         util: *dirtyUtil
         itm: 103
-  - name: 'Simply Improved Breezehome.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
   - name: 'SK_Berserk.esp'
     dirty:
       - crc: 0xc30c6667
@@ -16863,18 +15731,6 @@ plugins:
       - 'UFO - Dawnguard AddOn.esp'
       - 'UFO - Dragonborn Addon.esp'
       - 'UFO - Heartfire AddOn.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ko
-            str: '이 파일에는 TES5Edit이 자동으로 복구할 수 없는 1개의 삭제된 NavMesh 레코드가 포함되어 있으며 이는 게임에 문제가 발생 할 수도 있습니다. NavMesh의 삭제는 모드 제작자에게 보고해야합니다. [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859)으로 NavMesh의 삭제를 복구하는 방법은 [여기](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html)에 있습니다.'
-        condition: 'checksum("SkyHavenTempleEnhanced.esp",A2E8A0B6) or checksum("SkyHavenTempleEnhanced.esp",99AC1B47)'
     dirty:
       - crc: 0xdc10ae9f
         util: *dirtyUtil
@@ -16884,10 +15740,12 @@ plugins:
         util: *dirtyUtil
         itm: 85
         udr: 315
+        nav: 1
       - crc: 0x99AC1B47
         util: *dirtyUtil
         itm: 85
         udr: 315
+        nav: 1
   - name: 'Sky Haven Temple and Onsen.esp'
     dirty:
       - crc: 0x64f5ac1e
@@ -16941,19 +15799,11 @@ plugins:
         itm: 599
         udr: 67
   - name: 'SM_PlayerHome.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 9 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 9 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 9 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0xccb96081
         util: *dirtyUtil
         itm: 39
+        nav: 9
   - name: 'Smaller Trees Markarth.esp'
     dirty:
       - crc: 0x3df856f3
@@ -17017,20 +15867,12 @@ plugins:
         util: *dirtyUtil
         itm: 4
   - name: 'SoulForgeMysticArena.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x42e3cf2d
         util: *dirtyUtil
         itm: 31
         udr: 2
+        nav: 1
   - name: 'Sovngarde - completed main quest.esp'
     msg:
       - type: say
@@ -17060,16 +15902,6 @@ plugins:
   - name: 'Stag''sRest.esp'
     inc:
       - 'Cabin in the woods.esp'
-  - name: 'Star-NorthernFrostBrewery.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 9 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 9 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 9 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
   - name: 'SteezMyster''s Dungeon.esp'
     dirty:
       - crc: 0xfdd3c5fd
@@ -17086,19 +15918,12 @@ plugins:
           - lang: es
             str: 'Obsoleto. Actualizar a la última versión.'
         condition: 'checksum("Stegdon''s Book Collection.esp",A53FC583)'
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 35 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 35 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 35 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0xd87b6464
         util: *dirtyUtil
         itm: 10
         udr: 11
+        nav: 35
   - name: 'StillbornKingdom.esp'
     dirty:
       - crc: 0x856fb7e0
@@ -17110,63 +15935,31 @@ plugins:
         util: *dirtyUtil
         itm: 3
   - name: 'StonewallGarden3.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 3 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 3 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 3 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0xa9a027a0
         util: *dirtyUtil
         itm: 190
         udr: 32
+        nav: 3
   - name: 'Stoop Vlindrel Hall.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x3a4b94a0
         util: *dirtyUtil
         itm: 9
+        nav: 1
   - name: 'Stormreach Mansion.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x973c7cf3
         util: *dirtyUtil
         itm: 17
         udr: 7
+        nav: 1
   - name: 'suncresthall.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 2 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 2 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 2 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0xafea2e1
         util: *dirtyUtil
         itm: 48
+        nav: 2
   - name: 'SuperSkyrimBros.esp'
     dirty:
       - crc: 0xac16f40
@@ -17261,24 +16054,17 @@ plugins:
         util: *dirtyUtil
         itm: 2
   - name: 'TG Headquarters Overhaul v.1.5.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0xdab11b5f
         util: *dirtyUtil
         itm: 6
         udr: 224
+        nav: 1
       - crc: 0xD29B4EA2
         util: *dirtyUtil
         itm: 6
         udr: 224
+        nav: 1
   - name: 'Thanes Basement.esp'
     dirty:
       - crc: 0x7c9a098b
@@ -17290,19 +16076,11 @@ plugins:
         util: *dirtyUtil
         itm: 4
   - name: 'A Thane-Worthy Breezehome.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0xb7504810
         util: *dirtyUtil
         udr: 31
+        nav: 1
   - name: 'TheArena.esp'
     dirty:
       - crc: 0x48b89c4d
@@ -17315,35 +16093,19 @@ plugins:
         util: *dirtyUtil
         itm: 148
   - name: 'theaviary.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 3 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 3 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 3 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0xba55788c
         util: *dirtyUtil
         itm: 13
         udr: 12
+        nav: 3
   - name: 'TheCave_ASimpleLife.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0xef45600c
         util: *dirtyUtil
         itm: 2
         udr: 1
+        nav: 1
   - name: 'TheChampionsOfTamriel.esp'
     dirty:
       - crc: 0xa8c8f78a
@@ -17367,30 +16129,14 @@ plugins:
         itm: 2
         udr: 75
   - name: 'The Descent.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 5 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 5 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 5 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0xe30989af
         util: *dirtyUtil
         itm: 90
         udr: 24
+        nav: 5
   - name: 'The Descent_rus.esp'
     msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 5 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 5 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 5 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
       - type: warn
         content:
           - lang: en
@@ -17405,21 +16151,14 @@ plugins:
         util: *dirtyUtil
         itm: 57
         udr: 24
+        nav: 5
   - name: 'thedomain.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x851f358f
         util: *dirtyUtil
         itm: 1326
         udr: 20
+        nav: 1
   - name: 'The Fifth Gate.esp'
     dirty:
       - crc: 0x2726c0bf
@@ -17506,16 +16245,6 @@ plugins:
         util: *dirtyUtil
         itm: 76
         udr: 4
-  - name: 'The Void Walker.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 2 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 2 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 2 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
   - name: 'The Warden Stone.esp'
     dirty:
       - crc: 0xdee8cbe9
@@ -17566,19 +16295,12 @@ plugins:
           - lang: es
             str: 'Obsoleto. Actualizar a la última versión.'
         condition: 'checksum("tinyalchemisthut.esp",4D9F38F8) or checksum("tinyalchemisthut.esp",A0FAF929)'
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 3 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 3 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 3 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0xc7bb600c
         util: *dirtyUtil
         itm: 16
         udr: 15
+        nav: 3
   - name: 'tinyassassinhideout.esp'
     dirty:
       - crc: 0x4a59033
@@ -17595,18 +16317,11 @@ plugins:
           - lang: es
             str: 'Obsoleto. Actualizar a la última versión.'
         condition: 'checksum("tinymagetower.esp",33ADB458) or checksum("tinymagetower.esp",4536712D)'
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x52753b88
         util: *dirtyUtil
         itm: 5
+        nav: 1
   - name: 'tinymagetowernopainnogain.esp'
     msg:
       - type: say
@@ -17629,18 +16344,11 @@ plugins:
           - lang: es
             str: 'either tinymagetower.esp or tinymagetowernpainnogain.esp, no ambos.'
         condition: 'file("tinymagetower.esp")'
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x33fe7dae
         util: *dirtyUtil
         itm: 5
+        nav: 1
   - name: 'tinytreehome.esp'
     dirty:
       - crc: 0x31567aaa
@@ -17694,38 +16402,23 @@ plugins:
           - lang: es
             str: 'Obsoleto. Actualizar a la última versión.'
         condition: 'checksum("TruePeopleOfSkyrim.esp",487C296B)'
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 18 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 18 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 18 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0xedfb3782
         util: *dirtyUtil
         itm: 39
         udr: 3
+        nav: 18
   - name: '(TWE) Riften Brothel..esp'
     dirty:
       - crc: 0x81f1b405
         util: *dirtyUtil
         udr: 14
   - name: 'BBLuxurySuiteUndergroundBathhouse.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x487e17e1
         util: *dirtyUtil
         udr: 1
+        nav: 1
   - name: 'ub_bbls_merge.esp'
     dirty:
       - crc: 0xa7948be9
@@ -17798,33 +16491,18 @@ plugins:
             str: 'UDO.esm is mis-named.  It is NOT an esm file.'
           - lang: ru
             str: 'UDO.esm неверно назван.  Это не esm-файл.'
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x23a1b8f9
         util: *dirtyUtil
         udr: 3835
+        nav: 1
   - name: 'UDO.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0xd7d3445d
         util: *dirtyUtil
         itm: 15
         udr: 4448
+        nav: 1
   - name: 'UDOchestless.esp'
     msg:
       - type: say
@@ -17847,20 +16525,12 @@ plugins:
     tag:
       - Relev
   - name: 'underbreeze.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 2 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 2 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 2 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x749fbdac
         util: *dirtyUtil
         itm: 2
         udr: 1
+        nav: 2
   - name: 'unicorncave.esp'
     msg:
       - type: warn
@@ -17894,20 +16564,12 @@ plugins:
         util: *dirtyUtil
         udr: 120
   - name: 'Unstable tower eng.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 3 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 3 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 3 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x4bb6b136
         util: *dirtyUtil
         itm: 62
         udr: 4
+        nav: 3
   - name: 'Vampire Slavers Den.esp'
     dirty:
       - crc: 0x47aa2819
@@ -18004,24 +16666,17 @@ plugins:
         itm: 46
         udr: 8
   - name: 'vlexmodsCastleDovah.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 5 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 5 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 5 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x969ef6cb
         util: *dirtyUtil
         itm: 7
         udr: 45
+        nav: 5
       - crc: 0x326E463C
         util: *dirtyUtil
         itm: 7
         udr: 45
+        nav: 5
   - name: 'Vlindrel Hall Reborn.esp'
     dirty:
       - crc: 0x805dd410
@@ -18101,20 +16756,11 @@ plugins:
           - lang: es
             str: 'Requiere: [Cloaks of Skyrim](http://www.nexusmods.com/skyrim/mods/12092)'
   - name: 'waterstonemanor.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 5 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 5 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 5 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-        condition: 'checksum("waterstonemanor.esp",C8562277)'
     dirty:
       - crc: 0xc8562277
         util: *dirtyUtil
         itm: 2
+        nav: 5
   - name: 'WayofDragonborn.esp'
     req: [ *SKSE ]
   - name: 'WayofDragonbornCreativePerks.esp'
@@ -18210,14 +16856,6 @@ plugins:
       - type: warn
         content:
           - lang: en
-            str: 'This file contains 7 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 7 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 7 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-      - type: warn
-        content:
-          - lang: en
             str: 'Use either ICP Whiterun Exterior.esp or ImmersiveCitiesProjectPart2.esp, not both.'
           - lang: ru
             str: 'Используйте любой, или ICP Whiterun Exterior.esp или ImmersiveCitiesProjectPart2.esp, не оба.'
@@ -18229,6 +16867,7 @@ plugins:
         util: *dirtyUtil
         itm: 8
         udr: 409
+        nav: 7
   - name: '(BETA) Immersive Cities - Whiterun.esp'
     msg: [ *obsolete ]
   - name: 'whiterunexenhanced.esp'
@@ -18257,35 +16896,19 @@ plugins:
         itm: 123
         udr: 12
   - name: 'RRBetterWhiterunInt.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x50931c9b
         util: *dirtyUtil
         itm: 35
         udr: 1
+        nav: 1
   - name: 'Whitewatch Tower.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 2 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 2 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 2 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0xe1254593
         util: *dirtyUtil
         itm: 24
         udr: 19
+        nav: 2
   - name: 'Wild Goose Chase Quest.esp'
     dirty:
       - crc: 0x9fa6917
@@ -18326,20 +16949,12 @@ plugins:
   - name: 'Winterhold repair.esp'
     msg: [ *obsolete ]
   - name: 'Winterhold repairV4.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x1cb2273b
         util: *dirtyUtil
         itm: 171
         udr: 26
+        nav: 1
   - name: 'wip.esp'
     dirty:
       - crc: 0x6865ccef
@@ -18347,20 +16962,12 @@ plugins:
         itm: 8
         udr: 4
   - name: 'Woodland sanctuary.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0xd0deb50d
         util: *dirtyUtil
         itm: 3
         udr: 12
+        nav: 1
   - name: 'Work a Steady Job as a Blacksmith.esp'
     dirty:
       - crc: 0x9ec79790
@@ -20771,15 +19378,6 @@ plugins:
       - 'Unique.esm'
   - name: 'Unique Unique.esp'
     req: [ *SKSE ]
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
   - name: 'Unread Books Glow.esp'
     msg: [ *obsolete ]
   - name: 'UnreadBooksGlow.esp'
@@ -21214,20 +19812,12 @@ plugins:
     inc:
       - 'ETaC SkyRealFF Patch - Standard.esp'
   - name: 'Expanded Villages2.0.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 3 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 3 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 3 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x8afa9e8e
         util: *dirtyUtil
         itm: 5
         udr: 242
+        nav: 3
   - name: 'ExpandedWinterholdRuins.esp'
     dirty:
       - crc: 0xdb0a9cb5
@@ -21253,20 +19843,12 @@ plugins:
         util: *dirtyUtil
         itm: 1
   - name: 'helgenrebuilt.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 3 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 3 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 3 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0xf604f9e1
         util: *dirtyUtil
         itm: 103
         udr: 15
+        nav: 3
   - name: 'Lanterns of Skyrim - All In One - Dawnstar Expanded Patch.esp'
     dirty:
       - crc: 0x336f1ce9
@@ -21343,55 +19925,31 @@ plugins:
         itm: 33
         udr: 25
   - name: 'Riverwood Enhanced.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x63725578
         util: *dirtyUtil
         itm: 28
         udr: 31
+        nav: 1
   - name: 'Riverwood Enhanced( - (Detailed Cities|NO NPC))?\.esp'
     msg:
       - <<: *useOnlyOneX
         condition: 'many("Riverwood Enhanced( - (Detailed Cities|NO NPC))?\.esp")'
         subs: [ 'Riverwood Enhanced .esp file' ]
   - name: 'Riverwood Enhanced - Detailed Cities.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x46637208
         util: *dirtyUtil
         itm: 29
         udr: 32
+        nav: 1
   - name: 'Riverwood Enhanced - NO NPC.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x73840440
         util: *dirtyUtil
         itm: 28
         udr: 31
+        nav: 1
   - name: 'RiverwoodEnhancedPlugin.esp'
     msg:
       - type: say
@@ -21419,20 +19977,12 @@ plugins:
       - 'Solitude A City Of Trade.esp'
       - 'Solitude A City Of Trade.esm'
   - name: 'solitude enhanced.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 2 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 2 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 2 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x1475c13b
         util: *dirtyUtil
         itm: 123
         udr: 53
+        nav: 2
   - name: 'SolitudeBetterDocks-SDD-CompatiblePatch.esp'
     msg:
       - type: say
@@ -21463,19 +20013,11 @@ plugins:
         itm: 12
         udr: 2
   - name: 'tavevillages.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x73b52f67
         util: *dirtyUtil
         itm: 15
+        nav: 1
   - name: 'tos_amber_guard.esp'
     dirty:
       - crc: 0xa74635ec
@@ -21517,20 +20059,12 @@ plugins:
   - name: 'ultime skyrim - riverwood.esp'
     msg: [ *obsolete ]
   - name: 'ultimate skyrim - riverwood.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 2 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 2 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 2 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x604d605a
         util: *dirtyUtil
         itm: 81
         udr: 235
+        nav: 2
   - name: 'UniqueTavernsFalkwreath.esp'
     msg:
       - *obsolete
@@ -21548,19 +20082,11 @@ plugins:
         util: *dirtyUtil
         udr: 15
   - name: 'WinterholdRuinsAddon_V1.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 4 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 4 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 4 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x1af5e998
         util: *dirtyUtil
         itm: 41
+        nav: 4
   - name: 'Better Forests and Environments.esp'
     dirty:
       - crc: 0xae2df319
@@ -21646,30 +20172,16 @@ plugins:
         itm: 1
         udr: 2
   - name: 'MoreForests.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 8 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 8 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 8 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0xa8b7dd63
         util: *dirtyUtil
         itm: 314
         udr: 150
+        nav: 8
   - name: 'MoreForestsLOD.esp'
     msg: [ *obsolete ]
   - name: 'MoreForestsLODckm - Copy.esp'
     msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 8 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит x удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
       - type: warn
         content:
           - lang: en
@@ -21684,6 +20196,7 @@ plugins:
         util: *dirtyUtil
         itm: 313
         udr: 149
+        nav: 8
   - name: 'MoreForestsNV.esp'
     dirty:
       - crc: 0x564d264f
@@ -21754,20 +20267,12 @@ plugins:
         util: *dirtyUtil
         udr: 3
   - name: 'morewr.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 12 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 12 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 12 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x6efae8a5
         util: *dirtyUtil
         itm: 17
         udr: 16
+        nav: 12
   - name: 'Populated Cities v.+\.esp'
     msg: [ *obsolete ]
   - name: 'Populated Cities 2.esp'
@@ -26812,14 +25317,6 @@ plugins:
       - crc: 0xdcbbff4d
         util: *dirtyUtil
         itm: 2
-  - name: 'Gli Beindae.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains <x> deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит <x> удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
   - name: 'Grandies_Companion_by_kill.esp'
     msg:
       - <<: *corrupt
@@ -29223,15 +27720,6 @@ plugins:
         util: *dirtyUtil
         itm: 3
   - name: 'MoT_Last_LoadOrder_File.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 2 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 2 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 2 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     tag:
       - Delev
       - Relev
@@ -29240,10 +27728,12 @@ plugins:
         util: *dirtyUtil
         itm: 180
         udr: 51
+        nav: 2
       - crc: 0xa2c3f4c9
         util: *dirtyUtil
         itm: 211
         udr: 56
+        nav: 2
   - name: 'SKSE Hotkeys.esp'
     req:
       - *SKSE
@@ -29526,20 +28016,12 @@ plugins:
         util: *dirtyUtil
         itm: 2
   - name: 'LakeviewManorRoad.esp'
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            str: 'This file contains 1 deleted NavMesh record(s) that TES5Edit cannot repair automatically and it may cause problems with your game. NavMesh deletions should be reported to the mod author. A guide to repairing NavMesh deletions with [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) is located [here](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: ru
-            str: 'Этот файл содержит 1 удаленных NavMesh-записей, которые не могут быть исправлены в TES5Edit, что может вызывать проблемы в игре. Инструкция по восстановлению этих записей, с помощью [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859), может быть найдена [здесь](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
-          - lang: es
-            str: 'Este archivo contiene 1 entradas NavMesh borradas que TES5Edit no puede reparar automaticamente y podrian causar problemas con tu juego. NavMesh borrados deben ser reportados al autor del mod. Una guía para repararlos con [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) se puede encontrar [aquí](http://www.iguanadons.net/Skyrim-Fixing-Navmesh-Deletion-Using-TES5Edit-511.html).'
     dirty:
       - crc: 0x14c1ed9b
         util: *dirtyUtil
         itm: 43
         udr: 6
+        nav: 1
   - name: 'Skyrim Unbound.esp'
     dirty:
       - crc: 0x59869ADE


### PR DESCRIPTION
MWAHAHA! My rebirth is completed... sort of, I still got a long way to go. But hey, at least it finally works! Anyway, just like it says on the tin, I deleted all the deleted navmesh messages and put nav tags in instead. for the small number of plugins that didn't have dirty data associated with them, I just deleted the message - I tried adding an alias, but loot got all spazzy on me, so I say, if they want to see their deleted navmeshs in LOOT, give us crcs!