### PR TITLE
Don't need g++, just the standard libs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ addons:
       - libboost-filesystem1.55-dev
       - libboost-locale1.55-dev
       - libboost-iostreams1.55-dev
-      - g++-5
+      - libstdc++6
 
 install: wget https://github.com/loot/loot/releases/download/v0.8.1/metadata-validator.tar.gz -O - | tar -xz
 


### PR DESCRIPTION
Swapping this out shaves another ~ 15s off the CI run time.