### PR TITLE
Updated to Skyrim Unlocked 1.7.4

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -26633,9 +26633,21 @@ plugins:
       - <<: *reqPatchForX
         condition: 'active("CollegeOfWinterholdImmersive.esp") and not active("Skyrim Unlocked - Immersive College of Winterhold Patch.esp")'
         subs: [ 'Immersive College of Winterhold' ]
+      - <<: *reqPatchForX
+        condition: 'active("ESFCompanions.esp") and not active("Skyrim Unlocked - ESF Companions Patch.esp")'
+        subs: [ 'Enhanced Skyrim Factions - The Companions Guild' ]
+      - <<: *reqPatchForX
+        condition: 'active("Alternate Start - Live Another Life.esp") and not active("Skyrim Unlocked - Live Another Life Patch.esp")'
+        subs: [ 'Alternate Start - Live Another Life' ]
       - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Skyrim Unlocked.esp") and not active("Requiem - Skyrim Unlocked - OCS.esp")'
-  - name: 'Skyrim Unlocked - Immersive College of Winterhold Patch'
+  - name: 'Skyrim Unlocked - Immersive College of Winterhold Patch.esp'
+    req:
+      - 'Skyrim Unlocked.esp'
+  - name: 'Skyrim Unlocked - ESF Companions Patch.esp'
+    req:
+      - 'Skyrim Unlocked.esp'
+  - name: 'Skyrim Unlocked - Live Another Life Patch.esp'
     req:
       - 'Skyrim Unlocked.esp'
   - name: 'Open Cities Skyrim - Skyrim Unlocked Patch.esp'


### PR DESCRIPTION
A compatibility patch for ESF Companions has been added. The patch doesn't have Skyrim Unlocked as master but it's obviously required to be present.

The compatibility patch for Live Another Life has been converted into a separate plugin. The patch doesn't have Skyrim Unlocked as master but it's obviously required to be present.

The compatibility patch for Immersive College of Winterhold doesn't have Skyrim Unlocked as master but it's obviously required to be present. This rule was already present but the file name was missing the extension.