### PR TITLE
Added Realistic AI Detection

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -26677,3 +26677,6 @@ plugins:
       - <<: *alreadyInX
         condition: 'active("Immersive Horses - Hearthfire Patch.esp") and version("Requiem - Immersive Horses - SkyTEST.esp", "1.63", >=)'
         subs: [ 'Requiem - Immersive Horses - SkyTEST.esp' ]
+  - name: 'Realistic AI Detection 2.*\.esp'
+    after:
+      - 'Requiem.esp'


### PR DESCRIPTION
Realistic AI Detection needs to be loaded after Requiem so that the modified game settings take precedence.