### PR TITLE
Metadata for Requiem

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -25159,7 +25159,7 @@ plugins:
       - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Rustic Soulgems.esp") and not active("Requiem - Rustic Soulgems - ISC.esp")'
       - <<: *redundantPluginX
-        condition: 'active("RUSTIC SOULGEMS - Unsorted.esp") and active("Requiem - Rustic Soulgems.esp") or active("RUSTIC SOULGEMS - Sorted.esp") and active("Requiem - Rustic Soulgems - ISC.esp")'
+        condition: 'active("RUSTIC SOULGEMS - Unsorted.esp") and active("Requiem - Rustic Soulgems.esp") or active("RUSTIC SOULGEMS - Unsorted.esp") and active("Requiem - Rustic Soulgems - ISC.esp")'
         subs: [ 'Requiem - Rustic Soulgems.esp' ]
   - name: 'ScopedBows.esp'
     msg:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -24976,7 +24976,7 @@ plugins:
   - name: 'No Vendor or Loot Spells.esp'
     global_priority: 105
   - name: 'Skyrim Unlocked.esp'
-    global_priority: 90
+    global_priority: 75
     inc:
       - name: "Open Cities Skyrim.esp"
         condition: 'not active("Open Cities Skyrim - Skyrim Unlocked Patch.esp")'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -18242,7 +18242,7 @@ plugins:
     after:
       - '3DNPC.esp'
       - 'TradeRoutes.esp'
-     msg:
+    msg:
       - <<: *needsRequiemPatch
         condition: 'file("Requiem.esp") and not active("RND_Requiem-Patch.esp") and not active("Requiem - Realistic Needs & Hypothermia.esp") and not active("RequiemSurvivalExperience.esp") and not active("Requiem Food patch.esp")'
     tag:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -16433,7 +16433,7 @@ plugins:
         <<: *dirtyPlugin
         itm: 2
   - name: 'Rebirth Monster.esp'
-     msg:
+    msg:
       - <<: *needsRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Revenge of the Enemies.esp") and not active("Rebirth Monster - Requiem Patch.esp") and not active("Rebirth Monster - Requiem Merged Patch.esp")'
     tag:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -8671,16 +8671,17 @@ plugins:
         <<: *dirtyPlugin
         itm: 306
         udr: 10
-  - name: 'Requiem - Dragonborn.esp'
-    dirty:
-      - crc: 0x740bb9f0
-        <<: *dirtyPlugin
-        itm: 3
-  - name: 'Requiem - Hearthfires.esp'
-    dirty:
-      - crc: 0xa3a78f22
-        <<: *dirtyPlugin
-        itm: 1
+  # must be loaded directly after Requiem.esp
+  - name: 'Requiem - Bugsmasher Edition.esp'
+    priority: -127
+    msg:
+      - type: say
+        content:
+          - lang: en
+            text: 'Hello'
+  # must be loaded directly after Requiem.esp
+  - name: 'Requiem - Legendary Bugsmasher Edition.esp'
+    priority: -127
   - name: 'Requiem - Difficulty Bar Restored.esp'
     inc:
       - 'Requiem - Difficulty Bar Restored - Nightmare.esp'
@@ -8697,37 +8698,21 @@ plugins:
       - <<: *useOnlyOneX
         condition: 'many("Requiem - TrainUnitsPerLevel(0|5|10|100)\.esp")'
         subs: [ 'Requiem - Weapon Damage Modifier .esp file' ]
-  - name: 'NRM Dragonborn - Requiem Patch.esp'
-    after:
-      - 'Requiem - USKP + UDGP.esp'
-      - 'Requiem - Bring Out Your Dead.esp'
-      - 'Requiem - Hearthfire.esp'
-  - name: 'Requiem - Kryptopyr''s Fixes Reqtified.esp'
-    after:
-      - 'Requiem - USKP + UDGP.esp'
-      - 'Requiem - Bring Out Your Dead.esp'
-      - 'Requiem - Hearthfire.esp'
-      - 'Requiem - Height Adjusted Races with True Giants.esp'
-  - name: 'KFR-Kryptopyr''sFixesReqtified.esp'
-    after:
-      - 'Requiem - USKP + UDGP.esp'
-      - 'Requiem - Bring Out Your Dead.esp'
-      - 'Requiem - Hearthfire.esp'
-      - 'Requiem - Height Adjusted Races with True Giants.esp'
-  - name: 'Requiem - Crafting Overhaul Reqtified.esp'
-    after:
-      - 'Requiem - USKP + UDGP.esp'
-      - 'Requiem - Bring Out Your Dead.esp'
-      - 'Requiem - Hearthfire.esp'
-      - 'Requiem - Height Adjusted Races with True Giants.esp'
-      - 'NRM Dragonborn - Requiem Patch.esp'
-  - name: 'COR-CraftingOverhaulReqtified.esp'
-    after:
-      - 'Requiem - USKP + UDGP.esp'
-      - 'Requiem - Bring Out Your Dead.esp'
-      - 'Requiem - Hearthfire.esp'
-      - 'Requiem - Height Adjusted Races with True Giants.esp'
-      - 'NRM Dragonborn - Requiem Patch.esp'
+  - name: 'Requiem - Hearthfires.esp'
+    dirty:
+      - crc: 0xa3a78f22
+        <<: *dirtyPlugin
+        itm: 1
+    url:
+      - 'http://www.nexusmods.com/skyrim/mods/58121/?'
+  # this is the old dragonborn patch by azirok
+  - name: 'Requiem - Dragonborn.esp'
+    dirty:
+      - crc: 0x740bb9f0
+        <<: *dirtyPlugin
+        itm: 3
+    url:
+      - 'http://www.nexusmods.com/skyrim/mods/54562/?'
   - name: 'Skyrim Hardcore Overhaul.esp'
     tag:
       - Delev

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -25051,7 +25051,7 @@ plugins:
         condition: 'file("Requiem.esp") and not active("Requiem - Height Adjusted Races with True Giants.esp")'
       - <<: *redundantPluginX
         condition: 'active("Height Adjusted Races.esp") and active("Requiem - Height Adjusted Races with True Giants.esp")'
-        subs: [ 'Requiem - Height Adjusted Races.esp' ]
+        subs: [ 'Requiem - Height Adjusted Races with True Giants.esp' ]
   - name: 'Height Adjusted Races - Morrowind Lore Heights.esp'
     msg:
       - <<: *reqRequiemPatch

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7559,7 +7559,7 @@ plugins:
         itm: 3
   - name: 'PrvtI_HeavyArmory.esp'
     msg:
-      [ *alreadyInSkyRe ]
+      - <<: *alreadyInSkyRe
       - <<: *needsRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Heavy Armory.esp")'
     tag:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -242,7 +242,7 @@ common:
     type: warn
     content:
       - lang: en
-        text: 'This mod is incompatible with Requiem. You should install a compatibility patch.'
+        text: 'Incompatible with: Requiem. You must install a compatibility patch.'
 
 # Cleaning data
   - &dirtyPlugin
@@ -24976,16 +24976,19 @@ plugins:
   - name: 'MoonAndStar_MAS.esp'
     after:
       - 'AuroraVillage.esp'
-
   - name: 'No Vendor or Loot Spells.esp'
     global_priority: 100
-
-# Mods that are incompatible with Requiem but have compatibility patches available
-  - name: 'Hypothermia.esp'
+  - name: 'Skyrim Unlocked.esp'
+    global_priority: 90
+    inc:
+      - name: "Open Cities Skyrim.esp"
+        condition: 'not active("Open Cities Skyrim - Skyrim Unlocked Patch.esp")'
     msg:
+      - type: warn
+        condition: 'active("Open Cities Skyrim.esp") and not active("Open Cities Skyrim - Skyrim Unlocked Patch.esp")'
+        content: 'Incompatible with: Open Cities Skyrim. You must install the compatibility patch.'
       - <<: *needsRequiemPatch
-        condition: 'file("Requiem.esp") and not active("Requiem - Realistic Needs & Hypothermia.esp")'
-  # Requiem patches provided by thetrader
+        condition: 'file("Requiem.esp") and not active("Requiem - Skyrim Unlocked.esp") and not active("Requiem - Skyrim Unlocked - OCS.esp")'
   - name: '83Willows_101BUGS_V4_HighRes_HighSpawn.esp' 
     msg:
       - <<: *needsRequiemPatch
@@ -25119,6 +25122,10 @@ plugins:
     msg:
       - <<: *needsRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Hoth.esp")'
+  - name: 'Hypothermia.esp'
+    msg:
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("Requiem - Realistic Needs & Hypothermia.esp")'
   - name: 'Immersive Horses.esp'
     msg:
       - <<: *needsRequiemPatch
@@ -25148,27 +25155,19 @@ plugins:
       - <<: *needsRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Rustic Soulgems.esp") and not active("Requiem - Rustic Soulgems - ISC.esp")'
       - <<: *redundantPluginX
-        condition: 'active("RUSTIC SOULGEMS - Sorted.esp") and active("Requiem - Rustic Soulgems.esp")'
+        condition: 'active("RUSTIC SOULGEMS - Sorted.esp") and active("Requiem - Rustic Soulgems.esp") or active("RUSTIC SOULGEMS - Sorted.esp") and active("Requiem - Rustic Soulgems - ISC.esp")'
         subs: [ 'Requiem - Rustic Soulgems.esp' ]
   - name: 'RUSTIC SOULGEMS - Unsorted.esp'
     msg:
       - <<: *needsRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Rustic Soulgems.esp") and not active("Requiem - Rustic Soulgems - ISC.esp")'
       - <<: *redundantPluginX
-        condition: 'active("RUSTIC SOULGEMS - Unsorted.esp") and active("Requiem - Rustic Soulgems.esp")'
+        condition: 'active("RUSTIC SOULGEMS - Unsorted.esp") and active("Requiem - Rustic Soulgems.esp") or active("RUSTIC SOULGEMS - Sorted.esp") and active("Requiem - Rustic Soulgems - ISC.esp")'
         subs: [ 'Requiem - Rustic Soulgems.esp' ]
   - name: 'ScopedBows.esp'
     msg:
       - <<: *needsRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Scoped Bows.esp")'
-  - name: 'Skyrim Unlocked.esp'
-    global_priority: 90
-    inc:
-      - name: "Open Cities Skyrim.esp"
-        condition: 'not active("Open Cities Skyrim - Skyrim Unlocked Patch.esp")'
-    msg:
-      - <<: *needsRequiemPatch
-        condition: 'file("Requiem.esp") and not active("Requiem - Skyrim Unlocked.esp") and not active("Requiem - Skyrim Unlocked - OCS.esp")'
   - name: 'Unique Uniques.esp'
     msg:
       - <<: *needsRequiemPatch
@@ -25185,8 +25184,6 @@ plugins:
     msg:
       - <<: *needsRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Dawnguard Arsenal.esp")'
-
-
   - name: 'ISC WAFR Patch.esp'
     msg:
       - <<: *redundantPluginX

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -8903,45 +8903,45 @@ plugins:
     priority: -50
     msg:
       - <<: *replacerPluginForX
-      condition: 'file("Height Adjusted Races.esp")'
-      subs: [ 'Height Adjusted Races.esp' ]
+        condition: 'file("Height Adjusted Races.esp")'
+        subs: [ 'Height Adjusted Races.esp' ]
       - <<: *replacerPluginForX
-      condition: 'file("Height Adjusted Races - Morrowind Lore Heights.esp")'
-      subs: [ 'Height Adjusted Races - Morrowind Lore Heights.esp' ]
+        condition: 'file("Height Adjusted Races - Morrowind Lore Heights.esp")'
+        subs: [ 'Height Adjusted Races - Morrowind Lore Heights.esp' ]
       - <<: *replacerPluginForX
-      condition: 'file("Height Adjusted Races - Oblivion Lore Heights.esp")'
-      subs: [ 'Height Adjusted Races - Oblivion Lore Heights.esp' ]
+        condition: 'file("Height Adjusted Races - Oblivion Lore Heights.esp")'
+        subs: [ 'Height Adjusted Races - Oblivion Lore Heights.esp' ]
       - <<: *replacerPluginForX
-      condition: 'file("Height Adjusted Races - Player Races Only.esp")'
-      subs: [ 'Height Adjusted Races - Player Races Only.esp' ]
+        condition: 'file("Height Adjusted Races - Player Races Only.esp")'
+        subs: [ 'Height Adjusted Races - Player Races Only.esp' ]
       - <<: *replacerPluginForX
-      condition: 'file("Height Adjusted Races - Player Races Only - Oblivion Lore Heights.esp")'
-      subs: [ 'Height Adjusted Races - Player Races Only - Oblivion Lore Heights.esp' ]
+        condition: 'file("Height Adjusted Races - Player Races Only - Oblivion Lore Heights.esp")'
+        subs: [ 'Height Adjusted Races - Player Races Only - Oblivion Lore Heights.esp' ]
       - <<: *replacerPluginForX
-      condition: 'file("Height Adjusted Races - Player Races Only - Morrowind Lore Heights.esp")'
-      subs: [ 'Height Adjusted Races - Player Races Only - Morrowind Lore Heights.esp' ]
+        condition: 'file("Height Adjusted Races - Player Races Only - Morrowind Lore Heights.esp")'
+        subs: [ 'Height Adjusted Races - Player Races Only - Morrowind Lore Heights.esp' ]
       - <<: *replacerPluginForX
-      condition: 'file("Height Adjusted Races with True Giants.esp")'
-      subs: [ 'Height Adjusted Races with True Giants.esp' ]
+        condition: 'file("Height Adjusted Races with True Giants.esp")'
+        subs: [ 'Height Adjusted Races with True Giants.esp' ]
       - <<: *replacerPluginForX
-      condition: 'file("Height Adjusted Races with True Giants - Smaller Giant Edition.esp")'
-      subs: [ 'Height Adjusted Races with True Giants - Smaller Giant Edition.esp' ]
+        condition: 'file("Height Adjusted Races with True Giants - Smaller Giant Edition.esp")'
+        subs: [ 'Height Adjusted Races with True Giants - Smaller Giant Edition.esp' ]
   - name: 'Requiem - True Giants and Mammoths.esp'
     msg:
       - <<: *replacerPluginForX
-      condition: 'file("Height Adjusted Races - True Giants and Mammoths.esp)'
-      subs: [ 'Height Adjusted Races - True Giants and Mammoths.esp' ]
+        condition: 'file("Height Adjusted Races - True Giants and Mammoths.esp)'
+        subs: [ 'Height Adjusted Races - True Giants and Mammoths.esp' ]
       - <<: *replacerPluginForX
-      condition: 'file("Height Adjusted Races - True Giants and Mammoths - Smaller Giant Edition.esp)'
-      subs: [ 'Height Adjusted Races - True Giants and Mammoths - Smaller Giant Edition.esp' ]
+        condition: 'file("Height Adjusted Races - True Giants and Mammoths - Smaller Giant Edition.esp)'
+        subs: [ 'Height Adjusted Races - True Giants and Mammoths - Smaller Giant Edition.esp' ]
   - name: 'Requiem - Rustic Soulgems( - ISC)?\.esp'
     msg:
       - <<: *replacerPluginForX
-      condition: 'file("RUSTIC SOULGEMS - Sorted.esp")'
-      subs: [ 'RUSTIC SOULGEMS - Sorted.esp' ]
+        condition: 'file("RUSTIC SOULGEMS - Sorted.esp")'
+        subs: [ 'RUSTIC SOULGEMS - Sorted.esp' ]
       - <<: *replacerPluginForX
-      condition: 'file("RUSTIC SOULGEMS - Unsorted.esp")'
-      subs: [ 'RUSTIC SOULGEMS - Unsorted.esp' ]
+        condition: 'file("RUSTIC SOULGEMS - Unsorted.esp")'
+        subs: [ 'RUSTIC SOULGEMS - Unsorted.esp' ]
   - name: 'Bounty Gold.esp'
     after:
       - 'Requiem.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -238,7 +238,7 @@ common:
     type: warn
     content: 'SkyUI.esp is not active in your load order. [SkyUI](http://www.nexusmods.com/skyrim/mods/3863) is required for this mod to be fully functional.'
     condition: 'not active("SkyUI.esp")'
-  - &needsRequiemPatch
+  - &reqRequiemPatch
     type: warn
     content:
       - lang: en
@@ -712,7 +712,7 @@ plugins:
   - name: 'Falskaar.esm'
     global_priority: -90
     msg:
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("NRM Falskaar - Requiem Patch.esp")'
     clean:
       - crc: 0xDDFDBEDE
@@ -723,7 +723,7 @@ plugins:
     after:
       - 'Falskaar.esm'
     msg:
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("NRM Wyrmstooth - Requiem Patch.esp")'
     dirty:
       - crc: 0x54f43cef
@@ -2234,7 +2234,7 @@ plugins:
     after:
       - 'Guard Dialogue Overhaul.esp'
     msg:
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("KFR-Kryptopyr''sFixesReqtified.esp") and not active("Requiem - CCF WAFR Patch.esp")'
     tag:
       - Delev
@@ -2244,7 +2244,7 @@ plugins:
     after:
       - 'Weapons & Armor Fixes_Remade.esp'
     msg:
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("KFR-Kryptopyr''sFixesReqtified.esp") and not active("Requiem - CCF WAFR Patch.esp")'
     tag:
       - Delev
@@ -2523,11 +2523,11 @@ plugins:
   - name: 'AOS.esp'
     after:
       - 'WetandCold.esp'
-      # AOS shouldn't be loaded after Requiem
+      # RWT must be loaded after Requiem but AOS shouldn't so this rule is disabled when Requiem is installed
       - name: 'RealisticWaterTwo.esp'
         condition: 'not file("AOS2_RealisticWaterTwo Patch.esp") and not file("WAO-.*RWT.*\.esp") and not file("Requiem.esp")'
     msg:
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Audio Overhaul for Skyrim.esp") and not active("AOS2_Requiem Patch.esp")'
     dirty:
       - crc: 0xd88afe72
@@ -2883,7 +2883,7 @@ plugins:
       - 'TouringCarriages.esp'
       - 'WhiterunHoldForest.esp'
     msg:
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Cutting Room Floor.esp")'
     tag:
       - C.Climate
@@ -2993,7 +2993,7 @@ plugins:
     after:
       - 'TradeRoutes.esp'
     msg:
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Trade and Barter.esp")'
     tag:
       - Delev
@@ -4000,7 +4000,7 @@ plugins:
   - name: 'ImmersiveSpells.esp'
     req: [ *SKSE ]
     msg:
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Immersive Spells.esp")'
   - name: 'ImmersiveSpells-NoDlcDawnDragComp.esp'
     req: [ *SKSE ]
@@ -4864,7 +4864,7 @@ plugins:
       - type: say
         content: 'This is the Lore-Friendly version by jackstarr.  Do not use the original esp or esm by lifestorock.'
         condition: 'checksum("Skyrim Immersive Creatures.esp",2EEAD88A)'
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Immersive Creatures.esp")'
     tag:
       - Delev
@@ -5885,7 +5885,7 @@ plugins:
     msg: [ *reqNudeAndJiggly ]
   - name: 'Black Mage Armor.esp'
     msg:
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Black Mage Armor.esp")'
     tag:
       - name: Deactivate
@@ -6033,7 +6033,7 @@ plugins:
       - <<: *useOnlyOneX
         condition: 'many("Cloaks( - (No Imperial|Player Only))?\.esp")'
         subs: [ 'Cloaks .esp file' ]
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("COR-CraftingOverhaulReqtified.esp") and not active("CFR-CloaksForRequiem.esp")'
   - name: 'Cloaks.esp'
     dirty:
@@ -6088,7 +6088,7 @@ plugins:
       - <<: *useOnlyOneX
         condition: 'many("1nivWICCloaks(CRAFT|NoGuards)?.esp")'
         subs: [ 'WICCloaks .esp file' ]
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("COR-CraftingOverhaulReqtified.esp") and not active("CFR-CloaksForRequiem.esp")'
     tag:
       - Relev
@@ -6719,7 +6719,7 @@ plugins:
       - type: warn
         content: 'This is the Skyjubs Invisible Helmets version of hothtrooper44_ArmorCompilation.esp and may not produce the effects desired in conjuntion with other hothtrooper patches. It is not compatible with any other Skyjubs Invisible Helmets esps other than the Dawnguard and Dragonborn plugins.'
         condition: 'checksum("hothtrooper44_ArmorCompilation.esp",1B01C914) or checksum("hothtrooper44_ArmorCompilation.esp",983EFB9E)'
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Immersive Armors.esp")'
     tag:
       - name: Delev
@@ -6828,7 +6828,7 @@ plugins:
     after:
       - 'AmazingFollowerTweaks.esp'
     msg:
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Immersive Weapons.esp")'
     tag:
       - Delev
@@ -7593,7 +7593,7 @@ plugins:
   - name: 'PrvtI_HeavyArmory.esp'
     msg:
       - <<: *alreadyInSkyRe
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Heavy Armory.esp")'
     tag:
       - Relev
@@ -8586,7 +8586,7 @@ plugins:
       - 'Clothing & Clutter Fixes.esp'
       - 'aMidianBorn_ContentAddon.esp'
     msg:
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("COR-CraftingOverhaulReqtified.esp")'
   - name: 'CCO_Frostfall_Patch.esp'
     dirty:
@@ -11236,7 +11236,7 @@ plugins:
     after:
       - 'Clothing & Clutter Fixes.esp'
     msg:
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Immersive College of Winterhold.esp")'
     dirty:
       - crc: 0xfb30c482
@@ -13175,7 +13175,7 @@ plugins:
       - 'OBIS.esp'
       - 'OBISDB.esp'
     msg:
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Civil War Overhaul Patch.esp")'
     dirty:
       - crc: 0x49e6e0bd
@@ -15068,7 +15068,7 @@ plugins:
         udr: 1
   - name: 'Animallica.esp'
     msg:
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Animallica.esp")'
     dirty:
       - crc: 0x8e94479b
@@ -15130,7 +15130,7 @@ plugins:
     after:
       - 'BetterQuestObjectives.esp'
     msg:
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("CAR-ContentAddonReqtified.esp")'
     tag:
       - Delev
@@ -15249,7 +15249,7 @@ plugins:
             text: 'Устарело. Пожалуйста используйте универсальный патч со страницы Even Better Quest Objectives. [Nexus](http://www.nexusmods.com/skyrim/mods/32695)'
           - lang: es
             text: 'This file is obsolete. Please use the universal patch on the Even Better Quest Objectives page. [Nexus](http://www.nexusmods.com/skyrim/mods/32695)'
-    # should lose conflicts because other patches may make important edits to quests
+  # Should lose conflicts because other patches may make important edits to quests
   - name: BetterQuestObjectives-RequiemPatch.esp
     priority: -50
     after:
@@ -15262,7 +15262,7 @@ plugins:
     after:
       - 'BetterQuestObjectives.esp'
     msg:
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Book Covers Skyrim.esp") and not active("REQ - BCS Patch.esp")'
     clean:
       - crc: 0x18343B2E
@@ -15688,7 +15688,7 @@ plugins:
       - 'BetterQuestObjectives.esp'
       - 'Requiem_Minor_Arcana.esp'
     msg:
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - ESF Companions.esp")'
     dirty:
       - crc: 0x16c76fa7
@@ -16071,11 +16071,11 @@ plugins:
       - <<: *reqModX
         condition: 'active("Unofficial Skyrim Patch.esp") and not file("RSChildren_PatchUSKP.esp") and not file("RSChildren_CompleteUSKP.esp")'
         subs: [ '[RSChildren USKP Patch](http://www.nexusmods.com/skyrim/mods/55555/)' ]
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - RS Children Overhaul.esp")'
   - name: 'RSChildren - Complete.esp'
     msg:
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - RS Children Overhaul.esp")'
   - name: 'RSChildren_PatchUSKP.esp'
     after:
@@ -16488,7 +16488,7 @@ plugins:
         itm: 2
   - name: 'Rebirth Monster.esp'
     msg:
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Revenge of the Enemies.esp") and not active("Rebirth Monster - Requiem Patch.esp") and not active("Rebirth Monster - Requiem Merged Patch.esp")'
     tag:
       - Delev
@@ -16728,7 +16728,7 @@ plugins:
         itm: 12
   - name: 'SkyTEST-RealisticAnimals&Predators.esm'
     msg:
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - SkyTEST.esp")'
     dirty:
       - crc: 0x7b5f9e63
@@ -16897,7 +16897,7 @@ plugins:
     after:
       - 'BetterQuestObjectives.esp'
     msg:
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Timing Is Everything.esp")'
     dirty:
       - crc: 0x99c43ba5
@@ -17914,7 +17914,7 @@ plugins:
       - type: warn
         content: 'Stolen content. Please show respect for authors'' rights and download from a legitimate source ([here](http://www.nexusmods.com/skyrim/mods/8058)).'
         condition: 'checksum("Open Cities Skyrim.esp", 022AD2C8)'
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Open Cities.esp") and not active("Requiem-OpenCities.esp")'
     tag:
       - C.Location
@@ -18329,7 +18329,7 @@ plugins:
       - '3DNPC.esp'
       - 'TradeRoutes.esp'
     msg:
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("RND_Requiem-Patch.esp") and not active("Requiem - Realistic Needs & Hypothermia.esp") and not active("RequiemSurvivalExperience.esp") and not active("Requiem Food patch.esp")'
     tag:
       - Delev
@@ -18563,7 +18563,7 @@ plugins:
     after:
       - 'Requiem.esp'
     msg:
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Better Vampires Patch.esp")'
   - name: 'Better Vampires ML.esp'
     inc:
@@ -18621,7 +18621,7 @@ plugins:
             text: 'Conflicts with other mods that change the vampirism system.'
           - lang: ru
             text: 'конфликты с другими модами, меняющими систему вампиризма.'
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("mslVampiricThirst - Requiem.esp")'
     dirty:
       - crc: 0xfafb18c2
@@ -21110,7 +21110,7 @@ plugins:
         condition: 'checksum("KhaleesiFacePreset.esp",42C16D17)'
   - name: '3DNPC.esp'
     msg:
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("NRM 3DNPC - Requiem Patch.esp")'
     dirty:
       - crc: 0x143c788a
@@ -21254,7 +21254,7 @@ plugins:
         condition: 'file("UFO - Ultimate Follower Overhaul.esp")'
   - name: 'Inigo.esp'
     msg:
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Inigo.esp")'
     dirty:
       - crc: 0xb9fc7507
@@ -22701,7 +22701,7 @@ plugins:
 # test placement of Brhuce as for Vilja; Trainwiz reco to place after every follower mod incl aft but I''m skeptical -LD
   - name: 'EMCompViljaSkyrim.esp'
     msg:
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Vilja.esp")'
     dirty:
       - crc: 0xc45d4383
@@ -22858,7 +22858,7 @@ plugins:
           - lang: ru
             text: 'Обнаружена старая версия ''Live Another Life.esp''. Вы должны удалить старую версию, перед использованием этой новой.'
         condition: 'file("Live Another Life.esp")'
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Live Another Life.esp")'
     tag:
       - C.Location
@@ -24589,7 +24589,7 @@ plugins:
       - type: warn
         condition: 'active("MoonAndStar_MAS.esp") and not active("MoonAndStar_Undeath_compat.esp")'
         content: 'This mod has certain conflicts with "MoonAndStar_MAS.esp". Consider using [the compatibility patch](http://www.nexusmods.com/skyrim/mods/52397/).'
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("NRM Undeath - Requiem Patch.esp")'
     url: [ 'http://www.nexusmods.com/skyrim/mods/40607' ]
   - name: 'Verdant - A Skyrim Grass Plugin.esp'
@@ -24890,14 +24890,14 @@ plugins:
     url: [ 'http://www.nexusmods.com/skyrim/mods/52326' ]
   - name: 'Campfire.esm'
     msg:
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Campfire.esp")'
     clean:
       - crc: 0xB536FDD0
         util: TES5Edit v3.1.3
   - name: 'CompanionArissa.esm'
     msg:
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Arissa.esp")'
     clean:
       - crc: 0xC4AE95C0
@@ -24976,7 +24976,7 @@ plugins:
   - name: 'No Vendor or Loot Spells.esp'
     global_priority: 105
   - name: 'Skyrim Unlocked.esp'
-    global_priority: 75
+    global_priority: 70
     inc:
       - name: "Open Cities Skyrim.esp"
         condition: 'not active("Open Cities Skyrim - Skyrim Unlocked Patch.esp")'
@@ -24984,202 +24984,202 @@ plugins:
       - type: warn
         condition: 'active("Open Cities Skyrim.esp") and not active("Open Cities Skyrim - Skyrim Unlocked Patch.esp")'
         content: 'Incompatible with: Open Cities Skyrim. You must install the compatibility patch.'
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Skyrim Unlocked.esp") and not active("Requiem - Skyrim Unlocked - OCS.esp")'
   - name: '83Willows_101BUGS_V4_HighRes_HighSpawn.esp' 
     msg:
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - 83Willows 101Bugs.esp")'
       - <<: *redundantPluginX
         condition: 'active("83Willows_101BUGS_V4_HighRes_HighSpawn.esp") and active("Requiem - 83Willows 101Bugs.esp")'
         subs: [ 'Requiem - 83Willows 101Bugs.esp' ]
   - name: '83Willows_101BUGS_V4_LowerRes_HighSpawn.esp'
     msg:
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - 83Willows 101Bugs.esp")'
       - <<: *redundantPluginX
         condition: 'active("83Willows_101BUGS_V4_LowerRes_HighSpawn.esp") and active("Requiem - 83Willows 101Bugs.esp")'
         subs: [ 'Requiem - 83Willows 101Bugs.esp' ]
   - name: '83Willows_101BUGS_V4_HighRes.esp'
     msg:
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - 83Willows 101Bugs.esp")'
       - <<: *redundantPluginX
         condition: 'active("83Willows_101BUGS_V4_HighRes.esp") and active("Requiem - 83Willows 101Bugs.esp")'
         subs: [ 'Requiem - 83Willows 101Bugs.esp' ]
   - name: '83Willows_101BUGS_V4_LowRes.esp'
     msg:
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - 83Willows 101Bugs.esp")'
       - <<: *redundantPluginX
         condition: 'active("83Willows_101BUGS_V4_LowRes.esp") and active("Requiem - 83Willows 101Bugs.esp")'
         subs: [ 'Requiem - 83Willows 101Bugs.esp' ]
   - name: 'Craftable Horse Barding.esp'
     msg:
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Craftable Horse Barding.esp")'
   - name: 'ExplosiveBoltsVisualized.esp'
     msg:
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Explosive Bolts Visualized.esp")'
       - <<: *redundantPluginX
         condition: 'active("ExplosiveBoltsVisualized.esp") and active("Requiem - Explosive Bolts Visualized.esp")'
         subs: [ 'Requiem - Explosive Bolts Visualized.esp' ]
   - name: 'DeadlyDragons.esp'
     msg:
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Deadly Dragons.esp") and not active("Requiem - Deadly Dragons - AOS.esp")'
   - name: 'Dragon Combat Overhaul.esp'
     msg:
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Dragon Combat Overhaul.esp")'
   - name: 'Faction Crossbows.esp'
     msg:
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Faction Crossbows.esp")'
   - name: 'FireAndIceOverhaul.esp'
     msg:
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Fire and Ice Overhaul.esp") and not active("Requiem - Fire and Ice Overhaul - AOS.esp")'
   - name: 'Frostfall.esp'
     msg:
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Frostfall.esp")'
   - name: 'Height Adjusted Races.esp'
     msg:
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Height Adjusted Races with True Giants.esp")'
       - <<: *redundantPluginX
         condition: 'active("Height Adjusted Races.esp") and active("Requiem - Height Adjusted Races with True Giants.esp")'
         subs: [ 'Requiem - Height Adjusted Races.esp' ]
   - name: 'Height Adjusted Races - Morrowind Lore Heights.esp'
     msg:
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Height Adjusted Races with True Giants.esp")'
       - <<: *redundantPluginX
         condition: 'active("Height Adjusted Races - Morrowind Lore Heights.esp") and active("Requiem - Height Adjusted Races with True Giants.esp")'
         subs: [ 'Requiem - Height Adjusted Races with True Giants.esp' ]
   - name: 'Height Adjusted Races - Oblivion Lore Heights.esp'
     msg:
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Height Adjusted Races with True Giants.esp")'
       - <<: *redundantPluginX
         condition: 'active("Height Adjusted Races - Oblivion Lore Heights.esp") and active("Requiem - Height Adjusted Races with True Giants.esp")'
         subs: [ 'Requiem - Height Adjusted Races with True Giants.esp' ]
   - name: 'Height Adjusted Races - Player Races Only.esp'
     msg:
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Height Adjusted Races with True Giants.esp")'
       - <<: *redundantPluginX
         condition: 'active("Height Adjusted Races - Player Races Only.esp") and active("Requiem - Height Adjusted Races with True Giants.esp")'
         subs: [ 'Requiem - Height Adjusted Races with True Giants.esp' ]
   - name: 'Height Adjusted Races - Player Races Only - Oblivion Lore Heights.esp'
     msg:
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Height Adjusted Races with True Giants.esp")'
       - <<: *redundantPluginX
         condition: 'active("Height Adjusted Races - Player Races Only - Oblivion Lore Heights.esp") and active("Requiem - Height Adjusted Races with True Giants.esp")'
         subs: [ 'Requiem - Height Adjusted Races with True Giants.esp' ]
   - name: 'Height Adjusted Races - Player Races Only - Morrowind Lore Heights.esp'
     msg:
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Height Adjusted Races with True Giants.esp")'
       - <<: *redundantPluginX
         condition: 'active("Height Adjusted Races - Player Races Only - Morrowind Lore Heights.esp") and active("Requiem - Height Adjusted Races with True Giants.esp")'
         subs: [ 'Requiem - Height Adjusted Races with True Giants.esp' ]
   - name: 'Height Adjusted Races with True Giants.esp'
     msg:
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Height Adjusted Races with True Giants.esp")'
       - <<: *redundantPluginX
         condition: 'active("Height Adjusted Races with True Giants.esp") and active("Requiem - Height Adjusted Races with True Giants.esp")'
         subs: [ 'Requiem - Height Adjusted Races with True Giants.esp' ]
   - name: 'Height Adjusted Races with True Giants - Smaller Giant Edition.esp'
     msg:
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Height Adjusted Races with True Giants.esp")'
       - <<: *redundantPluginX
         condition: 'active("Height Adjusted Races with True Giants - Smaller Giant Edition.esp") and active("Requiem - Height Adjusted Races with True Giants.esp")'
         subs: [ 'Requiem - Height Adjusted Races with True Giants.esp' ]
   - name: 'Height Adjusted Races - True Giants and Mammoths.esp'
     msg:
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - True Giants and Mammoths.esp")'
       - <<: *redundantPluginX
         condition: 'active("Height Adjusted Races - True Giants and Mammoths.esp") and active("Requiem - True Giants and Mammoths.esp")'
         subs: [ 'Requiem - True Giants and Mammoths.esp' ]
   - name: 'Height Adjusted Races - True Giants and Mammoths - Smaller Giant Edition.esp'
     msg:
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - True Giants and Mammoths.esp")'
       - <<: *redundantPluginX
         condition: 'active("Height Adjusted Races - True Giants and Mammoths - Smaller Giant Edition.esp") and active("Requiem - True Giants and Mammoths.esp")'
         subs: [ 'Requiem - True Giants and Mammoths.esp' ]
   - name: 'HothFollower.esp'
     msg:
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Hoth.esp")'
   - name: 'Hypothermia.esp'
     msg:
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Realistic Needs & Hypothermia.esp")'
   - name: 'Immersive Horses.esp'
     msg:
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Immersive Horses.esp") and not active("Requiem - Immersive Horses - SkyTEST.esp")'
   - name: 'Immersive Patrols II.esp'
     msg:
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Immersive Patrols.esp") and not active("Requiem - Immersive Patrols - CWO.esp")'
   - name: 'Immersive Sounds - Compendium.esp'
     msg:
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Immersive Sounds Compendium.esp")'
   - name: 'imp_helm_legend.esp'
     msg:
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Improved Closefaced Helmets.esp")'
   - name: 'Inconsequential NPCs.esp'
     msg:
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Inconsequential NPCs.esp")'
   - name: 'Inconsequential NPCs - Enhancement.esp'
     msg:
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Inconsequential NPCs - Enhancement.esp")'
   - name: 'RUSTIC SOULGEMS - Sorted.esp'
     msg:
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Rustic Soulgems.esp") and not active("Requiem - Rustic Soulgems - ISC.esp")'
       - <<: *redundantPluginX
         condition: 'active("RUSTIC SOULGEMS - Sorted.esp") and active("Requiem - Rustic Soulgems.esp") or active("RUSTIC SOULGEMS - Sorted.esp") and active("Requiem - Rustic Soulgems - ISC.esp")'
         subs: [ 'Requiem - Rustic Soulgems.esp' ]
   - name: 'RUSTIC SOULGEMS - Unsorted.esp'
     msg:
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Rustic Soulgems.esp") and not active("Requiem - Rustic Soulgems - ISC.esp")'
       - <<: *redundantPluginX
         condition: 'active("RUSTIC SOULGEMS - Unsorted.esp") and active("Requiem - Rustic Soulgems.esp") or active("RUSTIC SOULGEMS - Sorted.esp") and active("Requiem - Rustic Soulgems - ISC.esp")'
         subs: [ 'Requiem - Rustic Soulgems.esp' ]
   - name: 'ScopedBows.esp'
     msg:
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Scoped Bows.esp")'
   - name: 'Unique Uniques.esp'
     msg:
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Unique Uniques.esp") and not active("Requiem - Unique Uniques - AOS.esp")'
   - name: 'VioLens.esp'
     msg:
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - VioLens.esp")'
   - name: 'WM Flora Fixes.esp'
     msg:
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - WM Flora Fixes.esp")'
   - name: 'DawnguardArsenal.esp'
     msg:
-      - <<: *needsRequiemPatch
+      - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Dawnguard Arsenal.esp")'
   - name: 'ISC WAFR Patch.esp'
     msg:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -188,6 +188,11 @@ common:
         text: 'Delete or deactivate %1%.'
       - lang: ru
         text: 'Не забудьте отключить или удалить %1%.'
+  - &redundantPluginX
+    type: warn
+    content:
+      - lang: en
+        text: 'This plugin is redundant when using %1% and should be deactivated or deleted.'
   - &SmashedVsBashedPatch
     type: say
     content:
@@ -228,11 +233,16 @@ common:
   - &reqBetterMales
     <<: *reqModX
     subs: [ '[Better males - Beautiful nudes and faces - New hairstyles](http://www.nexusmods.com/skyrim/mods/2488)' ]
-
-  - &reqSkyUI # Useful for when a plugin needs SkyUI, but shouldn't load after it (eg. when it's a master plugin).
+  # Useful for when a plugin needs SkyUI, but shouldn't load after it (eg. when it's a master plugin).
+  - &reqSkyUI
     type: warn
     content: 'SkyUI.esp is not active in your load order. [SkyUI](http://www.nexusmods.com/skyrim/mods/3863) is required for this mod to be fully functional.'
     condition: 'not active("SkyUI.esp")'
+  - &needsRequiemPatch
+    type: warn
+    content:
+      - lang: en
+        text: 'This mod is incompatible with Requiem. You should install a compatibility patch.'
 
 # Cleaning data
   - &dirtyPlugin

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2534,9 +2534,38 @@ plugins:
         <<: *dirtyPlugin
         itm: 7
         udr: 0
+  - name: 'AOS2_DD Patch.esp'
+    msg:
+      - <<: *redundantPluginX
+        condition: 'active("AOS2_DD Patch.esp") and active("Requiem - Deadly Dragons - AOS.esp")'
+        subs: [ 'Requiem - Deadly Dragons - AOS.esp' ]
+  - name: 'AOS2_FIO Patch.esp'
+    msg:
+      - <<: *redundantPluginX
+        condition: 'active("AOS2_FIO Patch.esp") and active("Requiem - Fire and Ice Overhaul - AOS.esp")'
+        subs: [ 'Requiem - Fire and Ice Overhaul - AOS.esp' ]
+  - name: 'AOS2_GDO Patch.esp'
+    msg:
+      - <<: *redundantPluginX
+        condition: 'active("AOS2_GDO Patch.esp") and active("Requiem - Audio Overhaul for Skyrim.esp")'
+        subs: [ 'Requiem - Audio Overhaul for Skyrim.esp' ]
+  - name: 'AOS2_Unique Uniques Patch.esp'
+    msg:
+      - <<: *redundantPluginX
+        condition: 'active("AOS2_Unique Uniques Patch.esp") and active("Requiem - Unique Uniques - AOS.esp")'
+        subs: [ 'Requiem - Unique Uniques - AOS.esp' ]
   - name: 'AOS2_WAF Patch.esp'
     after:
       - name: 'AOS2_GDO Patch.esp'
+    msg:
+      - <<: *redundantPluginX
+        condition: 'active("AOS2_WAF Patch.esp") and active("Requiem - Audio Overhaul for Skyrim.esp")'
+        subs: [ 'Requiem - Audio Overhaul for Skyrim.esp' ]
+  - name: 'AOS2_Requiem Patch.esp'
+    msg:
+      - <<: *redundantPluginX
+        condition: 'active("AOS2_Requiem Patch.esp") and active("Requiem - Audio Overhaul for Skyrim.esp")'
+        subs: [ 'Requiem - Audio Overhaul for Skyrim.esp' ]
 # ## AOS_DG Patch.esp
 # ## AOS_DB Patch.esp
 # ## these should sort up here; regex: AOS_.+ down in compat patches section was unfortunately too broad -LD
@@ -6080,6 +6109,10 @@ plugins:
             text: 'Несовместим с: Cloaks of skyrim, возьмите патч совместимости из опциональных файлов WIC.'
         condition: 'file("Cloaks - No Imperial.esp") and not file("1nivWICSkyCloaksPatch-No Imp.esp")'
   - name: '1nivWICSkyCloaksPatch.esp'
+    msg:
+      - <<: *redundantPluginX
+        condition: 'active("1nivWICSkyCloaksPatch.esp") and active("CFR-CloaksForRequiem.esp")'
+        subs: [ 'CFR-CloaksForRequiem.esp' ]
     dirty:
       - crc: 0x2a8cad17
         <<: *dirtyPlugin
@@ -8839,6 +8872,12 @@ plugins:
     after:
       - 'Requiem - Immersive Horses.esp'
       - 'Requiem - Immersive Horses - SkyTEST.esp'
+  - name: 'Requiem - WAF+Clothing and Clutter Fixes Patch.esp'
+    inc:
+      - 'KFR-Kryptopyr''sFixesReqtified.esp")'
+  - name: 'Requiem - WAF+CCF+TrueWeapons Patch.esp'
+    inc:
+      - 'KFR-Kryptopyr''sFixesReqtified.esp")'
   - name: 'Requiem for the Indifferent.esp'
     global_priority: 95
 # mods that go after Requiem
@@ -15180,6 +15219,16 @@ plugins:
         condition: 'checksum("BetterQuestObjectives.esp",BCD35920)'
     tag:
       - NoMerge
+  - name: 'BetterQuestObjectives-AlternateStartPatch.esp'
+    msg:
+      - <<: *redundantPluginX
+        condition: 'active("BetterQuestObjectives-AlternateStartPatch.esp") and active("Requiem - Live Another Life.esp")'
+        subs: [ 'Requiem - Live Another Life.esp' ]
+  - name: 'BetterQuestObjectives-CRFPatch.esp'
+    msg:
+      - <<: *redundantPluginX
+        condition: 'active("BetterQuestObjectives-CRFPatch.esp") and active("Requiem - Cutting Room Floor.esp")'
+        subs: [ 'Requiem - Cutting Room Floor.esp' ]
   - name: 'BetterQuestObjectives-BSaQBPatch.esp'
     msg:
       - <<: *reqModX
@@ -17039,9 +17088,17 @@ plugins:
       - name: 'Guard Dialogue Overhaul.esp'
         display: '[Guard Dialouge Overhaul](http://www.nexusmods.com/skyrim/mods/23390)'
   - name: 'Weapons & Armor_TrueDaedricWeapons.esp'
+    msg:
+      - <<: *redundantPluginX
+        condition: 'active("Weapons & Armor_TrueDaedricWeapons.esp") and active("KFR-Kryptopyr''sFixesReqtified.esp")'
+        subs: [ 'KFR-Kryptopyr''sFixesReqtified.esp' ]
     tag:
       - Stats
   - name: 'Weapons & Armor_TrueOrcishWeapons.esp'
+    msg:
+      - <<: *redundantPluginX
+        condition: 'active("Weapons & Armor_TrueOrcishWeapons.esp") and active("KFR-Kryptopyr''sFixesReqtified.esp")'
+        subs: [ 'KFR-Kryptopyr''sFixesReqtified.esp' ]
     tag:
       - Delev
       - Relev
@@ -17049,10 +17106,34 @@ plugins:
   - name: 'Weapons & Armor_TrueOrcish&DaedricWeapons.esp'
     after:
       - 'Weapons & Armor Fixes_Remade.esp'
+    msg:
+      - <<: *redundantPluginX
+        condition: 'active("Weapons & Armor_TrueOrcish&DaedricWeapons.esp") and active("KFR-Kryptopyr''sFixesReqtified.esp")'
+        subs: [ 'KFR-Kryptopyr''sFixesReqtified.esp' ]
     tag:
       - Delev
       - Relev
       - Stats
+  - name: 'Weapons & Armor_TrueWeaponsLvlLists.esp'
+    msg:
+      - <<: *redundantPluginX
+        condition: 'active("Weapons & Armor_TrueWeaponsLvlLists.esp") and active("KFR-Kryptopyr''sFixesReqtified.esp")'
+        subs: [ 'KFR-Kryptopyr''sFixesReqtified.esp' ]
+  - name: 'Weapons & Armor_DragonPriestMasks.esp'
+    msg:
+      - <<: *redundantPluginX
+        condition: 'active("Weapons & Armor_DragonPriestMasks.esp") and active("KFR-Kryptopyr''sFixesReqtified.esp")'
+        subs: [ 'KFR-Kryptopyr''sFixesReqtified.esp' ]
+  - name: 'Weapons & Armor_FasterArrows.esp'
+    msg:
+      - <<: *redundantPluginX
+        condition: 'active("Weapons & Armor_FasterArrows.esp") and active("KFR-Kryptopyr''sFixesReqtified.esp")'
+        subs: [ 'KFR-Kryptopyr''sFixesReqtified.esp' ]
+  - name: 'WeaponsArmorFixes_ImmersiveWeapons_Patch.esp'
+    msg:
+      - <<: *redundantPluginX
+        condition: 'active("WeaponsArmorFixes_ImmersiveWeapons_Patch.esp") and active("Requiem - Immersive Weapons.esp")'
+        subs: [ 'Requiem - Immersive Weapons.esp' ]
   - name: 'Skyrim unleashed_items.esp'
     tag:
       - Delev
@@ -25104,3 +25185,70 @@ plugins:
     msg:
       - <<: *needsRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Dawnguard Arsenal.esp")'
+
+
+  - name: 'ISC WAFR Patch.esp'
+    msg:
+      - <<: *redundantPluginX
+        condition: 'active("ISC WAFR Patch.esp") and active("Requiem - Immersive Sounds Compendium.esp")'
+        subs: [ 'Requiem - Immersive Sounds Compendium.esp' ]
+  - name: 'ISC CCF Patch.esp'
+    msg:
+      - <<: *redundantPluginX
+        condition: 'active("ISC CCF Patch.esp") and active("Requiem - Immersive Sounds Compendium.esp")'
+        subs: [ 'Requiem - Immersive Sounds Compendium.esp' ]
+  - name: 'ISCompendium CCO Patch.esp'
+    msg:
+      - <<: *redundantPluginX
+        condition: 'active("ISCompendium CCO Patch.esp") and active("Requiem - Immersive Sounds Compendium.esp")'
+        subs: [ 'Requiem - Immersive Sounds Compendium.esp' ]
+  - name: 'ISC Requiem Patch.esp'
+    msg:
+      - <<: *redundantPluginX
+        condition: 'active("ISC Requiem Patch.esp") and active("Requiem - Immersive Sounds Compendium.esp")'
+        subs: [ 'Requiem - Immersive Sounds Compendium.esp' ]
+  - name: 'Requiem - Dragonborn - CCOR Patch.esp'
+    msg:
+      - <<: *redundantPluginX
+        condition: 'active("Requiem - Dragonborn - CCOR Patch.esp") and active("COR-CraftingOverhaulReqtified.esp")'
+        subs: [ 'COR-CraftingOverhaulReqtified.esp' ]
+  - name: 'CCO_WAFTrueWeapons_Patch.esp'
+    msg:
+      - <<: *redundantPluginX
+        condition: 'active("CCO_WAFTrueWeapons_Patch.esp") and active("COR-CraftingOverhaulReqtified.esp")'
+        subs: [ 'COR-CraftingOverhaulReqtified.esp' ]
+  - name: 'Cloaks - Dawnguard.esp'
+    msg:
+      - <<: *redundantPluginX
+        condition: 'active("Cloaks - Dawnguard.esp") and active("CFR-CloaksForRequiem.esp")'
+        subs: [ 'CFR-CloaksForRequiem.esp' ]
+  - name: 'COS_WIC_CCO_patch.esp'
+    msg:
+      - <<: *redundantPluginX
+        condition: 'active("COS_WIC_CCO_patch.esp") and active("CFR-CloaksForRequiem.esp")'
+        subs: [ 'CFR-CloaksForRequiem.esp' ]
+  - name: 'Requiem - Cloaks.esp'
+    msg:
+      - <<: *redundantPluginX
+        condition: 'active("Requiem - Cloaks.esp") and active("CFR-CloaksForRequiem.esp")'
+        subs: [ 'CFR-CloaksForRequiem.esp' ]
+  - name: 'Requiem - Cloaks of Skyrim.esp'
+    msg:
+      - <<: *redundantPluginX
+        condition: 'active("Requiem - Cloaks of Skyrim.esp") and active("CFR-CloaksForRequiem.esp")'
+        subs: [ 'CFR-CloaksForRequiem.esp' ]
+  - name: 'Requiem - Cloaks of Skyrim Hard - Times.esp'
+    msg:
+      - <<: *redundantPluginX
+        condition: 'active("Requiem - Cloaks of Skyrim Hard - Times.esp") and active("CFR-CloaksForRequiem.esp")'
+        subs: [ 'CFR-CloaksForRequiem.esp' ]
+  - name: 'Requiem - Cloaks of Skyrim Patch.esp'
+    msg:
+      - <<: *redundantPluginX
+        condition: 'active("Requiem - Cloaks of Skyrim Patch.esp") and active("CFR-CloaksForRequiem.esp")'
+        subs: [ 'CFR-CloaksForRequiem.esp' ]
+  - name: 'Requiem - Cloaks WICCloaks CCFR USKP.esp'
+    msg:
+      - <<: *redundantPluginX
+        condition: 'active("Requiem - Cloaks WICCloaks CCFR USKP.esp") and active("CFR-CloaksForRequiem.esp")'
+        subs: [ 'CFR-CloaksForRequiem.esp' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -25196,7 +25196,7 @@ plugins:
       - <<: *redundantPluginX
         condition: 'active("ISCompendium CCO Patch.esp") and active("Requiem - Immersive Sounds Compendium.esp")'
         subs: [ 'Requiem - Immersive Sounds Compendium.esp' ]
- - name: '(ISC Requiem Patch|Requiem - Immersive Sounds Compendium)\.esp'
+  - name: '(ISC Requiem Patch|Requiem - Immersive Sounds Compendium)\.esp'
     msg:
       - <<: *useOnlyOneX
         condition: 'many("(ISC Requiem Patch|Requiem - Immersive Sounds Compendium)\.esp")'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -711,6 +711,9 @@ plugins:
 # Falskaar is stated to be an "unofficial DLC", it should be loaded right after the Beth DLCs, logically. - William
   - name: 'Falskaar.esm'
     global_priority: -90
+    msg:
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("NRM Falskaar - Requiem Patch.esp")'
     clean:
       - crc: 0xDDFDBEDE
         util: TES5Edit v3.1.3
@@ -719,6 +722,9 @@ plugins:
     global_priority: -90
     after:
       - 'Falskaar.esm'
+    msg:
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("NRM Wyrmstooth - Requiem Patch.esp")'
     dirty:
       - crc: 0x54f43cef
         <<: *dirtyPlugin
@@ -2227,6 +2233,9 @@ plugins:
   - name: 'Weapons & Armor Fixes_Remade.esp'
     after:
       - 'Guard Dialogue Overhaul.esp'
+    msg:
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("KFR-Kryptopyr''sFixesReqtified.esp") and not active("Requiem - CCF WAFR Patch.esp")'
     tag:
       - Delev
       - Relev
@@ -2234,6 +2243,9 @@ plugins:
   - name: 'Clothing & Clutter Fixes.esp'
     after:
       - 'Weapons & Armor Fixes_Remade.esp'
+    msg:
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("KFR-Kryptopyr''sFixesReqtified.esp") and not active("Requiem - CCF WAFR Patch.esp")'
     tag:
       - Delev
       - Relev
@@ -2509,10 +2521,14 @@ plugins:
 # ## MoreSoundOptions.esp
 # ## suggested to load before ADS
   - name: 'AOS.esp'
-    after:
+     after:
       - 'WetandCold.esp'
+      # AOS shouldn't be loaded after Requiem
       - name: 'RealisticWaterTwo.esp'
-        condition: 'not file("AOS2_RealisticWaterTwo Patch.esp") and not file("WAO-.*RWT.*\.esp")'
+        condition: 'not file("AOS2_RealisticWaterTwo Patch.esp") and not file("WAO-.*RWT.*\.esp") and not file("Requiem.esp")'
+    msg:
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("Requiem - Audio Overhaul for Skyrim.esp") and not active("AOS2_Requiem Patch.esp")'
     dirty:
       - crc: 0xd88afe72
         <<: *dirtyPlugin
@@ -2837,6 +2853,9 @@ plugins:
     after:
       - 'TouringCarriages.esp'
       - 'WhiterunHoldForest.esp'
+    msg:
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("Requiem - Cutting Room Floor.esp")'
     tag:
       - C.Climate
       - C.Location
@@ -2944,6 +2963,9 @@ plugins:
       - *SkyUI
     after:
       - 'TradeRoutes.esp'
+    msg:
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("Requiem - Trade and Barter.esp")'
     tag:
       - Delev
       - Relev
@@ -3948,6 +3970,9 @@ plugins:
         udr: 2
   - name: 'ImmersiveSpells.esp'
     req: [ *SKSE ]
+    msg:
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("Requiem - Immersive Spells.esp")'
   - name: 'ImmersiveSpells-NoDlcDawnDragComp.esp'
     req: [ *SKSE ]
   - name: 'ImprovedFish.esp'
@@ -4810,6 +4835,8 @@ plugins:
       - type: say
         content: 'This is the Lore-Friendly version by jackstarr.  Do not use the original esp or esm by lifestorock.'
         condition: 'checksum("Skyrim Immersive Creatures.esp",2EEAD88A)'
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("Requiem - Immersive Creatures.esp")'
     tag:
       - Delev
       - Relev
@@ -5828,6 +5855,9 @@ plugins:
   - name: 'bikiniCHSBHC.esp'
     msg: [ *reqNudeAndJiggly ]
   - name: 'Black Mage Armor.esp'
+    msg:
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("Requiem - Black Mage Armor.esp")'
     tag:
       - name: Deactivate
         condition: 'file("SkyRe Black Mage Armor.esp")'
@@ -5974,6 +6004,8 @@ plugins:
       - <<: *useOnlyOneX
         condition: 'many("Cloaks( - (No Imperial|Player Only))?\.esp")'
         subs: [ 'Cloaks .esp file' ]
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("COR-CraftingOverhaulReqtified.esp") and not active("CFR-CloaksForRequiem.esp")'
   - name: 'Cloaks.esp'
     dirty:
       - crc: 0x35c871de
@@ -6027,6 +6059,8 @@ plugins:
       - <<: *useOnlyOneX
         condition: 'many("1nivWICCloaks(CRAFT|NoGuards)?.esp")'
         subs: [ 'WICCloaks .esp file' ]
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("COR-CraftingOverhaulReqtified.esp") and not active("CFR-CloaksForRequiem.esp")'
     tag:
       - Relev
   - name: '1nivWICCloaks.esp'
@@ -6652,6 +6686,8 @@ plugins:
       - type: warn
         content: 'This is the Skyjubs Invisible Helmets version of hothtrooper44_ArmorCompilation.esp and may not produce the effects desired in conjuntion with other hothtrooper patches. It is not compatible with any other Skyjubs Invisible Helmets esps other than the Dawnguard and Dragonborn plugins.'
         condition: 'checksum("hothtrooper44_ArmorCompilation.esp",1B01C914) or checksum("hothtrooper44_ArmorCompilation.esp",983EFB9E)'
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("Requiem - Immersive Armors.esp")'
     tag:
       - name: Delev
         condition: 'version("hothtrooper44_ArmorCompilation.esp", "7", >=) or file("SkyRe_Plugin_ImmersiveArmor.+\.esp")'
@@ -6756,11 +6792,14 @@ plugins:
     after:
       - 'WarmongerArmory_Vanilla.esp'
   - name: 'Immersive Weapons.esp'
+    after:
+      - 'AmazingFollowerTweaks.esp'
+    msg:
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("Requiem - Immersive Weapons.esp")'
     tag:
       - Delev
       - Relev
-    after:
-      - 'AmazingFollowerTweaks.esp'
     dirty:
       - crc: 0x2eae1f9d
         <<: *dirtyPlugin
@@ -7519,7 +7558,10 @@ plugins:
         <<: *dirtyPlugin
         itm: 3
   - name: 'PrvtI_HeavyArmory.esp'
-    msg: [ *alreadyInSkyRe ]
+    msg:
+      [ *alreadyInSkyRe ]
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("Requiem - Heavy Armory.esp")'
     tag:
       - Relev
   - name: 'PrvtI_HeavyArmory_DG_Addon.esp'
@@ -8510,6 +8552,9 @@ plugins:
       - 'Weapons & Armor Fixes_Remade.esp'
       - 'Clothing & Clutter Fixes.esp'
       - 'aMidianBorn_ContentAddon.esp'
+    msg:
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("COR-CraftingOverhaulReqtified.esp")'
   - name: 'CCO_Frostfall_Patch.esp'
     dirty:
       - crc: 0x7b3ce75d
@@ -11146,6 +11191,9 @@ plugins:
       - 'College Of Winterhold Overhaul Release - V1.02.esp'
     after:
       - 'Clothing & Clutter Fixes.esp'
+    msg:
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("Requiem - Immersive College of Winterhold.esp")'
     dirty:
       - crc: 0xfb30c482
         <<: *dirtyPlugin
@@ -13082,6 +13130,9 @@ plugins:
     after:
       - 'OBIS.esp'
       - 'OBISDB.esp'
+    msg:
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("Requiem - Civil War Overhaul Patch.esp")'
     dirty:
       - crc: 0x49e6e0bd
         <<: *dirtyPlugin
@@ -14972,6 +15023,9 @@ plugins:
         <<: *dirtyPlugin
         udr: 1
   - name: 'Animallica.esp'
+    msg:
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("Requiem - Animallica.esp")'
     dirty:
       - crc: 0x8e94479b
         <<: *dirtyPlugin
@@ -15029,11 +15083,14 @@ plugins:
         <<: *dirtyPlugin
         itm: 5
   - name: 'aMidianBorn_ContentAddon.esp'
+    after:
+      - 'BetterQuestObjectives.esp'
+    msg:
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("CAR-ContentAddonReqtified.esp")'
     tag:
       - Delev
       - Relev
-    after:
-      - 'BetterQuestObjectives.esp'
   - name: 'Babette.esp'
     msg:
       - <<: *corrupt
@@ -15150,6 +15207,9 @@ plugins:
   - name: 'Book Covers Skyrim.esp'
     after:
       - 'BetterQuestObjectives.esp'
+    msg:
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("Requiem - Book Covers Skyrim.esp") and not active("REQ - BCS Patch.esp")'
     clean:
       - crc: 0x18343B2E
         util: TES5Edit v3.1.3
@@ -15572,6 +15632,10 @@ plugins:
     after:
       - 'Brevi_MoonlightTales.esp'
       - 'BetterQuestObjectives.esp'
+      - 'Requiem_Minor_Arcana.esp'
+    msg:
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("Requiem - ESF Companions.esp")'
     dirty:
       - crc: 0x16c76fa7
         <<: *dirtyPlugin
@@ -15953,6 +16017,12 @@ plugins:
       - <<: *reqModX
         condition: 'active("Unofficial Skyrim Patch.esp") and not file("RSChildren_PatchUSKP.esp") and not file("RSChildren_CompleteUSKP.esp")'
         subs: [ '[RSChildren USKP Patch](http://www.nexusmods.com/skyrim/mods/55555/)' ]
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("Requiem - RS Children Overhaul.esp")'
+  - name: 'RSChildren - Complete.esp'
+    msg:
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("Requiem - RS Children Overhaul.esp")'
   - name: 'RSChildren_PatchUSKP.esp'
     after:
       - 'RSChildren_V.esp'
@@ -16363,6 +16433,9 @@ plugins:
         <<: *dirtyPlugin
         itm: 2
   - name: 'Rebirth Monster.esp'
+     msg:
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("Requiem - Revenge of the Enemies.esp") and not active("Rebirth Monster - Requiem Patch.esp") and not active("Rebirth Monster - Requiem Merged Patch.esp")'
     tag:
       - Delev
       - Relev
@@ -16600,6 +16673,9 @@ plugins:
         <<: *dirtyPlugin
         itm: 12
   - name: 'SkyTEST-RealisticAnimals&Predators.esm'
+    msg:
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("Requiem - SkyTEST.esp")'
     dirty:
       - crc: 0x7b5f9e63
         <<: *dirtyPlugin
@@ -16766,6 +16842,9 @@ plugins:
       - *SkyUI
     after:
       - 'BetterQuestObjectives.esp'
+    msg:
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("Requiem - Timing Is Everything.esp")'
     dirty:
       - crc: 0x99c43ba5
         <<: *dirtyPlugin
@@ -17745,12 +17824,15 @@ plugins:
       - 'URN+CoT Patch.esp'
       - 'Atlas Map Markers.esp'
       - 'The Horkerpocalypse.esp'
-    tag:
-      - C.Location
     msg:
       - type: warn
         content: 'Stolen content. Please show respect for authors'' rights and download from a legitimate source ([here](http://www.nexusmods.com/skyrim/mods/8058)).'
         condition: 'checksum("Open Cities Skyrim.esp", 022AD2C8)'
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("Requiem - Open Cities.esp") and not active("Requiem-OpenCities.esp")'
+    tag:
+      - C.Location
+
 # Moved into a separate group because mods that place objects can inadvertently overwrite changes from this mod.
 # Also includes Sound Propagation Overhaul, because the author of Sounds of Skyrim recommends that that be loaded
 # after his mod.
@@ -18034,7 +18116,7 @@ plugins:
     after:
       - 'Immersive Citizens - AI Overhaul.esp'
   - name: 'ELE_Legendary_Lite.esp'
-    priority: 110
+    global_priority: 110
     after:
       - 'Immersive Citizens - AI Overhaul.esp'
       - 'RelightingSkyrim_Legendary.esp'
@@ -18044,15 +18126,15 @@ plugins:
       - 'RelightingSkyrim_HF.esp'
       - 'RelightingSkyrim_DB.esp'
   - name: 'ELE_Legendary_Fs_Wt_Lite.esp'
-    priority: 110
+    global_priority: 110
     after:
       - 'Immersive Citizens - AI Overhaul.esp'
   - name: 'ELE_S_DG_DB_Lite.esp'
-    priority: 110
+    global_priority: 110
     after:
       - 'Immersive Citizens - AI Overhaul.esp'
   - name: 'ELE_S_Lite.esp'
-    priority: 110
+    global_priority: 110
     after:
       - 'Immersive Citizens - AI Overhaul.esp'
   - name: 'SV - The Indoors.esp'
@@ -18160,6 +18242,9 @@ plugins:
     after:
       - '3DNPC.esp'
       - 'TradeRoutes.esp'
+     msg:
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("RND_Requiem-Patch.esp") and not active("Requiem - Realistic Needs & Hypothermia.esp") and not active("RequiemSurvivalExperience.esp") and not active("Requiem Food patch.esp")'
     tag:
       - Delev
       - Relev
@@ -18389,6 +18474,11 @@ plugins:
   - name: 'Better Vampires DG.esp'
     msg: [ *obsolete ]
   - name: 'Better Vampires.esp'
+    after:
+      - 'Requiem.esp'
+    msg:
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("Requiem - Better Vampires Patch.esp")'
   - name: 'Better Vampires ML.esp'
     inc:
       - 'Better Vampires.esp'
@@ -18435,6 +18525,8 @@ plugins:
         condition: 'file("LFox Werewolf Improvements.esp")'
         subs: [ 'LFox Werewolf Improvements.esp' ]
   - name: 'mslVampiricThirst.esp'
+    after:
+      - 'Requiem.esp'
     req: [ *SKSE ]
     msg:
       - type: say
@@ -18443,6 +18535,8 @@ plugins:
             text: 'Conflicts with other mods that change the vampirism system.'
           - lang: ru
             text: 'конфликты с другими модами, меняющими систему вампиризма.'
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("mslVampiricThirst - Requiem.esp")'
     dirty:
       - crc: 0xfafb18c2
         <<: *dirtyPlugin
@@ -20929,6 +21023,9 @@ plugins:
         content: 'This file is broken and will not work.'
         condition: 'checksum("KhaleesiFacePreset.esp",42C16D17)'
   - name: '3DNPC.esp'
+    msg:
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("NRM 3DNPC - Requiem Patch.esp")'
     dirty:
       - crc: 0x143c788a
         <<: *dirtyPlugin
@@ -21070,6 +21167,9 @@ plugins:
             text: 'HorseRidingFollowers уже включен в UFO - Ultimate Follower Overhaul.esp, удалите и используйте UFO'
         condition: 'file("UFO - Ultimate Follower Overhaul.esp")'
   - name: 'Inigo.esp'
+    msg:
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("Requiem - Inigo.esp")'
     dirty:
       - crc: 0xb9fc7507
         <<: *dirtyPlugin
@@ -22514,6 +22614,9 @@ plugins:
 # IFNOT FILE("UFO - Ultimate Follower Overhaul.esp") MOD: brhucelegacy.esp
 # test placement of Brhuce as for Vilja; Trainwiz reco to place after every follower mod incl aft but I''m skeptical -LD
   - name: 'EMCompViljaSkyrim.esp'
+    msg:
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("Requiem - Vilja.esp")'
     dirty:
       - crc: 0xc45d4383
         <<: *dirtyPlugin
@@ -22661,8 +22764,6 @@ plugins:
         itm: 141
   - name: 'Alternate Start - Live Another Life.esp'
     global_priority: 70
-    tag:
-      - C.Location
     msg:
       - type: error
         content:
@@ -22671,6 +22772,10 @@ plugins:
           - lang: ru
             text: 'Обнаружена старая версия ''Live Another Life.esp''. Вы должны удалить старую версию, перед использованием этой новой.'
         condition: 'file("Live Another Life.esp")'
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("Requiem - Live Another Life.esp")'
+    tag:
+      - C.Location
   - name: 'Bandit Start.esp'
     dirty:
       - crc: 0x57d4e755
@@ -24396,19 +24501,19 @@ plugins:
   - name: 'NPO Module - Crossbows.esp'
     after:
       - 'PerkusMaximus_Warrior.esp'
-
   - name: 'Default Teammate Weapon Draw Distance.esp'
     after:
       - 'Convenient Horses.esp'
-
   - name: 'Undeath.esp'
-    url: [ 'http://www.nexusmods.com/skyrim/mods/40607' ]
     after:
       - 'MoonAndStar_MAS.esp'
     msg:
       - type: warn
         condition: 'active("MoonAndStar_MAS.esp") and not active("MoonAndStar_Undeath_compat.esp")'
         content: 'This mod has certain conflicts with "MoonAndStar_MAS.esp". Consider using [the compatibility patch](http://www.nexusmods.com/skyrim/mods/52397/).'
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("NRM Undeath - Requiem Patch.esp")'
+    url: [ 'http://www.nexusmods.com/skyrim/mods/40607' ]
   - name: 'Verdant - A Skyrim Grass Plugin.esp'
     after:
       - 'Skyrim Flora Overhaul.esp'
@@ -24706,10 +24811,16 @@ plugins:
         content: 'Guard Dialogue Overhaul detected.  Use the Guard Dialogue Overhaul version to have both mods work as intended.'
     url: [ 'http://www.nexusmods.com/skyrim/mods/52326' ]
   - name: 'Campfire.esm'
+    msg:
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("Requiem - Campfire.esp")'
     clean:
       - crc: 0xB536FDD0
         util: TES5Edit v3.1.3
   - name: 'CompanionArissa.esm'
+    msg:
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("Requiem - Arissa.esp")'
     clean:
       - crc: 0xC4AE95C0
         util: TES5Edit v3.1.3
@@ -24787,3 +24898,209 @@ plugins:
 
   - name: 'No Vendor or Loot Spells.esp'
     global_priority: 100
+
+# Mods that are incompatible with Requiem but have compatibility patches available
+  - name: 'Hypothermia.esp'
+    msg:
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("Requiem - Realistic Needs & Hypothermia.esp")'
+  # Requiem patches provided by thetrader
+  - name: '83Willows_101BUGS_V4_HighRes_HighSpawn.esp' 
+    msg:
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("Requiem - 83Willows 101Bugs.esp")'
+      - <<: *redundantPluginX
+        condition: 'active("83Willows_101BUGS_V4_HighRes_HighSpawn.esp") and active("Requiem - 83Willows 101Bugs.esp")'
+        subs: [ 'Requiem - 83Willows 101Bugs.esp' ]
+  - name: '83Willows_101BUGS_V4_LowerRes_HighSpawn.esp'
+    msg:
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("Requiem - 83Willows 101Bugs.esp")'
+      - <<: *redundantPluginX
+        condition: 'active("83Willows_101BUGS_V4_LowerRes_HighSpawn.esp") and active("Requiem - 83Willows 101Bugs.esp")'
+        subs: [ 'Requiem - 83Willows 101Bugs.esp' ]
+  - name: '83Willows_101BUGS_V4_HighRes.esp'
+    msg:
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("Requiem - 83Willows 101Bugs.esp")'
+      - <<: *redundantPluginX
+        condition: 'active("83Willows_101BUGS_V4_HighRes.esp") and active("Requiem - 83Willows 101Bugs.esp")'
+        subs: [ 'Requiem - 83Willows 101Bugs.esp' ]
+  - name: '83Willows_101BUGS_V4_LowRes.esp'
+    msg:
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("Requiem - 83Willows 101Bugs.esp")'
+      - <<: *redundantPluginX
+        condition: 'active("83Willows_101BUGS_V4_LowRes.esp") and active("Requiem - 83Willows 101Bugs.esp")'
+        subs: [ 'Requiem - 83Willows 101Bugs.esp' ]
+  - name: 'Craftable Horse Barding.esp'
+    msg:
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("Requiem - Craftable Horse Barding.esp")'
+  - name: 'ExplosiveBoltsVisualized.esp'
+    msg:
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("Requiem - Explosive Bolts Visualized.esp")'
+      - <<: *redundantPluginX
+        condition: 'active("ExplosiveBoltsVisualized.esp") and active("Requiem - Explosive Bolts Visualized.esp")'
+        subs: [ 'Requiem - Explosive Bolts Visualized.esp' ]
+  - name: 'DeadlyDragons.esp'
+    msg:
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("Requiem - Deadly Dragons.esp") and not active("Requiem - Deadly Dragons - AOS.esp")'
+  - name: 'Dragon Combat Overhaul.esp'
+    msg:
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("Requiem - Dragon Combat Overhaul.esp")'
+  - name: 'Faction Crossbows.esp'
+    msg:
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("Requiem - Faction Crossbows.esp")'
+  - name: 'FireAndIceOverhaul.esp'
+    msg:
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("Requiem - Fire and Ice Overhaul.esp") and not active("Requiem - Fire and Ice Overhaul - AOS.esp")'
+  - name: 'Frostfall.esp'
+    msg:
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("Requiem - Frostfall.esp")'
+  - name: 'Height Adjusted Races.esp'
+    msg:
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("Requiem - Height Adjusted Races with True Giants.esp")'
+      - <<: *redundantPluginX
+        condition: 'active("Height Adjusted Races.esp") and active("Requiem - Height Adjusted Races with True Giants.esp")'
+        subs: [ 'Requiem - Height Adjusted Races.esp' ]
+  - name: 'Height Adjusted Races - Morrowind Lore Heights.esp'
+    msg:
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("Requiem - Height Adjusted Races with True Giants.esp")'
+      - <<: *redundantPluginX
+        condition: 'active("Height Adjusted Races - Morrowind Lore Heights.esp") and active("Requiem - Height Adjusted Races with True Giants.esp")'
+        subs: [ 'Requiem - Height Adjusted Races with True Giants.esp' ]
+  - name: 'Height Adjusted Races - Oblivion Lore Heights.esp'
+    msg:
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("Requiem - Height Adjusted Races with True Giants.esp")'
+      - <<: *redundantPluginX
+        condition: 'active("Height Adjusted Races - Oblivion Lore Heights.esp") and active("Requiem - Height Adjusted Races with True Giants.esp")'
+        subs: [ 'Requiem - Height Adjusted Races with True Giants.esp' ]
+  - name: 'Height Adjusted Races - Player Races Only.esp'
+    msg:
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("Requiem - Height Adjusted Races with True Giants.esp")'
+      - <<: *redundantPluginX
+        condition: 'active("Height Adjusted Races - Player Races Only.esp") and active("Requiem - Height Adjusted Races with True Giants.esp")'
+        subs: [ 'Requiem - Height Adjusted Races with True Giants.esp' ]
+  - name: 'Height Adjusted Races - Player Races Only - Oblivion Lore Heights.esp'
+    msg:
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("Requiem - Height Adjusted Races with True Giants.esp")'
+      - <<: *redundantPluginX
+        condition: 'active("Height Adjusted Races - Player Races Only - Oblivion Lore Heights.esp") and active("Requiem - Height Adjusted Races with True Giants.esp")'
+        subs: [ 'Requiem - Height Adjusted Races with True Giants.esp' ]
+  - name: 'Height Adjusted Races - Player Races Only - Morrowind Lore Heights.esp'
+    msg:
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("Requiem - Height Adjusted Races with True Giants.esp")'
+      - <<: *redundantPluginX
+        condition: 'active("Height Adjusted Races - Player Races Only - Morrowind Lore Heights.esp") and active("Requiem - Height Adjusted Races with True Giants.esp")'
+        subs: [ 'Requiem - Height Adjusted Races with True Giants.esp' ]
+  - name: 'Height Adjusted Races with True Giants.esp'
+    msg:
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("Requiem - Height Adjusted Races with True Giants.esp")'
+      - <<: *redundantPluginX
+        condition: 'active("Height Adjusted Races with True Giants.esp") and active("Requiem - Height Adjusted Races with True Giants.esp")'
+        subs: [ 'Requiem - Height Adjusted Races with True Giants.esp' ]
+  - name: 'Height Adjusted Races with True Giants - Smaller Giant Edition.esp'
+    msg:
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("Requiem - Height Adjusted Races with True Giants.esp")'
+      - <<: *redundantPluginX
+        condition: 'active("Height Adjusted Races with True Giants - Smaller Giant Edition.esp") and active("Requiem - Height Adjusted Races with True Giants.esp")'
+        subs: [ 'Requiem - Height Adjusted Races with True Giants.esp' ]
+  - name: 'Height Adjusted Races - True Giants and Mammoths.esp'
+    msg:
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("Requiem - True Giants and Mammoths.esp")'
+      - <<: *redundantPluginX
+        condition: 'active("Height Adjusted Races - True Giants and Mammoths.esp") and active("Requiem - True Giants and Mammoths.esp")'
+        subs: [ 'Requiem - True Giants and Mammoths.esp' ]
+  - name: 'Height Adjusted Races - True Giants and Mammoths - Smaller Giant Edition.esp'
+    msg:
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("Requiem - True Giants and Mammoths.esp")'
+      - <<: *redundantPluginX
+        condition: 'active("Height Adjusted Races - True Giants and Mammoths - Smaller Giant Edition.esp") and active("Requiem - True Giants and Mammoths.esp")'
+        subs: [ 'Requiem - True Giants and Mammoths.esp' ]
+  - name: 'HothFollower.esp'
+    msg:
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("Requiem - Hoth.esp")'
+  - name: 'Immersive Horses.esp'
+    msg:
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("Requiem - Immersive Horses.esp") and not active("Requiem - Immersive Horses - SkyTEST.esp")'
+  - name: 'Immersive Patrols II.esp'
+    msg:
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("Requiem - Immersive Patrols.esp") and not active("Requiem - Immersive Patrols - CWO.esp")'
+  - name: 'Immersive Sounds - Compendium.esp'
+    msg:
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("Requiem - Immersive Sounds Compendium.esp")'
+  - name: 'imp_helm_legend.esp'
+    msg:
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("Requiem - Improved Closefaced Helmets.esp")'
+  - name: 'Inconsequential NPCs.esp'
+    msg:
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("Requiem - Inconsequential NPCs.esp")'
+  - name: 'Inconsequential NPCs - Enhancement.esp'
+    msg:
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("Requiem - Inconsequential NPCs - Enhancement.esp")'
+  - name: 'RUSTIC SOULGEMS - Sorted.esp'
+    msg:
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("Requiem - Rustic Soulgems.esp") and not active("Requiem - Rustic Soulgems - ISC.esp")'
+      - <<: *redundantPluginX
+        condition: 'active("RUSTIC SOULGEMS - Sorted.esp") and active("Requiem - Rustic Soulgems.esp")'
+        subs: [ 'Requiem - Rustic Soulgems.esp' ]
+  - name: 'RUSTIC SOULGEMS - Unsorted.esp'
+    msg:
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("Requiem - Rustic Soulgems.esp") and not active("Requiem - Rustic Soulgems - ISC.esp")'
+      - <<: *redundantPluginX
+        condition: 'active("RUSTIC SOULGEMS - Unsorted.esp") and active("Requiem - Rustic Soulgems.esp")'
+        subs: [ 'Requiem - Rustic Soulgems.esp' ]
+  - name: 'ScopedBows.esp'
+    msg:
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("Requiem - Scoped Bows.esp")'
+  - name: 'Skyrim Unlocked.esp'
+    global_priority: 90
+    inc:
+      - name: "Open Cities Skyrim.esp"
+        condition: 'not active("Open Cities Skyrim - Skyrim Unlocked Patch.esp")'
+    msg:
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("Requiem - Skyrim Unlocked.esp") and not active("Requiem - Skyrim Unlocked - OCS.esp")'
+  - name: 'Unique Uniques.esp'
+    msg:
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("Requiem - Unique Uniques.esp") and not active("Requiem - Unique Uniques - AOS.esp")'
+  - name: 'VioLens.esp'
+    msg:
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("Requiem - VioLens.esp")'
+  - name: 'WM Flora Fixes.esp'
+    msg:
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("Requiem - WM Flora Fixes.esp")'
+  - name: 'DawnguardArsenal.esp'
+    msg:
+      - <<: *needsRequiemPatch
+        condition: 'file("Requiem.esp") and not active("Requiem - Dawnguard Arsenal.esp")'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -8803,6 +8803,27 @@ plugins:
       - 'Requiem - Immersive Horses - SkyTEST.esp'
   - name: 'Requiem for the Indifferent.esp'
     global_priority: 95
+# mods that go after Requiem
+  - name: 'Bounty Gold.esp'
+    after:
+      - 'Requiem.esp'
+  # realistic ragdoll
+  - name: 'XPMSE.esp'
+    after:
+      - 'Requiem.esp'
+  - name: 'RealisticRoomRental(-Basic)?.esp'
+    after:
+      - 'Requiem.esp'
+  - name: 'Unlimited Training.esp'
+    after:
+      - 'Requiem.esp'
+  - name: 'WerewolfPerksExpanded.esp'
+    after:
+      - 'Requiem.esp'
+  # RealisticWaterTwo.esp
+  - name: 'No Vendor or Loot Spells - Riverwood Trader Requiem.esp'
+    req:
+      - 'Requiem.esp'
 
   - name: 'Skyrim Hardcore Overhaul.esp'
     tag:
@@ -22747,6 +22768,8 @@ plugins:
             text: 'SKYUI.esp no se encuentra presente o activado. No podrás utilizar SkyUI MCM.'
         condition: 'not active("SkyUI.esp")'
   - name: 'dD.?- Realistic Ragdoll Force.*\.esp'
+    after:
+      - 'Requiem.esp'
     msg:
       - type: say
         content:
@@ -23522,6 +23545,7 @@ plugins:
       - 'Ducks and Swans.esp'
       - 'Helgen Reborn.esp'
       - 'Immersive Citizens - AI Overhaul.esp'
+      - 'Requiem.esp'
   - name: 'RealisticWaterTwo - Legendary.esp'
     after:
       - 'SkyFalls + SkyMills.esp'
@@ -24757,3 +24781,14 @@ plugins:
   - name: 'MoonAndStar_MAS.esp'
     after:
       - 'AuroraVillage.esp'
+
+  - name: 'No Vendor or Loot Spells.esp'
+    global_priority: 100
+  - name: 'ELE_Legendary_Lite.esp'
+    priority: 110
+  - name: 'ELE_Legendary_Fs_Wt_Lite.esp'
+    priority: 110
+  - name: 'ELE_S_DG_DB_Lite.esp'
+    priority: 110
+  - name: 'ELE_S_Lite.esp'
+    priority: 110

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -8929,10 +8929,10 @@ plugins:
   - name: 'Requiem - True Giants and Mammoths.esp'
     msg:
       - <<: *replacerPluginForX
-        condition: 'file("Height Adjusted Races - True Giants and Mammoths.esp)'
+        condition: 'file("Height Adjusted Races - True Giants and Mammoths.esp")'
         subs: [ 'Height Adjusted Races - True Giants and Mammoths.esp' ]
       - <<: *replacerPluginForX
-        condition: 'file("Height Adjusted Races - True Giants and Mammoths - Smaller Giant Edition.esp)'
+        condition: 'file("Height Adjusted Races - True Giants and Mammoths - Smaller Giant Edition.esp")'
         subs: [ 'Height Adjusted Races - True Giants and Mammoths - Smaller Giant Edition.esp' ]
   - name: 'Requiem - Rustic Soulgems( - ISC)?\.esp'
     msg:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -8653,6 +8653,10 @@ plugins:
           - lang: en
             text: 'Delete MineOreScript.pex from Requiem. [CCOR](http://www.nexusmods.com/skyrim/mods/49791)''s script must take precedence.'
         condition: 'active("Complete Crafting Overhaul_Remade.esp") and checksum("Scripts/MineOreScript.pex", 82F96995)'
+      - type: say
+        content:
+          - lang: en
+            text: 'Hello1'
     tag:
       - Delev
       - Relev
@@ -8674,11 +8678,6 @@ plugins:
   # must be loaded directly after Requiem.esp
   - name: 'Requiem - Bugsmasher Edition.esp'
     priority: -127
-    msg:
-      - type: say
-        content:
-          - lang: en
-            text: 'Hello'
   # must be loaded directly after Requiem.esp
   - name: 'Requiem - Legendary Bugsmasher Edition.esp'
     priority: -127
@@ -8713,6 +8712,88 @@ plugins:
         itm: 3
     url:
       - 'http://www.nexusmods.com/skyrim/mods/54562/?'
+  # should be loaded directly after Requiem.esp and the bugsmasher
+  - name: 'Requiem - Hearthfire.esp'
+    priority: -127
+    after:
+      - 'Requiem - Bugsmasher Edition.esp'
+      - 'Requiem - Legendary Bugsmasher Edition.esp'
+  # should lose conflicts because other patches may make important edits to Dragonborn content
+  - name: 'NRM_Dragonborn_Reqtified.esp'
+    priority: -75
+    inc:
+      - 'Fozars_Dragonborn_-_Requiem_Patch.esp'
+  # should lose conflicts because other patches may make important edits to Dragonborn content
+  - name: 'Fozars_Dragonborn_-_Requiem_Patch.esp'
+    priority: -75
+    after:
+      - 'KFR-Kryptopyr''sFixesReqtified.esp'
+      - 'COR-CraftingOverhaulReqtified.esp'
+  # should lose conflicts because other patches may make important edits to quests
+  - name: BetterQuestObjectives-RequiemPatch.esp
+    priority: -50
+    msg:
+      - <<: *redundantPluginX
+        condition: 'version("Requiem.esp", "2.0", >=) and active("BetterQuestObjectives-RequiemPatch.esp")'
+        subs: [ 'Requiem.esp' ]
+  # should lose conflicts because other patches may make important edits to the races
+  - name: 'Requiem - Height Adjusted Races with True Giants.esp'
+    priority: -50
+  # should lose conflicts because other patches may make important edits to something touched by AOS
+  - name: 'Requiem - Audio Overhaul for Skyrim.esp'
+    priority: -50
+    after:
+      - 'KFR-Kryptopyr''sFixesReqtified.esp'
+      - 'COR-CraftingOverhaulReqtified.esp'
+  - name: 'KFR-Kryptopyr''sFixesReqtified.esp'
+    after:
+      - 'NRM_Dragonborn_Reqtified.esp'
+  - name: 'COR-CraftingOverhaulReqtified.esp'
+    after:
+      - 'KFR-Kryptopyr''sFixesReqtified.esp'
+  - name: 'COR-Campfire.esp'
+    req:
+      - 'COR-CraftingOverhaulReqtified.esp'
+  - name: 'COR-WetAndCold.esp'
+    req:
+      - 'COR-CraftingOverhaulReqtified.esp'
+  - name: 'Open Face Guard Helmets.esp'
+    after:
+      - 'KFR-Kryptopyr''sFixesReqtified.esp'
+  - name: 'Requiem_Minor_Arcana.esp'
+    after:
+      - 'KFR-Kryptopyr''sFixesReqtified.esp'
+      - 'COR-CraftingOverhaulReqtified.esp'
+      - 'Requiem - Immersive Spells.esp'
+      - 'Open Face Guard Helmets.esp'
+      - 'Requiem - Civil War Overhaul Patch.esp'
+  # must be loaded directly after Minor Arcana
+  - name: 'Requiem - Minor Arcana - USLEEP patch.esp'
+    priority: -127
+  - name: 'Requiem - ESF Companions.esp'
+    after:
+      - 'Requiem_Minor_Arcana.esp'
+  - name: 'Requiem - WRF_MinorArcana_MortalEnemies_TG.esp'
+    after:
+      - 'Requiem_Minor_Arcana.esp'
+  - name: 'Requiem - Immersive Creatures.esp'
+    after:
+      - 'Fozars_Dragonborn_-_Requiem_Patch.esp'
+  - name: 'Requiem - Immersive Horses.esp'
+    after:
+      - 'REQMOD.esp'
+  - name: 'Requiem - Immersive Horses - SkyTEST.esp'
+    req:
+      - 'Requiem - SkyTEST.esp'
+    after:
+      - 'REQMOD.esp'
+  - name: 'Requiem - Craftable Horse Barding.esp'
+    after:
+      - 'Requiem - Immersive Horses.esp'
+      - 'Requiem - Immersive Horses - SkyTEST.esp'
+  - name: 'Requiem for the Indifferent.esp'
+    global_priority: 95
+
   - name: 'Skyrim Hardcore Overhaul.esp'
     tag:
       - Delev

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -188,11 +188,11 @@ common:
         text: 'Delete or deactivate %1%.'
       - lang: ru
         text: 'Не забудьте отключить или удалить %1%.'
-  - &redundantPluginX
-    type: warn
+  - &replacerPluginForX
+    type: error
     content:
       - lang: en
-        text: 'This plugin is redundant when using %1% and should be deactivated or deleted.'
+        text: 'This replaces %1%. Delete or deactivate %1% but keep its resources.'
   - &SmashedVsBashedPatch
     type: say
     content:
@@ -818,6 +818,13 @@ plugins:
       - Relev
     url:
       - 'http://www.nexusmods.com/skyrim/mods/4955'
+  - name: '(83Willows_101BUGS_V4_).+\.esp'
+    msg:
+      - <<: *useOnlyOneX
+        condition: 'many("(83Willows_101BUGS_V4_).+.esp")'
+        subs: [ '83Willows_101BUGS_V4_ .esp file' ]
+      - <<: *reqRequiemPatch
+        condition: 'file("Requiem.esp") and not active("Requiem - 83Willows 101Bugs.esp")'
   - name: 'actorEvents.esm'
     req:
       - *SKSE
@@ -2536,30 +2543,30 @@ plugins:
         udr: 0
   - name: 'AOS2_DD Patch.esp'
     msg:
-      - <<: *redundantPluginX
-        condition: 'active("AOS2_DD Patch.esp") and active("Requiem - Deadly Dragons - AOS.esp")'
+      - <<: *alreadyInX
+        condition: 'active("Requiem - Deadly Dragons - AOS.esp")'
         subs: [ 'Requiem - Deadly Dragons - AOS.esp' ]
   - name: 'AOS2_FIO Patch.esp'
     msg:
-      - <<: *redundantPluginX
-        condition: 'active("AOS2_FIO Patch.esp") and active("Requiem - Fire and Ice Overhaul - AOS.esp")'
+      - <<: *alreadyInX
+        condition: 'active("Requiem - Fire and Ice Overhaul - AOS.esp")'
         subs: [ 'Requiem - Fire and Ice Overhaul - AOS.esp' ]
   - name: 'AOS2_GDO Patch.esp'
     msg:
-      - <<: *redundantPluginX
-        condition: 'active("AOS2_GDO Patch.esp") and active("Requiem - Audio Overhaul for Skyrim.esp")'
+      - <<: *alreadyInX
+        condition: 'active("Requiem - Audio Overhaul for Skyrim.esp")'
         subs: [ 'Requiem - Audio Overhaul for Skyrim.esp' ]
   - name: 'AOS2_Unique Uniques Patch.esp'
     msg:
-      - <<: *redundantPluginX
-        condition: 'active("AOS2_Unique Uniques Patch.esp") and active("Requiem - Unique Uniques - AOS.esp")'
+      - <<: *alreadyInX
+        condition: 'active("Requiem - Unique Uniques - AOS.esp")'
         subs: [ 'Requiem - Unique Uniques - AOS.esp' ]
   - name: 'AOS2_WAF Patch.esp'
     after:
       - name: 'AOS2_GDO Patch.esp'
     msg:
-      - <<: *redundantPluginX
-        condition: 'active("AOS2_WAF Patch.esp") and active("Requiem - Audio Overhaul for Skyrim.esp")'
+      - <<: *alreadyInX
+        condition: 'active("Requiem - Audio Overhaul for Skyrim.esp")'
         subs: [ 'Requiem - Audio Overhaul for Skyrim.esp' ]
   - name: '(AOS2_Requiem Patch|Requiem - Audio Overhaul for Skyrim)\.esp'
     msg:
@@ -6110,8 +6117,8 @@ plugins:
         condition: 'file("Cloaks - No Imperial.esp") and not file("1nivWICSkyCloaksPatch-No Imp.esp")'
   - name: '1nivWICSkyCloaksPatch.esp'
     msg:
-      - <<: *redundantPluginX
-        condition: 'active("1nivWICSkyCloaksPatch.esp") and active("CFR-CloaksForRequiem.esp")'
+      - <<: *alreadyInX
+        condition: 'active("CFR-CloaksForRequiem.esp")'
         subs: [ 'CFR-CloaksForRequiem.esp' ]
     dirty:
       - crc: 0x2a8cad17
@@ -8718,7 +8725,7 @@ plugins:
     msg: [ *obsolete ]
 ### Rules for Requiem and its patches ###
   - name: 'Requiem.esp'
-    global_priority: 75
+    global_priority: 70
     inc:
       - 'Requiem plus PCEA 3-5.esp'
       - 'Ordinator - Perks of Skyrim.esp'
@@ -8814,9 +8821,6 @@ plugins:
     after:
       - 'KFR-Kryptopyr''sFixesReqtified.esp'
       - 'COR-CraftingOverhaulReqtified.esp'
-  # Should lose conflicts because other patches may make important edits to the races
-  - name: 'Requiem - Height Adjusted Races with True Giants.esp'
-    priority: -50
   # Should lose conflicts because other patches may make important edits to something touched by AOS
   - name: 'Requiem - Audio Overhaul for Skyrim.esp'
     priority: -50
@@ -8875,7 +8879,69 @@ plugins:
   - name: 'Requiem - WAF+CCF+TrueWeapons Patch.esp'
     inc:
       - 'KFR-Kryptopyr''sFixesReqtified.esp")'
-# Mods that must be loaded after Requiem
+  - name: 'Requiem - 83Willows 101Bugs.esp'
+    msg:
+      - <<: *replacerPluginForX
+        condition: 'file("83Willows_101BUGS_V4_LowRes.esp")'
+        subs: [ '83Willows_101BUGS_V4_LowRes.esp' ]
+      - <<: *replacerPluginForX
+        condition: 'file("83Willows_101BUGS_V4_HighRes.esp")'
+        subs: [ '83Willows_101BUGS_V4_HighRes.esp' ]
+      - <<: *replacerPluginForX
+        condition: 'file("83Willows_101BUGS_V4_LowerRes_HighSpawn.esp")'
+        subs: [ '83Willows_101BUGS_V4_LowerRes_HighSpawn.esp' ]
+      - <<: *replacerPluginForX
+        condition: 'file("83Willows_101BUGS_V4_HighRes_HighSpawn.esp")'
+        subs: [ '83Willows_101BUGS_V4_HighRes_HighSpawn.esp' ]
+  - name: 'Requiem - Explosive Bolts Visualized.esp'
+    msg:
+      - <<: *replacerPluginForX
+        condition: 'file("ExplosiveBoltsVisualized.esp")'
+        subs: [ 'ExplosiveBoltsVisualized.esp' ]
+  # Should lose conflicts because other patches may make important edits to the races
+  - name: 'Requiem - Height Adjusted Races with True Giants.esp'
+    priority: -50
+    msg:
+      - <<: *replacerPluginForX
+      condition: 'file("Height Adjusted Races.esp")'
+      subs: [ 'Height Adjusted Races.esp' ]
+      - <<: *replacerPluginForX
+      condition: 'file("Height Adjusted Races - Morrowind Lore Heights.esp")'
+      subs: [ 'Height Adjusted Races - Morrowind Lore Heights.esp' ]
+      - <<: *replacerPluginForX
+      condition: 'file("Height Adjusted Races - Oblivion Lore Heights.esp")'
+      subs: [ 'Height Adjusted Races - Oblivion Lore Heights.esp' ]
+      - <<: *replacerPluginForX
+      condition: 'file("Height Adjusted Races - Player Races Only.esp")'
+      subs: [ 'Height Adjusted Races - Player Races Only.esp' ]
+      - <<: *replacerPluginForX
+      condition: 'file("Height Adjusted Races - Player Races Only - Oblivion Lore Heights.esp")'
+      subs: [ 'Height Adjusted Races - Player Races Only - Oblivion Lore Heights.esp' ]
+      - <<: *replacerPluginForX
+      condition: 'file("Height Adjusted Races - Player Races Only - Morrowind Lore Heights.esp")'
+      subs: [ 'Height Adjusted Races - Player Races Only - Morrowind Lore Heights.esp' ]
+      - <<: *replacerPluginForX
+      condition: 'file("Height Adjusted Races with True Giants.esp")'
+      subs: [ 'Height Adjusted Races with True Giants.esp' ]
+      - <<: *replacerPluginForX
+      condition: 'file("Height Adjusted Races with True Giants - Smaller Giant Edition.esp")'
+      subs: [ 'Height Adjusted Races with True Giants - Smaller Giant Edition.esp' ]
+  - name: 'Requiem - True Giants and Mammoths.esp'
+    msg:
+      - <<: *replacerPluginForX
+      condition: 'file("Height Adjusted Races - True Giants and Mammoths.esp)'
+      subs: [ 'Height Adjusted Races - True Giants and Mammoths.esp' ]
+      - <<: *replacerPluginForX
+      condition: 'file("Height Adjusted Races - True Giants and Mammoths - Smaller Giant Edition.esp)'
+      subs: [ 'Height Adjusted Races - True Giants and Mammoths - Smaller Giant Edition.esp' ]
+  - name: 'Requiem - Rustic Soulgems( - ISC)?\.esp'
+    msg:
+      - <<: *replacerPluginForX
+      condition: 'file("RUSTIC SOULGEMS - Sorted.esp")'
+      subs: [ 'RUSTIC SOULGEMS - Sorted.esp' ]
+      - <<: *replacerPluginForX
+      condition: 'file("RUSTIC SOULGEMS - Unsorted.esp")'
+      subs: [ 'RUSTIC SOULGEMS - Unsorted.esp' ]
   - name: 'Bounty Gold.esp'
     after:
       - 'Requiem.esp'
@@ -8904,8 +8970,6 @@ plugins:
   - name: 'No Vendor or Loot Spells - Riverwood Trader Requiem.esp'
     req:
       - 'Requiem.esp'
-  # other mods that must be loaded after Requiem but are listed somewhere else in LOOT's rules:
-  # - RealisticWaterTwo.esp
 ### End of Requiem's rules ###
   - name: 'Skyrim Hardcore Overhaul.esp'
     tag:
@@ -15226,13 +15290,13 @@ plugins:
       - NoMerge
   - name: 'BetterQuestObjectives-AlternateStartPatch.esp'
     msg:
-      - <<: *redundantPluginX
-        condition: 'active("BetterQuestObjectives-AlternateStartPatch.esp") and active("Requiem - Live Another Life.esp")'
+      - <<: *alreadyInX
+        condition: 'active("Requiem - Live Another Life.esp")'
         subs: [ 'Requiem - Live Another Life.esp' ]
   - name: 'BetterQuestObjectives-CRFPatch.esp'
     msg:
-      - <<: *redundantPluginX
-        condition: 'active("BetterQuestObjectives-CRFPatch.esp") and active("Requiem - Cutting Room Floor.esp")'
+      - <<: *alreadyInX
+        condition: 'active("Requiem - Cutting Room Floor.esp")'
         subs: [ 'Requiem - Cutting Room Floor.esp' ]
   - name: 'BetterQuestObjectives-BSaQBPatch.esp'
     msg:
@@ -15255,8 +15319,8 @@ plugins:
     after:
       - 'ESFCompanions.esp'
     msg:
-      - <<: *redundantPluginX
-        condition: 'version("Requiem.esp", "2.0", >=) and active("BetterQuestObjectives-RequiemPatch.esp")'
+      - <<: *alreadyInX
+        condition: 'version("Requiem.esp", "2.0", >=)'
         subs: [ 'Requiem.esp' ]
   - name: 'Book Covers Skyrim.esp'
     after:
@@ -17094,15 +17158,15 @@ plugins:
         display: '[Guard Dialouge Overhaul](http://www.nexusmods.com/skyrim/mods/23390)'
   - name: 'Weapons & Armor_TrueDaedricWeapons.esp'
     msg:
-      - <<: *redundantPluginX
-        condition: 'active("Weapons & Armor_TrueDaedricWeapons.esp") and active("KFR-Kryptopyr''sFixesReqtified.esp")'
+      - <<: *alreadyInX
+        condition: 'active("KFR-Kryptopyr''sFixesReqtified.esp")'
         subs: [ 'KFR-Kryptopyr''sFixesReqtified.esp' ]
     tag:
       - Stats
   - name: 'Weapons & Armor_TrueOrcishWeapons.esp'
     msg:
-      - <<: *redundantPluginX
-        condition: 'active("Weapons & Armor_TrueOrcishWeapons.esp") and active("KFR-Kryptopyr''sFixesReqtified.esp")'
+      - <<: *alreadyInX
+        condition: 'active("KFR-Kryptopyr''sFixesReqtified.esp")'
         subs: [ 'KFR-Kryptopyr''sFixesReqtified.esp' ]
     tag:
       - Delev
@@ -17112,8 +17176,8 @@ plugins:
     after:
       - 'Weapons & Armor Fixes_Remade.esp'
     msg:
-      - <<: *redundantPluginX
-        condition: 'active("Weapons & Armor_TrueOrcish&DaedricWeapons.esp") and active("KFR-Kryptopyr''sFixesReqtified.esp")'
+      - <<: *alreadyInX
+        condition: 'active("KFR-Kryptopyr''sFixesReqtified.esp")'
         subs: [ 'KFR-Kryptopyr''sFixesReqtified.esp' ]
     tag:
       - Delev
@@ -17121,23 +17185,23 @@ plugins:
       - Stats
   - name: 'Weapons & Armor_TrueWeaponsLvlLists.esp'
     msg:
-      - <<: *redundantPluginX
-        condition: 'active("Weapons & Armor_TrueWeaponsLvlLists.esp") and active("KFR-Kryptopyr''sFixesReqtified.esp")'
+      - <<: *alreadyInX
+        condition: 'active("KFR-Kryptopyr''sFixesReqtified.esp")'
         subs: [ 'KFR-Kryptopyr''sFixesReqtified.esp' ]
   - name: 'Weapons & Armor_DragonPriestMasks.esp'
     msg:
-      - <<: *redundantPluginX
-        condition: 'active("Weapons & Armor_DragonPriestMasks.esp") and active("KFR-Kryptopyr''sFixesReqtified.esp")'
+      - <<: *alreadyInX
+        condition: 'active("KFR-Kryptopyr''sFixesReqtified.esp")'
         subs: [ 'KFR-Kryptopyr''sFixesReqtified.esp' ]
   - name: 'Weapons & Armor_FasterArrows.esp'
     msg:
-      - <<: *redundantPluginX
-        condition: 'active("Weapons & Armor_FasterArrows.esp") and active("KFR-Kryptopyr''sFixesReqtified.esp")'
+      - <<: *alreadyInX
+        condition: 'active("KFR-Kryptopyr''sFixesReqtified.esp")'
         subs: [ 'KFR-Kryptopyr''sFixesReqtified.esp' ]
   - name: 'WeaponsArmorFixes_ImmersiveWeapons_Patch.esp'
     msg:
-      - <<: *redundantPluginX
-        condition: 'active("WeaponsArmorFixes_ImmersiveWeapons_Patch.esp") and active("Requiem - Immersive Weapons.esp")'
+      - <<: *alreadyInX
+        condition: 'active("Requiem - Immersive Weapons.esp")'
         subs: [ 'Requiem - Immersive Weapons.esp' ]
   - name: 'Skyrim unleashed_items.esp'
     tag:
@@ -18202,7 +18266,7 @@ plugins:
     after:
       - 'Immersive Citizens - AI Overhaul.esp'
   - name: 'ELE_Legendary_Lite.esp'
-    global_priority: 77
+    global_priority: 75
     after:
       - 'Immersive Citizens - AI Overhaul.esp'
       - 'RelightingSkyrim_Legendary.esp'
@@ -18212,15 +18276,15 @@ plugins:
       - 'RelightingSkyrim_HF.esp'
       - 'RelightingSkyrim_DB.esp'
   - name: 'ELE_Legendary_Fs_Wt_Lite.esp'
-    global_priority: 77
+    global_priority: 75
     after:
       - 'Immersive Citizens - AI Overhaul.esp'
   - name: 'ELE_S_DG_DB_Lite.esp'
-    global_priority: 77
+    global_priority: 75
     after:
       - 'Immersive Citizens - AI Overhaul.esp'
   - name: 'ELE_S_Lite.esp'
-    global_priority: 77
+    global_priority: 75
     after:
       - 'Immersive Citizens - AI Overhaul.esp'
   - name: 'SV - The Indoors.esp'
@@ -22910,6 +22974,8 @@ plugins:
       - <<: *useOnlyOneX
         condition: 'many("Height Adjusted Races( .+)?\.esp")'
         subs: [ 'Height Adjusted Races .esp file' ]
+      - <<: *reqRequiemPatch
+        condition: 'file("Requiem.esp") and not active("Requiem - Height Adjusted Races with True Giants.esp") and not active("Requiem - True Giants and Mammoths.esp")'
   - name: 'True Giants( v\d)?\.esp'
     msg:
       - type: say
@@ -24986,34 +25052,6 @@ plugins:
         content: 'Incompatible with: Open Cities Skyrim. You must install the compatibility patch.'
       - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Skyrim Unlocked.esp") and not active("Requiem - Skyrim Unlocked - OCS.esp")'
-  - name: '83Willows_101BUGS_V4_HighRes_HighSpawn.esp' 
-    msg:
-      - <<: *reqRequiemPatch
-        condition: 'file("Requiem.esp") and not active("Requiem - 83Willows 101Bugs.esp")'
-      - <<: *redundantPluginX
-        condition: 'active("83Willows_101BUGS_V4_HighRes_HighSpawn.esp") and active("Requiem - 83Willows 101Bugs.esp")'
-        subs: [ 'Requiem - 83Willows 101Bugs.esp' ]
-  - name: '83Willows_101BUGS_V4_LowerRes_HighSpawn.esp'
-    msg:
-      - <<: *reqRequiemPatch
-        condition: 'file("Requiem.esp") and not active("Requiem - 83Willows 101Bugs.esp")'
-      - <<: *redundantPluginX
-        condition: 'active("83Willows_101BUGS_V4_LowerRes_HighSpawn.esp") and active("Requiem - 83Willows 101Bugs.esp")'
-        subs: [ 'Requiem - 83Willows 101Bugs.esp' ]
-  - name: '83Willows_101BUGS_V4_HighRes.esp'
-    msg:
-      - <<: *reqRequiemPatch
-        condition: 'file("Requiem.esp") and not active("Requiem - 83Willows 101Bugs.esp")'
-      - <<: *redundantPluginX
-        condition: 'active("83Willows_101BUGS_V4_HighRes.esp") and active("Requiem - 83Willows 101Bugs.esp")'
-        subs: [ 'Requiem - 83Willows 101Bugs.esp' ]
-  - name: '83Willows_101BUGS_V4_LowRes.esp'
-    msg:
-      - <<: *reqRequiemPatch
-        condition: 'file("Requiem.esp") and not active("Requiem - 83Willows 101Bugs.esp")'
-      - <<: *redundantPluginX
-        condition: 'active("83Willows_101BUGS_V4_LowRes.esp") and active("Requiem - 83Willows 101Bugs.esp")'
-        subs: [ 'Requiem - 83Willows 101Bugs.esp' ]
   - name: 'Craftable Horse Barding.esp'
     msg:
       - <<: *reqRequiemPatch
@@ -25022,9 +25060,6 @@ plugins:
     msg:
       - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Explosive Bolts Visualized.esp")'
-      - <<: *redundantPluginX
-        condition: 'active("ExplosiveBoltsVisualized.esp") and active("Requiem - Explosive Bolts Visualized.esp")'
-        subs: [ 'Requiem - Explosive Bolts Visualized.esp' ]
   - name: 'DeadlyDragons.esp'
     msg:
       - <<: *reqRequiemPatch
@@ -25045,76 +25080,6 @@ plugins:
     msg:
       - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Frostfall.esp")'
-  - name: 'Height Adjusted Races.esp'
-    msg:
-      - <<: *reqRequiemPatch
-        condition: 'file("Requiem.esp") and not active("Requiem - Height Adjusted Races with True Giants.esp")'
-      - <<: *redundantPluginX
-        condition: 'active("Height Adjusted Races.esp") and active("Requiem - Height Adjusted Races with True Giants.esp")'
-        subs: [ 'Requiem - Height Adjusted Races with True Giants.esp' ]
-  - name: 'Height Adjusted Races - Morrowind Lore Heights.esp'
-    msg:
-      - <<: *reqRequiemPatch
-        condition: 'file("Requiem.esp") and not active("Requiem - Height Adjusted Races with True Giants.esp")'
-      - <<: *redundantPluginX
-        condition: 'active("Height Adjusted Races - Morrowind Lore Heights.esp") and active("Requiem - Height Adjusted Races with True Giants.esp")'
-        subs: [ 'Requiem - Height Adjusted Races with True Giants.esp' ]
-  - name: 'Height Adjusted Races - Oblivion Lore Heights.esp'
-    msg:
-      - <<: *reqRequiemPatch
-        condition: 'file("Requiem.esp") and not active("Requiem - Height Adjusted Races with True Giants.esp")'
-      - <<: *redundantPluginX
-        condition: 'active("Height Adjusted Races - Oblivion Lore Heights.esp") and active("Requiem - Height Adjusted Races with True Giants.esp")'
-        subs: [ 'Requiem - Height Adjusted Races with True Giants.esp' ]
-  - name: 'Height Adjusted Races - Player Races Only.esp'
-    msg:
-      - <<: *reqRequiemPatch
-        condition: 'file("Requiem.esp") and not active("Requiem - Height Adjusted Races with True Giants.esp")'
-      - <<: *redundantPluginX
-        condition: 'active("Height Adjusted Races - Player Races Only.esp") and active("Requiem - Height Adjusted Races with True Giants.esp")'
-        subs: [ 'Requiem - Height Adjusted Races with True Giants.esp' ]
-  - name: 'Height Adjusted Races - Player Races Only - Oblivion Lore Heights.esp'
-    msg:
-      - <<: *reqRequiemPatch
-        condition: 'file("Requiem.esp") and not active("Requiem - Height Adjusted Races with True Giants.esp")'
-      - <<: *redundantPluginX
-        condition: 'active("Height Adjusted Races - Player Races Only - Oblivion Lore Heights.esp") and active("Requiem - Height Adjusted Races with True Giants.esp")'
-        subs: [ 'Requiem - Height Adjusted Races with True Giants.esp' ]
-  - name: 'Height Adjusted Races - Player Races Only - Morrowind Lore Heights.esp'
-    msg:
-      - <<: *reqRequiemPatch
-        condition: 'file("Requiem.esp") and not active("Requiem - Height Adjusted Races with True Giants.esp")'
-      - <<: *redundantPluginX
-        condition: 'active("Height Adjusted Races - Player Races Only - Morrowind Lore Heights.esp") and active("Requiem - Height Adjusted Races with True Giants.esp")'
-        subs: [ 'Requiem - Height Adjusted Races with True Giants.esp' ]
-  - name: 'Height Adjusted Races with True Giants.esp'
-    msg:
-      - <<: *reqRequiemPatch
-        condition: 'file("Requiem.esp") and not active("Requiem - Height Adjusted Races with True Giants.esp")'
-      - <<: *redundantPluginX
-        condition: 'active("Height Adjusted Races with True Giants.esp") and active("Requiem - Height Adjusted Races with True Giants.esp")'
-        subs: [ 'Requiem - Height Adjusted Races with True Giants.esp' ]
-  - name: 'Height Adjusted Races with True Giants - Smaller Giant Edition.esp'
-    msg:
-      - <<: *reqRequiemPatch
-        condition: 'file("Requiem.esp") and not active("Requiem - Height Adjusted Races with True Giants.esp")'
-      - <<: *redundantPluginX
-        condition: 'active("Height Adjusted Races with True Giants - Smaller Giant Edition.esp") and active("Requiem - Height Adjusted Races with True Giants.esp")'
-        subs: [ 'Requiem - Height Adjusted Races with True Giants.esp' ]
-  - name: 'Height Adjusted Races - True Giants and Mammoths.esp'
-    msg:
-      - <<: *reqRequiemPatch
-        condition: 'file("Requiem.esp") and not active("Requiem - True Giants and Mammoths.esp")'
-      - <<: *redundantPluginX
-        condition: 'active("Height Adjusted Races - True Giants and Mammoths.esp") and active("Requiem - True Giants and Mammoths.esp")'
-        subs: [ 'Requiem - True Giants and Mammoths.esp' ]
-  - name: 'Height Adjusted Races - True Giants and Mammoths - Smaller Giant Edition.esp'
-    msg:
-      - <<: *reqRequiemPatch
-        condition: 'file("Requiem.esp") and not active("Requiem - True Giants and Mammoths.esp")'
-      - <<: *redundantPluginX
-        condition: 'active("Height Adjusted Races - True Giants and Mammoths - Smaller Giant Edition.esp") and active("Requiem - True Giants and Mammoths.esp")'
-        subs: [ 'Requiem - True Giants and Mammoths.esp' ]
   - name: 'HothFollower.esp'
     msg:
       - <<: *reqRequiemPatch
@@ -25147,20 +25112,10 @@ plugins:
     msg:
       - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Inconsequential NPCs - Enhancement.esp")'
-  - name: 'RUSTIC SOULGEMS - Sorted.esp'
+  - name: 'RUSTIC SOULGEMS - (Uns|S)orted\.esp'
     msg:
       - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Rustic Soulgems.esp") and not active("Requiem - Rustic Soulgems - ISC.esp")'
-      - <<: *redundantPluginX
-        condition: 'active("RUSTIC SOULGEMS - Sorted.esp") and active("Requiem - Rustic Soulgems.esp") or active("RUSTIC SOULGEMS - Sorted.esp") and active("Requiem - Rustic Soulgems - ISC.esp")'
-        subs: [ 'Requiem - Rustic Soulgems.esp' ]
-  - name: 'RUSTIC SOULGEMS - Unsorted.esp'
-    msg:
-      - <<: *reqRequiemPatch
-        condition: 'file("Requiem.esp") and not active("Requiem - Rustic Soulgems.esp") and not active("Requiem - Rustic Soulgems - ISC.esp")'
-      - <<: *redundantPluginX
-        condition: 'active("RUSTIC SOULGEMS - Unsorted.esp") and active("Requiem - Rustic Soulgems.esp") or active("RUSTIC SOULGEMS - Unsorted.esp") and active("Requiem - Rustic Soulgems - ISC.esp")'
-        subs: [ 'Requiem - Rustic Soulgems.esp' ]
   - name: 'ScopedBows.esp'
     msg:
       - <<: *reqRequiemPatch
@@ -25183,18 +25138,18 @@ plugins:
         condition: 'file("Requiem.esp") and not active("Requiem - Dawnguard Arsenal.esp")'
   - name: 'ISC WAFR Patch.esp'
     msg:
-      - <<: *redundantPluginX
-        condition: 'active("ISC WAFR Patch.esp") and active("Requiem - Immersive Sounds Compendium.esp")'
+      - <<: *alreadyInX
+        condition: 'active("Requiem - Immersive Sounds Compendium.esp")'
         subs: [ 'Requiem - Immersive Sounds Compendium.esp' ]
   - name: 'ISC CCF Patch.esp'
     msg:
-      - <<: *redundantPluginX
-        condition: 'active("ISC CCF Patch.esp") and active("Requiem - Immersive Sounds Compendium.esp")'
+      - <<: *alreadyInX
+        condition: 'active("Requiem - Immersive Sounds Compendium.esp")'
         subs: [ 'Requiem - Immersive Sounds Compendium.esp' ]
   - name: 'ISCompendium CCO Patch.esp'
     msg:
-      - <<: *redundantPluginX
-        condition: 'active("ISCompendium CCO Patch.esp") and active("Requiem - Immersive Sounds Compendium.esp")'
+      - <<: *alreadyInX
+        condition: 'active("Requiem - Immersive Sounds Compendium.esp")'
         subs: [ 'Requiem - Immersive Sounds Compendium.esp' ]
   - name: '(ISC Requiem Patch|Requiem - Immersive Sounds Compendium)\.esp'
     msg:
@@ -25203,23 +25158,23 @@ plugins:
         subs: [ 'Requiem patch for Immersive Sounds Compendium' ]
   - name: 'Requiem - Dragonborn - CCOR Patch.esp'
     msg:
-      - <<: *redundantPluginX
-        condition: 'active("Requiem - Dragonborn - CCOR Patch.esp") and active("COR-CraftingOverhaulReqtified.esp")'
+      - <<: *alreadyInX
+        condition: 'active("COR-CraftingOverhaulReqtified.esp")'
         subs: [ 'COR-CraftingOverhaulReqtified.esp' ]
   - name: 'CCO_WAFTrueWeapons_Patch.esp'
     msg:
-      - <<: *redundantPluginX
-        condition: 'active("CCO_WAFTrueWeapons_Patch.esp") and active("COR-CraftingOverhaulReqtified.esp")'
+      - <<: *alreadyInX
+        condition: 'active("COR-CraftingOverhaulReqtified.esp")'
         subs: [ 'COR-CraftingOverhaulReqtified.esp' ]
   - name: 'Cloaks - Dawnguard.esp'
     msg:
-      - <<: *redundantPluginX
-        condition: 'active("Cloaks - Dawnguard.esp") and active("CFR-CloaksForRequiem.esp")'
+      - <<: *alreadyInX
+        condition: 'active("CFR-CloaksForRequiem.esp")'
         subs: [ 'CFR-CloaksForRequiem.esp' ]
   - name: 'COS_WIC_CCO_patch.esp'
     msg:
-      - <<: *redundantPluginX
-        condition: 'active("COS_WIC_CCO_patch.esp") and active("CFR-CloaksForRequiem.esp")'
+      - <<: *alreadyInX
+        condition: 'active("CFR-CloaksForRequiem.esp")'
         subs: [ 'CFR-CloaksForRequiem.esp' ]
   - name: '(CFR-CloaksForRequiem|Requiem - Cloaks( of Skyrim| of Skyrim Hard - Times| of Skyrim Patch| WICCloaks CCFR USKP)?)\.esp'
     msg:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -8739,13 +8739,6 @@ plugins:
     after:
       - 'KFR-Kryptopyr''sFixesReqtified.esp'
       - 'COR-CraftingOverhaulReqtified.esp'
-  # should lose conflicts because other patches may make important edits to quests
-  - name: BetterQuestObjectives-RequiemPatch.esp
-    priority: -50
-    msg:
-      - <<: *redundantPluginX
-        condition: 'version("Requiem.esp", "2.0", >=) and active("BetterQuestObjectives-RequiemPatch.esp")'
-        subs: [ 'Requiem.esp' ]
   # should lose conflicts because other patches may make important edits to the races
   - name: 'Requiem - Height Adjusted Races with True Giants.esp'
     priority: -50
@@ -15145,9 +15138,15 @@ plugins:
             text: 'Устарело. Пожалуйста используйте универсальный патч со страницы Even Better Quest Objectives. [Nexus](http://www.nexusmods.com/skyrim/mods/32695)'
           - lang: es
             text: 'This file is obsolete. Please use the universal patch on the Even Better Quest Objectives page. [Nexus](http://www.nexusmods.com/skyrim/mods/32695)'
-  - name: 'BetterQuestObjectives-RequiemPatch.esp'
+    # should lose conflicts because other patches may make important edits to quests
+  - name: BetterQuestObjectives-RequiemPatch.esp
+    priority: -50
     after:
       - 'ESFCompanions.esp'
+    msg:
+      - <<: *redundantPluginX
+        condition: 'version("Requiem.esp", "2.0", >=) and active("BetterQuestObjectives-RequiemPatch.esp")'
+        subs: [ 'Requiem.esp' ]
   - name: 'Book Covers Skyrim.esp'
     after:
       - 'BetterQuestObjectives.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -8629,18 +8629,35 @@ plugins:
   - name: 'FactionOverhaulV25.esp'
     msg: [ *obsolete ]
   - name: 'Requiem.esp'
+    global_priority: 75
+    inc:
+      - 'Requiem plus PCEA 3-5.esp'
+      - 'Ordinator - Perks of Skyrim.esp'
+      - 'PerkusMaximus_Mage.esp'
+      - 'PerkusMaximus_Master.esp'
+      - 'PerkusMaximus_Thief.esp'
+      - 'PerkusMaximus_Warrior.esp'
+      - 'SkyRe_Main.esp'
+      - name: 'Requiem - Hard Times.esp'
+        condition: 'version("Requiem.esp", "1.8", >=) and checksum("Requiem - Hard Times.esp", A393D1E3)'
     msg:
-      - type: say
+      - <<: *doNotClean
+        condition: 'version("Requiem.esp", "1.9.3", >=)'
+      - type: warn
         content:
           - lang: en
-            text: 'Requiem makes a LOT of changes. You may want to consider creating and using a Userlist based on your particular mod loadout.'
-          - lang: ru
-            text: 'Requiem вносит в игру большое количество изменений. Возможно вам потребуется использование создание пользовательских правил для вашего конкретного набора модов или использование других средств, для дополнительной корректировки порядка загрузки установленных модов.'
-          - lang: es
-            text: 'Requiem makes a LOT of changes. You may want to consider creating and using a Userlist based on your particular mod loadout.'
+            text: 'Your load order does not contain the extra plugin called Bugsmasher, which includes all fixes from the Unofficial Patches that require an explicit dependence on their plugins.'
+        condition: 'not active("Requiem - Bugsmasher Edition.esp") and not active("Requiem - Legendary Bugsmasher Edition.esp")'
+      - type: error
+        content:
+          - lang: en
+            text: 'Delete MineOreScript.pex from Requiem. [CCOR](http://www.nexusmods.com/skyrim/mods/49791)''s script must take precedence.'
+        condition: 'active("Complete Crafting Overhaul_Remade.esp") and checksum("Scripts/MineOreScript.pex", 82F96995)'
     tag:
       - Delev
       - Relev
+    url:
+      - 'http://www.nexusmods.com/skyrim/mods/19281'
     dirty:
       - crc: 0x3b5fc1df
         <<: *dirtyPlugin

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -18197,7 +18197,7 @@ plugins:
     after:
       - 'Immersive Citizens - AI Overhaul.esp'
   - name: 'ELE_Legendary_Lite.esp'
-    global_priority: 110
+    global_priority: 77
     after:
       - 'Immersive Citizens - AI Overhaul.esp'
       - 'RelightingSkyrim_Legendary.esp'
@@ -18207,15 +18207,15 @@ plugins:
       - 'RelightingSkyrim_HF.esp'
       - 'RelightingSkyrim_DB.esp'
   - name: 'ELE_Legendary_Fs_Wt_Lite.esp'
-    global_priority: 110
+    global_priority: 77
     after:
       - 'Immersive Citizens - AI Overhaul.esp'
   - name: 'ELE_S_DG_DB_Lite.esp'
-    global_priority: 110
+    global_priority: 77
     after:
       - 'Immersive Citizens - AI Overhaul.esp'
   - name: 'ELE_S_Lite.esp'
-    global_priority: 110
+    global_priority: 77
     after:
       - 'Immersive Citizens - AI Overhaul.esp'
   - name: 'SV - The Indoors.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -8716,6 +8716,7 @@ plugins:
       - 'EpicGloryByMadmole.esp'
   - name: 'FactionOverhaulV25.esp'
     msg: [ *obsolete ]
+### Rules for Requiem and its patches ###
   - name: 'Requiem.esp'
     global_priority: 75
     inc:
@@ -8741,15 +8742,11 @@ plugins:
           - lang: en
             text: 'Delete MineOreScript.pex from Requiem. [CCOR](http://www.nexusmods.com/skyrim/mods/49791)''s script must take precedence.'
         condition: 'active("Complete Crafting Overhaul_Remade.esp") and checksum("Scripts/MineOreScript.pex", 82F96995)'
-      - type: say
-        content:
-          - lang: en
-            text: 'Hello1'
     tag:
       - Delev
       - Relev
     url:
-      - 'http://www.nexusmods.com/skyrim/mods/19281'
+      - 'http://www.nexusmods.com/skyrim/mods/19281/?'
     dirty:
       - crc: 0x3b5fc1df
         <<: *dirtyPlugin
@@ -8763,10 +8760,10 @@ plugins:
         <<: *dirtyPlugin
         itm: 306
         udr: 10
-  # must be loaded directly after Requiem.esp
+  # Must be loaded directly after Requiem.esp
   - name: 'Requiem - Bugsmasher Edition.esp'
     priority: -127
-  # must be loaded directly after Requiem.esp
+  # Must be loaded directly after Requiem.esp
   - name: 'Requiem - Legendary Bugsmasher Edition.esp'
     priority: -127
   - name: 'Requiem - Difficulty Bar Restored.esp'
@@ -8792,7 +8789,7 @@ plugins:
         itm: 1
     url:
       - 'http://www.nexusmods.com/skyrim/mods/58121/?'
-  # this is the old dragonborn patch by azirok
+  # This is the old dragonborn patch by azirok
   - name: 'Requiem - Dragonborn.esp'
     dirty:
       - crc: 0x740bb9f0
@@ -8800,27 +8797,27 @@ plugins:
         itm: 3
     url:
       - 'http://www.nexusmods.com/skyrim/mods/54562/?'
-  # should be loaded directly after Requiem.esp and the bugsmasher
+  # Should be loaded directly after Requiem.esp and the bugsmasher
   - name: 'Requiem - Hearthfire.esp'
     priority: -127
     after:
       - 'Requiem - Bugsmasher Edition.esp'
       - 'Requiem - Legendary Bugsmasher Edition.esp'
-  # should lose conflicts because other patches may make important edits to Dragonborn content
+  # Should lose conflicts because other patches may make important edits to Dragonborn content
   - name: 'NRM_Dragonborn_Reqtified.esp'
     priority: -75
     inc:
       - 'Fozars_Dragonborn_-_Requiem_Patch.esp'
-  # should lose conflicts because other patches may make important edits to Dragonborn content
+  # Should lose conflicts because other patches may make important edits to Dragonborn content
   - name: 'Fozars_Dragonborn_-_Requiem_Patch.esp'
     priority: -75
     after:
       - 'KFR-Kryptopyr''sFixesReqtified.esp'
       - 'COR-CraftingOverhaulReqtified.esp'
-  # should lose conflicts because other patches may make important edits to the races
+  # Should lose conflicts because other patches may make important edits to the races
   - name: 'Requiem - Height Adjusted Races with True Giants.esp'
     priority: -50
-  # should lose conflicts because other patches may make important edits to something touched by AOS
+  # Should lose conflicts because other patches may make important edits to something touched by AOS
   - name: 'Requiem - Audio Overhaul for Skyrim.esp'
     priority: -50
     after:
@@ -8848,7 +8845,7 @@ plugins:
       - 'Requiem - Immersive Spells.esp'
       - 'Open Face Guard Helmets.esp'
       - 'Requiem - Civil War Overhaul Patch.esp'
-  # must be loaded directly after Minor Arcana
+  # Must be loaded directly after Minor Arcana
   - name: 'Requiem - Minor Arcana - USLEEP patch.esp'
     priority: -127
   - name: 'Requiem - ESF Companions.esp'
@@ -8878,13 +8875,20 @@ plugins:
   - name: 'Requiem - WAF+CCF+TrueWeapons Patch.esp'
     inc:
       - 'KFR-Kryptopyr''sFixesReqtified.esp")'
-  - name: 'Requiem for the Indifferent.esp'
-    global_priority: 95
-# mods that go after Requiem
+# Mods that must be loaded after Requiem
   - name: 'Bounty Gold.esp'
     after:
       - 'Requiem.esp'
-  # realistic ragdoll
+  - name: 'dD.?- Realistic Ragdoll Force.*\.esp'
+    after:
+      - 'Requiem.esp'
+    msg:
+      - type: say
+        content:
+          - lang: en
+            text: 'Ragdolls will conflict with other mods that change the skeleton.nif. Check [ Custom Skeleton Replacers](http://www.nexusmods.com/skyrim/mods/16712) for compatibly with other skeleton.nif.'
+          - lang: ru
+            text: 'Конфликтует с другими модами, меняющими файл skeleton.nif. Смотрите страницу [ Custom Skeleton Replacers](http://www.nexusmods.com/skyrim/mods/16712), для поддержки других версий skeleton.nif или попробуйте использовать [XP32 Maximum Skeleton Extended - XPMSE](http://www.nexusmods.com/skyrim/mods/68000).'
   - name: 'XPMSE.esp'
     after:
       - 'Requiem.esp'
@@ -8897,11 +8901,12 @@ plugins:
   - name: 'WerewolfPerksExpanded.esp'
     after:
       - 'Requiem.esp'
-  # RealisticWaterTwo.esp
   - name: 'No Vendor or Loot Spells - Riverwood Trader Requiem.esp'
     req:
       - 'Requiem.esp'
-
+  # other mods that must be loaded after Requiem but are listed somewhere else in LOOT's rules:
+  # - RealisticWaterTwo.esp
+### End of Requiem's rules ###
   - name: 'Skyrim Hardcore Overhaul.esp'
     tag:
       - Delev
@@ -22956,16 +22961,6 @@ plugins:
           - lang: es
             text: 'SKYUI.esp no se encuentra presente o activado. No podrás utilizar SkyUI MCM.'
         condition: 'not active("SkyUI.esp")'
-  - name: 'dD.?- Realistic Ragdoll Force.*\.esp'
-    after:
-      - 'Requiem.esp'
-    msg:
-      - type: say
-        content:
-          - lang: en
-            text: 'Ragdolls will conflict with other mods that change the skeleton.nif. Check [ Custom Skeleton Replacers](http://www.nexusmods.com/skyrim/mods/16712) for compatibly with other skeleton.nif.'
-          - lang: ru
-            text: 'Конфликтует с другими модами, меняющими файл skeleton.nif. Смотрите страницу [ Custom Skeleton Replacers](http://www.nexusmods.com/skyrim/mods/16712), для поддержки других версий skeleton.nif или попробуйте использовать [XP32 Maximum Skeleton Extended - XPMSE](http://www.nexusmods.com/skyrim/mods/68000).'
   - name: 'driveableboat.esp'
     dirty:
       - crc: 0x920c6e44
@@ -24357,6 +24352,8 @@ plugins:
     global_priority: 95
   - name: 'ReProccer.esp'
     global_priority: 95
+  - name: 'Requiem for the Indifferent.esp'
+    global_priority: 95
   - name: 'ScrollProccer.esp'
     global_priority: 95
   - name: 'The Staff Machine.esp'
@@ -24977,7 +24974,7 @@ plugins:
     after:
       - 'AuroraVillage.esp'
   - name: 'No Vendor or Loot Spells.esp'
-    global_priority: 100
+    global_priority: 105
   - name: 'Skyrim Unlocked.esp'
     global_priority: 90
     inc:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -18034,6 +18034,7 @@ plugins:
     after:
       - 'Immersive Citizens - AI Overhaul.esp'
   - name: 'ELE_Legendary_Lite.esp'
+    priority: 110
     after:
       - 'Immersive Citizens - AI Overhaul.esp'
       - 'RelightingSkyrim_Legendary.esp'
@@ -18043,12 +18044,15 @@ plugins:
       - 'RelightingSkyrim_HF.esp'
       - 'RelightingSkyrim_DB.esp'
   - name: 'ELE_Legendary_Fs_Wt_Lite.esp'
+    priority: 110
     after:
       - 'Immersive Citizens - AI Overhaul.esp'
   - name: 'ELE_S_DG_DB_Lite.esp'
+    priority: 110
     after:
       - 'Immersive Citizens - AI Overhaul.esp'
   - name: 'ELE_S_Lite.esp'
+    priority: 110
     after:
       - 'Immersive Citizens - AI Overhaul.esp'
   - name: 'SV - The Indoors.esp'
@@ -24783,11 +24787,3 @@ plugins:
 
   - name: 'No Vendor or Loot Spells.esp'
     global_priority: 100
-  - name: 'ELE_Legendary_Lite.esp'
-    priority: 110
-  - name: 'ELE_Legendary_Fs_Wt_Lite.esp'
-    priority: 110
-  - name: 'ELE_S_DG_DB_Lite.esp'
-    priority: 110
-  - name: 'ELE_S_Lite.esp'
-    priority: 110

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2561,11 +2561,11 @@ plugins:
       - <<: *redundantPluginX
         condition: 'active("AOS2_WAF Patch.esp") and active("Requiem - Audio Overhaul for Skyrim.esp")'
         subs: [ 'Requiem - Audio Overhaul for Skyrim.esp' ]
-  - name: 'AOS2_Requiem Patch.esp'
+  - name: '(AOS2_Requiem Patch|Requiem - Audio Overhaul for Skyrim)\.esp'
     msg:
-      - <<: *redundantPluginX
-        condition: 'active("AOS2_Requiem Patch.esp") and active("Requiem - Audio Overhaul for Skyrim.esp")'
-        subs: [ 'Requiem - Audio Overhaul for Skyrim.esp' ]
+      - <<: *useOnlyOneX
+        condition: 'many("(AOS2_Requiem Patch|Requiem - Audio Overhaul for Skyrim)\.esp")'
+        subs: [ 'Requiem patch for Audio Overhaul for Skyrim' ]
 # ## AOS_DG Patch.esp
 # ## AOS_DB Patch.esp
 # ## these should sort up here; regex: AOS_.+ down in compat patches section was unfortunately too broad -LD
@@ -8746,7 +8746,7 @@ plugins:
       - Delev
       - Relev
     url:
-      - 'http://www.nexusmods.com/skyrim/mods/19281/?'
+      - 'http://www.nexusmods.com/skyrim/mods/19281'
     dirty:
       - crc: 0x3b5fc1df
         <<: *dirtyPlugin
@@ -8788,7 +8788,7 @@ plugins:
         <<: *dirtyPlugin
         itm: 1
     url:
-      - 'http://www.nexusmods.com/skyrim/mods/58121/?'
+      - 'http://www.nexusmods.com/skyrim/mods/58121'
   # This is the old dragonborn patch by azirok
   - name: 'Requiem - Dragonborn.esp'
     dirty:
@@ -8796,7 +8796,7 @@ plugins:
         <<: *dirtyPlugin
         itm: 3
     url:
-      - 'http://www.nexusmods.com/skyrim/mods/54562/?'
+      - 'http://www.nexusmods.com/skyrim/mods/54562'
   # Should be loaded directly after Requiem.esp and the bugsmasher
   - name: 'Requiem - Hearthfire.esp'
     priority: -127
@@ -25196,11 +25196,11 @@ plugins:
       - <<: *redundantPluginX
         condition: 'active("ISCompendium CCO Patch.esp") and active("Requiem - Immersive Sounds Compendium.esp")'
         subs: [ 'Requiem - Immersive Sounds Compendium.esp' ]
-  - name: 'ISC Requiem Patch.esp'
+ - name: '(ISC Requiem Patch|Requiem - Immersive Sounds Compendium)\.esp'
     msg:
-      - <<: *redundantPluginX
-        condition: 'active("ISC Requiem Patch.esp") and active("Requiem - Immersive Sounds Compendium.esp")'
-        subs: [ 'Requiem - Immersive Sounds Compendium.esp' ]
+      - <<: *useOnlyOneX
+        condition: 'many("(ISC Requiem Patch|Requiem - Immersive Sounds Compendium)\.esp")'
+        subs: [ 'Requiem patch for Immersive Sounds Compendium' ]
   - name: 'Requiem - Dragonborn - CCOR Patch.esp'
     msg:
       - <<: *redundantPluginX
@@ -25221,28 +25221,8 @@ plugins:
       - <<: *redundantPluginX
         condition: 'active("COS_WIC_CCO_patch.esp") and active("CFR-CloaksForRequiem.esp")'
         subs: [ 'CFR-CloaksForRequiem.esp' ]
-  - name: 'Requiem - Cloaks.esp'
+  - name: '(CFR-CloaksForRequiem|Requiem - Cloaks( of Skyrim| of Skyrim Hard - Times| of Skyrim Patch| WICCloaks CCFR USKP)?)\.esp'
     msg:
-      - <<: *redundantPluginX
-        condition: 'active("Requiem - Cloaks.esp") and active("CFR-CloaksForRequiem.esp")'
-        subs: [ 'CFR-CloaksForRequiem.esp' ]
-  - name: 'Requiem - Cloaks of Skyrim.esp'
-    msg:
-      - <<: *redundantPluginX
-        condition: 'active("Requiem - Cloaks of Skyrim.esp") and active("CFR-CloaksForRequiem.esp")'
-        subs: [ 'CFR-CloaksForRequiem.esp' ]
-  - name: 'Requiem - Cloaks of Skyrim Hard - Times.esp'
-    msg:
-      - <<: *redundantPluginX
-        condition: 'active("Requiem - Cloaks of Skyrim Hard - Times.esp") and active("CFR-CloaksForRequiem.esp")'
-        subs: [ 'CFR-CloaksForRequiem.esp' ]
-  - name: 'Requiem - Cloaks of Skyrim Patch.esp'
-    msg:
-      - <<: *redundantPluginX
-        condition: 'active("Requiem - Cloaks of Skyrim Patch.esp") and active("CFR-CloaksForRequiem.esp")'
-        subs: [ 'CFR-CloaksForRequiem.esp' ]
-  - name: 'Requiem - Cloaks WICCloaks CCFR USKP.esp'
-    msg:
-      - <<: *redundantPluginX
-        condition: 'active("Requiem - Cloaks WICCloaks CCFR USKP.esp") and active("CFR-CloaksForRequiem.esp")'
-        subs: [ 'CFR-CloaksForRequiem.esp' ]
+      - <<: *useOnlyOneX
+        condition: 'many("(CFR-CloaksForRequiem|Requiem - Cloaks( of Skyrim| of Skyrim Hard - Times| of Skyrim Patch| WICCloaks CCFR USKP)?)\.esp")'
+        subs: [ 'Requiem patch for Cloaks of Skyrim' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2521,7 +2521,7 @@ plugins:
 # ## MoreSoundOptions.esp
 # ## suggested to load before ADS
   - name: 'AOS.esp'
-     after:
+    after:
       - 'WetandCold.esp'
       # AOS shouldn't be loaded after Requiem
       - name: 'RealisticWaterTwo.esp'


### PR DESCRIPTION
In short: This is all the metadata needed to create a good Requiem-based load order.

It points out known incompatibilities, mods that require a patch, redundant plugins and ensures a correct load order for Requiem and its patches. Explaining every single rule would take way too long and  it almost always boils down to "it's recommended by the Requiem Dungeon Masters (the developers)" or "it's recommended by the patch maker". I hope it suffices that I'm part of the Requiem Dungeon Masters and one of the major patch makers for Requiem and that this metadata has been tested for three months.
I compiled the metadata in a userlist.yaml and uploaded it in March on my [patch central](http://www.nexusmods.com/skyrim/mods/61621/?) for public testing. The last version had over 200 unique downloads. When no more issues were reported for several weeks I moved the metadata to the masterlist and put it up for testing again in case I overlooked something during the process and didn’t catch it in local testing. I got a few positive and no negative reports so I guess it’s now ready for merge.

Additional metadata that isn't strictly related to Requiem but is required for a correct load order with Requiem (and of course without Requiem too):
- [ELE](http://www.nexusmods.com/skyrim/mods/59733/?) should be loaded after all plugins that aren't dynamically created like e.g. DynDOLOD because any additional or edited reference also adds a (necessary) ITM record of the parent cell/worldspace to the plugin, that then overwrites ELE. I set its global priority to 77.
- [No Spell Tomes as Loot or From Vendors](http://www.nexusmods.com/skyrim/mods/81341/?) No mod **ever** has any reason to overwrite it. Dynamically created plugins like a bashed patch may even undo the changes. I set its global priority to 105.
- [Skyrim Unlocked](http://www.nexusmods.com/skyrim/mods/69420/?) should be loaded at the bottom of the load order like LAL or Open Cities. I set its global priority to 70.
