### PR TITLE
Load ETaC after 3DNPC

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -19307,6 +19307,7 @@ plugins:
     after:
       - 'Tamriel Reloaded HD.esp'
       - 'WhiterunHoldForest.esp'
+      - '3DNPC.esp'
   - name: 'ETaC - Darkwater.esp'
     msg:
       - type: error
@@ -19320,6 +19321,8 @@ plugins:
       - crc: 0x41f31139
         util: *dirtyUtil
         itm: 31
+    after:
+      - '3DNPC.esp'
   - name: 'ETaC - Dragon Bridge.esp'
     msg:
       - type: error
@@ -19333,6 +19336,8 @@ plugins:
       - crc: 0x5145a4b
         util: *dirtyUtil
         itm: 196
+    after:
+      - '3DNPC.esp'
   - name: 'ETaC - Ivarstead.esp'
     msg:
       - type: error
@@ -19342,6 +19347,8 @@ plugins:
           - lang: ru
             str: 'Удалите. Уже включено в ETaC - Villages Complete.esp'
         condition: 'file("ETaC - Villages Complete.esp")'
+    after:
+      - '3DNPC.esp'
   - name: 'ETaC - Riverwood.esp'
     msg:
       - type: error
@@ -19355,6 +19362,8 @@ plugins:
       - crc: 0xb699fc8e
         util: *dirtyUtil
         itm: 29
+    after:
+      - '3DNPC.esp'
   - name: 'ETaC - Rorikstead.esp'
     msg:
       - type: error
@@ -19368,11 +19377,15 @@ plugins:
       - crc: 0x5626a22c
         util: *dirtyUtil
         itm: 38
+    after:
+      - '3DNPC.esp'
   - name: 'ETaC - Morthal.esp'
     dirty:
       - crc: 0xa20e7abc
         util: *dirtyUtil
         itm: 31
+    after:
+      - '3DNPC.esp'
   - name: 'ETaC SkyRealFF Patch - Dawnguard.esp'
     inc:
       - 'ETaC SkyRealFF Patch - Standard.esp'


### PR DESCRIPTION
ETaC now has built-in compatibility for Interesting NPCs, but says in its MCM configuration that all ETaC files should be loaded after 3DNPC.esp to configure properly.
