### PR TITLE
Girls Overhaul (Tiny Grils) load order

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -33081,3 +33081,9 @@ plugins:
       - crc: 0x1F024AC9
         util: *dirtyUtil
         itm: 1
+  #Load after RSChildren to work as intended
+  - name: 'Girls Overhaul.esp'
+    after:
+      - 'RSChildren_PatchUSKP.esp'
+    url:
+      - 'http://www.nexusmods.com/skyrim/mods/66690'


### PR DESCRIPTION
Set Girls Overhaul load order after RSChildren_USKP otherwise the two mods will not work correctly.