### PR TITLE
Added CFTO to masterlist, sorted after ICAO

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27208,3 +27208,6 @@ plugins:
   - name: 'Relationship Dialogue Overhaul.esp'
     after:
       - 'Immersive Citizens - AI Overhaul.esp'
+  - name: 'CFTO.esp'
+    after:
+      - 'Immersive Citizens - AI Overhaul.esp'


### PR DESCRIPTION
CFTO needs to be sorted after ICAO. ICAO flags existing ferry NPCs as persistent. CFTO disables these same ferry operators in place of its own NPCs. If ICAO loads after CFTO, the old ferry operators are re-enabled, resulting in duplicate ferry NPCs.