### PR TITLE
The lite version of ESF Companions doesn't require a Requiem patch

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9346,7 +9346,7 @@ plugins:
       - 'Requiem - ESF Companions.esp'
     msg:
       - <<: *reqPatchForX
-        condition: 'file("ESFCompanions.esp") and not active("Requiem_Minor_Arcana - ESF Companions.esp")'
+        condition: 'version("ESFCompanions.esp", "0.3.8", >=) and not active("Requiem_Minor_Arcana - ESF Companions.esp")'
         subs: [ 'ESFCompanions.esp' ]
   # Must be loaded directly after Minor Arcana
   - name: 'Requiem - Minor Arcana - USLEEP patch.esp'
@@ -16589,7 +16589,7 @@ plugins:
       - 'BetterQuestObjectives.esp'
     msg:
       - <<: *reqRequiemPatch
-        condition: 'file("Requiem.esp") and not active("Requiem - ESF Companions.esp")'
+        condition: 'version("ESFCompanions.esp", "0.3.8", >=) and file("Requiem.esp") and not active("Requiem - ESF Companions.esp")'
     dirty:
       - crc: 0x16c76fa7
         <<: *dirtyPlugin


### PR DESCRIPTION
The full and lite version of ESF Companions are two different mods that share the same name. The lite version is fully compatible with Requiem and shouldn't warn about a missing patch.