### PR TITLE
'Guard Dialogue Overhaul' after 'Immersive Armors'

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -17706,6 +17706,10 @@ plugins:
       - crc: 0xbe573683
         util: *dirtyUtil
         itm: 3
+  - name: 'Guard Dialogue Overhaul.esp'
+    after:
+      - 'Hothtrooper44_ArmorCompilation.esp'
+      - 'Hothtrooper44_Armor_Ecksstra.esp'
   - name: 'Guard Patrols.esp'
     dirty:
       - crc: 0x745dbcc


### PR DESCRIPTION
The [Guard Dialogue Overhaul page on the Nexus](http://www.nexusmods.com/skyrim/mods/23390/?) notes that it should be loaded after Immersive Armors. This adds an entry to that effect.
