### PR TITLE
Update Unofficial Patch Metadata and recommend USLEEP

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -490,50 +490,9 @@ plugins:
     global_priority: -120
     msg:
       - type: say
-        condition: 'active("Dawnguard.esm") and not file("Unofficial Dawnguard Patch.esp")'
         content:
           - lang: en
-            text: 'It is highly recommended that you also use the [Unofficial Dawnguard Patch](http://www.nexusmods.com/skyrim/mods/23491).'
-          - lang: ru
-            text: 'Настоятельно рекомендуется также использовать [Unofficial Dawnguard Patch](http://www.nexusmods.com/skyrim/mods/23491).'
-          - lang: es
-            text: 'Se recomienda que utilizes [Unofficial Dawnguard Patch](http://www.nexusmods.com/skyrim/mods/23491) además de Dawnguard. Se necesita para el correcto funcionamiento de Dawnguard.'
-          - lang: ko
-            text: '[Unofficial Dawnguard Patch](http://www.nexusmods.com/skyrim/mods/23491)도 사용하는 것을 적극 권장합니다.'
-          - lang: zh_CN
-            text: '强烈建议你使用[Unofficial Dawnguard Patch](http://www.nexusmods.com/skyrim/mods/23491)。'
-          - lang: ja
-            text: '[Unofficial Dawnguard Patch](http://www.nexusmods.com/skyrim/mods/23491)と併用することをお勧めします。'
-      - type: say
-        condition: 'active("Hearthfires.esm") and not file("Unofficial Hearthfire Patch.esp")'
-        content:
-          - lang: en
-            text: 'It is highly recommended that you also use the [Unofficial Hearthfire Patch](http://www.nexusmods.com/skyrim/mods/25127).'
-          - lang: ru
-            text: 'Настоятельно рекомендуется также использовать [Unofficial Hearthfire Patch](http://www.nexusmods.com/skyrim/mods/25127).'
-          - lang: es
-            text: 'Se recomienda que utilizes [Unofficial Hearthfire Patch](http://www.nexusmods.com/skyrim/mods/25127) además de Hearthfire. Se necesita para el correcto funcionamiento de Hearthfire.'
-          - lang: ko
-            text: '[Unofficial Hearthfire Patch](http://www.nexusmods.com/skyrim/mods/25127)도 사용하는 것을 적극 권장합니다.'
-          - lang: zh_CN
-            text: '强烈建议你使用[Unofficial Hearthfire Patch](http://www.nexusmods.com/skyrim/mods/25127)。'
-          - lang: ja
-            text: '[Unofficial Hearthfire Patch](http://www.nexusmods.com/skyrim/mods/25127)と併用することをお勧めします。'
-      - type: say
-        condition: 'active("Dragonborn.esm") and not file("Unofficial Dragonborn Patch.esp")'
-        content:
-          - lang: en
-            text: 'It is highly recommended that you also use the [Unofficial Dragonborn Patch](http://www.nexusmods.com/skyrim/mods/31083).'
-          - lang: ru
-            text: 'Настоятельно рекомендуется также использовать [Unofficial Dragonborn Patch](http://www.nexusmods.com/skyrim/mods/31083).'
-          - lang: es
-            text: 'Se recomienda que utilizes [Unofficial Dragonborn Patch](http://www.nexusmods.com/skyrim/mods/31083) además de Dragonborn. Se necesita para el correcto funcionamiento de Dragonborn.'
-          - lang: ko
-            text: '[Unofficial Dragonborn Patch](http://www.nexusmods.com/skyrim/mods/31083).도 사용하는 것을 적극 권장합니다.'
-          - lang: zh_CN
-            text: '强烈建议你使用[Unofficial Dragonborn Patch](http://www.nexusmods.com/skyrim/mods/31083)。'
-          - lang: ja
-            text: '[Unofficial Dragonborn Patch](http://www.nexusmods.com/skyrim/mods/31083)と併用することをお勧めします。'
+            text: 'Outdated. It is highly recommended to install the [Unofficial Skyrim Legendary Edition Patch](https://www.nexusmods.com/skyrim/mods/71214).'
     tag:
       - C.Acoustic
       - C.Climate
@@ -593,6 +552,11 @@ plugins:
     after:
       - 'Unofficial Skyrim Patch.esp'
       - 'Dawnguard - Textures.esm'
+    msg:
+      - type: say
+        content:
+          - lang: en
+            text: 'Outdated. It is highly recommended to install the [Unofficial Skyrim Legendary Edition Patch](https://www.nexusmods.com/skyrim/mods/71214).'
     tag:
       - C.Climate
       - C.Encounter
@@ -672,6 +636,11 @@ plugins:
       - 'Unofficial Dawnguard Patch.esp'
       - 'Dawnguard - Textures.esm'
       - 'HearthFires - Textures.esm'
+    msg:
+      - type: say
+        content:
+          - lang: en
+            text: 'Outdated. It is highly recommended to install the [Unofficial Skyrim Legendary Edition Patch](https://www.nexusmods.com/skyrim/mods/71214).'
     tag:
       - C.Climate
       - C.Location
@@ -724,6 +693,11 @@ plugins:
       - 'Dawnguard - Textures.esm'
       - 'HearthFires - Textures.esm'
       - 'Dragonborn - Textures.esm'
+    msg:
+      - type: say
+        content:
+          - lang: en
+            text: 'Outdated. It is highly recommended to install the [Unofficial Skyrim Legendary Edition Patch](https://www.nexusmods.com/skyrim/mods/71214).'
     tag:
       - C.Climate
       - C.Encounter
@@ -798,17 +772,7 @@ plugins:
       - type: error
         content:
           - lang: en
-            text: 'This esm file WILL damage your game. We strongly advise that you use the official version of the [Unofficial Skyrim Patch](http://www.nexusmods.com/skyrim/mods/19). Do not modify its extension.'
-          - lang: ru
-            text: 'Этот esm-файл может повредить вашу игру. Настоятельно рекомендуется использовать этот [Unofficial Skyrim Patch](http://www.nexusmods.com/skyrim/mods/19).'
-          - lang: es
-            text: 'Este archivo esm dañará tu juego. Recomendamos fuertemente que descarges [Unofficial Skyrim Patch](http://www.nexusmods.com/skyrim/mods/19).'
-          - lang: ko
-            text: '이 esm파일은 게임을 손상시킬 수도 있습니다. [Unofficial Skyrim Patch](http://www.nexusmods.com/skyrim/mods/19)의 공식 버전을 사용하는 것을 적극 권장합니다. 확장자를 변경하지 마십시오.'
-          - lang: zh_CN
-            text: '这个esm文件会破坏你的游戏。我们强烈建议你使用官方版本的[Unofficial Skyrim Patch](http://www.nexusmods.com/skyrim/mods/19)。不要做任何修改。'
-          - lang: ja
-            text: 'このEsmファイルはゲームデータを破損させる恐れがあります。オフィシャル版の[Unofficial Skyrim Patch](http://www.nexusmods.com/skyrim/mods/19)を使用することを強く推奨します。拡張子は変更しないでください。'
+            text: 'This esm file WILL damage your game. We strongly advise that you use the [Unofficial Skyrim Legendary Edition Patch](https://www.nexusmods.com/skyrim/mods/71214). Do not modify its extension.'
   - name: 'MoT_First_LoadOrder_File_After_Skyrim.esm'
     dirty:
       - crc: 0x6d3163ad


### PR DESCRIPTION
Since the USKP, UDGP, UHFP and UDBP are long outdated and got removed from Skyrim Nexus, the url's to said unofficial patches in the masterlist are no longer working and it's better to suggest using USLEEP instead.

CC: @Arthmoor 