### PR TITLE
Improved groups for Requiem

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -500,14 +500,17 @@ groups:
   - name: &requiemGroup Requiem
     after: [ *morrowlootGroup ]
 
-  - name: &requiemEarlyGroup Requiem - Early Patches
+  - name: &requiemBugsmasherGroup Requiem - Bugsmasher
     after: [ *requiemGroup ]
 
-  - name: &requiemDragonbornGroup Requiem - Dragonborn Patches
-    after: [ *requiemEarlyGroup ]
+  - name: &requiemDLCGroup Requiem - DLC Patches
+    after: [ *requiemBugsmasherGroup ]
+
+  - name: &requiemEarlyGroup Requiem - Early Patches
+    after: [ *requiemDLCGroup ]
 
   - name: &requiemPatchesGroup Requiem - Misc. Patches
-    after: [ *requiemDragonbornGroup ]
+    after: [ *requiemEarlyGroup ]
 
   - name: &alternateStartGroup Alternate Start & Requiem
     after: [ *requiemPatchesGroup ]
@@ -9340,29 +9343,12 @@ plugins:
         <<: *dirtyPlugin
         itm: 306
         udr: 10
-  # Must be loaded directly after Requiem.esp
   - name: 'Requiem - Bugsmasher Edition.esp'
-    group: *requiemEarlyGroup
-  # Must be loaded directly after Requiem.esp
+    group: *requiemBugsmasherGroup
   - name: 'Requiem - Legendary Bugsmasher Edition.esp'
-    group: *requiemEarlyGroup
-  - name: 'Requiem - Difficulty Bar Restored.esp'
-    inc:
-      - 'Requiem - Difficulty Bar Restored - Nightmare.esp'
-  - name: 'Requiem - No Overencumbered Messages.esp'
-    inc:
-      - 'Requiem - No Messages.esp'
-  - name: 'Requiem - TrainUnitsPerLevel(0|5|10|100)\.esp'
-    msg:
-      - <<: *useOnlyOneX
-        condition: 'many("Requiem - TrainUnitsPerLevel(0|5|10|100)\.esp")'
-        subs: [ 'TrainUnitsPerLevel .esp file' ]
-  - name: 'Requiem - Weapon Damage Modifier (2|3)x Vanilla.esp'
-    msg:
-      - <<: *useOnlyOneX
-        condition: 'many("Requiem - TrainUnitsPerLevel(0|5|10|100)\.esp")'
-        subs: [ 'Requiem - Weapon Damage Modifier .esp file' ]
+    group: *requiemBugsmasherGroup
   - name: 'Requiem - Hearthfires.esp'
+    group: *requiemDLCGroup
     dirty:
       - crc: 0xa3a78f22
         <<: *dirtyPlugin
@@ -9371,128 +9357,86 @@ plugins:
       - 'http://www.nexusmods.com/skyrim/mods/58121'
   # This is the old dragonborn patch by azirok
   - name: 'Requiem - Dragonborn.esp'
+    group: *requiemDLCGroup
     dirty:
       - crc: 0x740bb9f0
         <<: *dirtyPlugin
         itm: 3
     url:
       - 'http://www.nexusmods.com/skyrim/mods/54562'
-  # Should be loaded directly after Requiem.esp and the bugsmasher
   - name: 'Requiem - Hearthfire.esp'
-    group: *requiemEarlyGroup
-    after:
-      - 'Requiem - Bugsmasher Edition.esp'
-      - 'Requiem - Legendary Bugsmasher Edition.esp'
+    group: *requiemDLCGroup
     msg:
       - <<: *alreadyInX
         condition: 'active("Requiem - Hearthfire.esp") and version("Requiem.esp", "2.0.0", >=)'
         subs: [ 'Requiem.esp' ]
-  # Should lose conflicts because other patches may make important edits to Dragonborn content
   - name: 'NRM_Dragonborn_Reqtified.esp'
-    group: *requiemDragonbornGroup
+    group: *requiemDLCGroup
     inc:
       - 'Fozars_Dragonborn_-_Requiem_Patch.esp'
-  # Should lose conflicts because other patches may make important edits to Dragonborn content
   - name: 'Fozars_Dragonborn_-_Requiem_Patch.esp'
-    group: *requiemDragonbornGroup
-  # Should lose conflicts because other patches may make important edits to something touched by AOS
-  - name: 'Requiem - Audio Overhaul for Skyrim.esp'
-    group: *requiemPatchesGroup
-    after:
-      - 'KFR-Kryptopyr''sFixesReqtified.esp'
-      - 'COR-CraftingOverhaulReqtified.esp'
-      - 'Requiem - Cutting Room Floor.esp'
-      - 'Alternate Start - Live Another Life.esp'
+    group: *requiemDLCGroup
   - name: 'KFR-Kryptopyr''sFixesReqtified.esp'
-    after:
-      - 'NRM_Dragonborn_Reqtified.esp'
-      - 'Fozars_Dragonborn_-_Requiem_Patch.esp'
+    group: *requiemEarlyGroup
     msg:
       - <<: *reqPatchForX
         condition: 'active("Fozars_Dragonborn_-_Requiem_Patch.esp") and not active("KFR-FZR.esp")'
         subs: [ 'Fozar''s Dragonborn patch' ]
-  - name: 'COR-CraftingOverhaulReqtified.esp'
-    after:
+  - name: 'KFR-FZR.esp'
+    group: *requiemEarlyGroup
+    req:
       - 'KFR-Kryptopyr''sFixesReqtified.esp'
       - 'Fozars_Dragonborn_-_Requiem_Patch.esp'
+  - name: 'KFR-NoHeavyStormcloaks.esp'
+    group: *requiemEarlyGroup
+    req:
+      - 'KFR-Kryptopyr''sFixesReqtified.esp'
+  - name: 'KFR-CircletsWithHoods.esp'
+    group: *requiemEarlyGroup
+    req:
+      - 'KFR-Kryptopyr''sFixesReqtified.esp'
+  - name: 'COR-CraftingOverhaulReqtified.esp'
+    group: *requiemEarlyGroup
     msg:
       - <<: *reqPatchForX
         condition: 'active("Fozars_Dragonborn_-_Requiem_Patch.esp") and not active("COR-FZR.esp")'
         subs: [ 'Fozar''s Dragonborn patch' ]
-  - name: 'COR-Campfire.esp'
-    req:
-      - 'COR-CraftingOverhaulReqtified.esp'
-  - name: 'COR-WetAndCold.esp'
-    req:
-      - 'COR-CraftingOverhaulReqtified.esp'
-  - name: 'Open Face Guard Helmets.esp'
-    after:
-      - 'KFR-Kryptopyr''sFixesReqtified.esp'
-  - name: 'Requiem - Guard Dialogue & Open Helmets.esp'
-    after:
-      - 'KFR-Kryptopyr''sFixesReqtified.esp'
-  - name: 'Requiem_Minor_Arcana.esp'
-    after:
-      - 'KFR-Kryptopyr''sFixesReqtified.esp'
-      - 'COR-CraftingOverhaulReqtified.esp'
-      - 'Open Face Guard Helmets.esp'
-      - 'Requiem - Guard Dialogue & Open Helmets.esp'
-      - 'Requiem - Immersive Spells.esp'
-      - 'Requiem - Civil War Overhaul Patch.esp'
-      - 'Requiem - ESF Companions.esp'
-    msg:
-      - <<: *reqPatchForX
-        condition: 'version("ESFCompanions.esp", "0.3.8", >=) and not active("Requiem_Minor_Arcana - ESF Companions.esp")'
-        subs: [ 'ESFCompanions.esp' ]
-  # Must be loaded directly after Minor Arcana
-  - name: 'Requiem - Minor Arcana - USLEEP patch.esp'
+  - name: 'COR-FZR.esp'
     group: *requiemEarlyGroup
-  - name: 'Requiem - WRF_MinorArcana_MortalEnemies_TG.esp'
-    after:
-      - 'Requiem_Minor_Arcana.esp'
-  - name: 'Requiem - Immersive Creatures.esp'
-    after:
-      - 'Fozars_Dragonborn_-_Requiem_Patch.esp'
-  - name: 'Requiem - Immersive Horses.esp'
-    after:
-      - 'REQMOD.esp'
-  - name: 'Requiem - Immersive Horses - SkyTEST.esp'
     req:
-      - 'Requiem - SkyTEST.esp'
-    after:
-      - 'REQMOD.esp'
-  - name: 'Requiem - Craftable Horse Barding.esp'
-    after:
-      - 'Requiem - Immersive Horses.esp'
-      - 'Requiem - Immersive Horses - SkyTEST.esp'
+      - 'COR-CraftingOverhaulReqtified.esp'
+      - 'Fozars_Dragonborn_-_Requiem_Patch.esp'
+  - name: 'COR-NoHeavyStormcloaks.esp'
+    group: *requiemEarlyGroup
+    req:
+      - 'COR-CraftingOverhaulReqtified.esp'
+  - name: 'COR-CircletsWithHoods.esp'
+    group: *requiemEarlyGroup
+    req:
+      - 'COR-CraftingOverhaulReqtified.esp'
   - name: 'Requiem - WAF+Clothing and Clutter Fixes Patch.esp'
+    group: *requiemEarlyGroup
     inc:
-      - 'KFR-Kryptopyr''sFixesReqtified.esp")'
+      - 'KFR-Kryptopyr''sFixesReqtified.esp'
   - name: 'Requiem - WAF+CCF+TrueWeapons Patch.esp'
+    group: *requiemEarlyGroup
     inc:
-      - 'KFR-Kryptopyr''sFixesReqtified.esp")'
-  - name: 'Requiem - 83Willows 101Bugs.esp'
-    msg:
-      - <<: *replacerPluginForX
-        condition: 'file("83Willows_101BUGS_V4_LowRes.esp")'
-        subs: [ '83Willows_101BUGS_V4_LowRes.esp' ]
-      - <<: *replacerPluginForX
-        condition: 'file("83Willows_101BUGS_V4_HighRes.esp")'
-        subs: [ '83Willows_101BUGS_V4_HighRes.esp' ]
-      - <<: *replacerPluginForX
-        condition: 'file("83Willows_101BUGS_V4_LowerRes_HighSpawn.esp")'
-        subs: [ '83Willows_101BUGS_V4_LowerRes_HighSpawn.esp' ]
-      - <<: *replacerPluginForX
-        condition: 'file("83Willows_101BUGS_V4_HighRes_HighSpawn.esp")'
-        subs: [ '83Willows_101BUGS_V4_HighRes_HighSpawn.esp' ]
-  - name: 'Requiem - Explosive Bolts Visualized.esp'
-    msg:
-      - <<: *replacerPluginForX
-        condition: 'file("ExplosiveBoltsVisualized.esp")'
-        subs: [ 'ExplosiveBoltsVisualized.esp' ]
-  # Should lose conflicts because other patches may make important edits to the races
+      - 'KFR-Kryptopyr''sFixesReqtified.esp'
+  - name: 'Requiem - Cutting Room Floor.esp'
+    group: *requiemEarlyGroup
+  - name: 'Requiem - Audio Overhaul for Skyrim.esp'
+    group: *requiemEarlyGroup
+    after:
+      - 'Requiem - Cutting Room Floor.esp'
+      - 'KFR-Kryptopyr''sFixesReqtified.esp'
+      - 'COR-CraftingOverhaulReqtified.esp'
+  - name: 'Requiem - Immersive Sounds Compendium.esp'
+    group: *requiemEarlyGroup
+    after:
+      - 'KFR-Kryptopyr''sFixesReqtified.esp'
+      - 'COR-CraftingOverhaulReqtified.esp'
   - name: 'Requiem - Height Adjusted Races with True Giants.esp'
-    group: *requiemPatchesGroup
+    group: *requiemEarlyGroup
     msg:
       - <<: *replacerPluginForX
         condition: 'file("Height Adjusted Races.esp")'
@@ -9519,6 +9463,7 @@ plugins:
         condition: 'file("Height Adjusted Races with True Giants - Smaller Giant Edition.esp")'
         subs: [ 'Height Adjusted Races with True Giants - Smaller Giant Edition.esp' ]
   - name: 'Requiem - True Giants and Mammoths.esp'
+    group: *requiemEarlyGroup
     msg:
       - <<: *replacerPluginForX
         condition: 'file("Height Adjusted Races - True Giants and Mammoths.esp")'
@@ -9526,6 +9471,65 @@ plugins:
       - <<: *replacerPluginForX
         condition: 'file("Height Adjusted Races - True Giants and Mammoths - Smaller Giant Edition.esp")'
         subs: [ 'Height Adjusted Races - True Giants and Mammoths - Smaller Giant Edition.esp' ]
+  - name: 'COR-Campfire.esp'
+    req:
+      - 'COR-CraftingOverhaulReqtified.esp'
+  - name: 'COR-WetAndCold.esp'
+    req:
+      - 'COR-CraftingOverhaulReqtified.esp'
+  - name: 'COR-WoodenBows.esp'
+    req:
+      - 'COR-CraftingOverhaulReqtified.esp'
+  - name: 'Requiem - Guard Dialogue & Open Helmets.esp'
+    after:
+      - 'KFR-Kryptopyr''sFixesReqtified.esp'
+  - name: 'Requiem_Minor_Arcana.esp'
+    after:
+      - 'KFR-Kryptopyr''sFixesReqtified.esp'
+      - 'COR-CraftingOverhaulReqtified.esp'
+      - 'Open Face Guard Helmets.esp'
+      - 'Requiem - Guard Dialogue & Open Helmets.esp'
+      - 'Requiem - Immersive Spells.esp'
+      - 'Requiem - Civil War Overhaul Patch.esp'
+      - 'Requiem - ESF Companions.esp'
+    msg:
+      - <<: *reqPatchForX
+        condition: 'version("ESFCompanions.esp", "0.3.8", >=) and not active("Requiem_Minor_Arcana - ESF Companions.esp")'
+        subs: [ 'ESFCompanions.esp' ]
+  - name: 'Requiem - WRF_MinorArcana_MortalEnemies_TG.esp'
+    after:
+      - 'Requiem_Minor_Arcana.esp'
+  - name: 'Requiem - Immersive Horses.esp'
+    after:
+      - 'REQMOD.esp'
+  - name: 'Requiem - Immersive Horses - SkyTEST.esp'
+    req:
+      - 'Requiem - SkyTEST.esp'
+    after:
+      - 'REQMOD.esp'
+  - name: 'Requiem - Craftable Horse Barding.esp'
+    after:
+      - 'Requiem - Immersive Horses.esp'
+      - 'Requiem - Immersive Horses - SkyTEST.esp'
+  - name: 'Requiem - 83Willows 101Bugs.esp'
+    msg:
+      - <<: *replacerPluginForX
+        condition: 'file("83Willows_101BUGS_V4_LowRes.esp")'
+        subs: [ '83Willows_101BUGS_V4_LowRes.esp' ]
+      - <<: *replacerPluginForX
+        condition: 'file("83Willows_101BUGS_V4_HighRes.esp")'
+        subs: [ '83Willows_101BUGS_V4_HighRes.esp' ]
+      - <<: *replacerPluginForX
+        condition: 'file("83Willows_101BUGS_V4_LowerRes_HighSpawn.esp")'
+        subs: [ '83Willows_101BUGS_V4_LowerRes_HighSpawn.esp' ]
+      - <<: *replacerPluginForX
+        condition: 'file("83Willows_101BUGS_V4_HighRes_HighSpawn.esp")'
+        subs: [ '83Willows_101BUGS_V4_HighRes_HighSpawn.esp' ]
+  - name: 'Requiem - Explosive Bolts Visualized.esp'
+    msg:
+      - <<: *replacerPluginForX
+        condition: 'file("ExplosiveBoltsVisualized.esp")'
+        subs: [ 'ExplosiveBoltsVisualized.esp' ]
   - name: 'Requiem - Rustic Soulgems( - ISC)?\.esp'
     msg:
       - <<: *replacerPluginForX
@@ -9534,6 +9538,25 @@ plugins:
       - <<: *replacerPluginForX
         condition: 'file("RUSTIC SOULGEMS - Unsorted.esp")'
         subs: [ 'RUSTIC SOULGEMS - Unsorted.esp' ]
+  - name: 'Requiem - Difficulty Bar Restored.esp'
+    inc:
+      - 'Requiem - Difficulty Bar Restored - Nightmare.esp'
+  - name: 'Requiem - No Overencumbered Messages.esp'
+    inc:
+      - 'Requiem - No Messages.esp'
+  - name: 'Requiem - TrainUnitsPerLevel(0|5|10|100)\.esp'
+    msg:
+      - <<: *useOnlyOneX
+        condition: 'many("Requiem - TrainUnitsPerLevel(0|5|10|100)\.esp")'
+        subs: [ 'TrainUnitsPerLevel .esp file' ]
+  - name: 'Requiem - Weapon Damage Modifier (2|3)x Vanilla.esp'
+    msg:
+      - <<: *useOnlyOneX
+        condition: 'many("Requiem - TrainUnitsPerLevel(0|5|10|100)\.esp")'
+        subs: [ 'Requiem - Weapon Damage Modifier .esp file' ]
+  - name: 'Open Face Guard Helmets.esp'
+    after:
+      - 'KFR-Kryptopyr''sFixesReqtified.esp'
   - name: 'Bounty Gold.esp'
     after:
       - 'Requiem.esp'
@@ -16176,7 +16199,6 @@ plugins:
             text: '旧式のファイルです。Even Better Quest Objectivesのページ内にある個別パッチをご利用ください。[Nexus](http://www.nexusmods.com/skyrim/mods/32695)'
   # Should lose conflicts because other patches may make important edits to quests
   - name: BetterQuestObjectives-RequiemPatch.esp
-    group: *requiemPatchesGroup
     after:
       - 'ESFCompanions.esp'
     msg:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9491,6 +9491,9 @@ plugins:
     after:
       - 'Requiem - Immersive Horses.esp'
       - 'Requiem - Immersive Horses - SkyTEST.esp'
+  - name: 'Requiem - Deadly Dragons( - AOS)?\.esp'
+    after:
+      - 'Requiem - Wild World.esp'
   - name: 'Requiem - 83Willows 101Bugs.esp'
     msg:
       - <<: *replacerPluginForX

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -506,8 +506,14 @@ groups:
   - name: &requiemDLCGroup Requiem - DLC Patches
     after: [ *requiemBugsmasherGroup ]
 
-  - name: &requiemEarlyGroup Requiem - Early Patches
+  - name: &requiemWAFRGroup Requiem - WAFR & CCR
     after: [ *requiemDLCGroup ]
+
+  - name: &requiemCCORGroup Requiem - CCOR
+    after: [ *requiemWAFRGroup ]
+
+  - name: &requiemEarlyGroup Requiem - Early Patches
+    after: [ *requiemCCORGroup ]
 
   - name: &requiemPatchesGroup Requiem - Misc. Patches
     after: [ *requiemEarlyGroup ]
@@ -9376,65 +9382,42 @@ plugins:
       - 'Fozars_Dragonborn_-_Requiem_Patch.esp'
   - name: 'Fozars_Dragonborn_-_Requiem_Patch.esp'
     group: *requiemDLCGroup
+  - name: 'Requiem - WAF+Clothing and Clutter Fixes Patch.esp'
+    group: *requiemWAFRGroup
+    inc:
+      - 'KFR-Kryptopyr''sFixesReqtified.esp'
+  - name: 'Requiem - WAF+CCF+TrueWeapons Patch.esp'
+    group: *requiemWAFRGroup
+    inc:
+      - 'KFR-Kryptopyr''sFixesReqtified.esp'
   - name: 'KFR-Kryptopyr''sFixesReqtified.esp'
-    group: *requiemEarlyGroup
+    group: *requiemWAFRGroup
     msg:
       - <<: *reqPatchForX
         condition: 'active("Fozars_Dragonborn_-_Requiem_Patch.esp") and not active("KFR-FZR.esp")'
         subs: [ 'Fozar''s Dragonborn patch' ]
-  - name: 'KFR-FZR.esp'
-    group: *requiemEarlyGroup
-    req:
-      - 'KFR-Kryptopyr''sFixesReqtified.esp'
-      - 'Fozars_Dragonborn_-_Requiem_Patch.esp'
-  - name: 'KFR-NoHeavyStormcloaks.esp'
-    group: *requiemEarlyGroup
-    req:
-      - 'KFR-Kryptopyr''sFixesReqtified.esp'
-  - name: 'KFR-CircletsWithHoods.esp'
-    group: *requiemEarlyGroup
+  - name: 'KFR-(?!Kryptopyr''sFixesReqtified).+\.esp'
+    group: *requiemWAFRGroup
     req:
       - 'KFR-Kryptopyr''sFixesReqtified.esp'
   - name: 'COR-CraftingOverhaulReqtified.esp'
-    group: *requiemEarlyGroup
+    group: *requiemCCORGroup
     msg:
       - <<: *reqPatchForX
         condition: 'active("Fozars_Dragonborn_-_Requiem_Patch.esp") and not active("COR-FZR.esp")'
         subs: [ 'Fozar''s Dragonborn patch' ]
-  - name: 'COR-FZR.esp'
-    group: *requiemEarlyGroup
+  - name: 'COR-(?!CraftingOverhaulReqtified).+\.esp'
+    group: *requiemCCORGroup
     req:
       - 'COR-CraftingOverhaulReqtified.esp'
-      - 'Fozars_Dragonborn_-_Requiem_Patch.esp'
-  - name: 'COR-NoHeavyStormcloaks.esp'
-    group: *requiemEarlyGroup
-    req:
-      - 'COR-CraftingOverhaulReqtified.esp'
-  - name: 'COR-CircletsWithHoods.esp'
-    group: *requiemEarlyGroup
-    req:
-      - 'COR-CraftingOverhaulReqtified.esp'
-  - name: 'Requiem - WAF+Clothing and Clutter Fixes Patch.esp'
-    group: *requiemEarlyGroup
-    inc:
-      - 'KFR-Kryptopyr''sFixesReqtified.esp'
-  - name: 'Requiem - WAF+CCF+TrueWeapons Patch.esp'
-    group: *requiemEarlyGroup
-    inc:
-      - 'KFR-Kryptopyr''sFixesReqtified.esp'
   - name: 'Requiem - Cutting Room Floor.esp'
     group: *requiemEarlyGroup
   - name: 'Requiem - Audio Overhaul for Skyrim.esp'
     group: *requiemEarlyGroup
     after:
       - 'Requiem - Cutting Room Floor.esp'
-      - 'KFR-Kryptopyr''sFixesReqtified.esp'
-      - 'COR-CraftingOverhaulReqtified.esp'
   - name: 'Requiem - Immersive Sounds Compendium.esp'
     group: *requiemEarlyGroup
-    after:
-      - 'KFR-Kryptopyr''sFixesReqtified.esp'
-      - 'COR-CraftingOverhaulReqtified.esp'
   - name: 'Requiem - Height Adjusted Races with True Giants.esp'
     group: *requiemEarlyGroup
     msg:
@@ -9471,15 +9454,6 @@ plugins:
       - <<: *replacerPluginForX
         condition: 'file("Height Adjusted Races - True Giants and Mammoths - Smaller Giant Edition.esp")'
         subs: [ 'Height Adjusted Races - True Giants and Mammoths - Smaller Giant Edition.esp' ]
-  - name: 'COR-Campfire.esp'
-    req:
-      - 'COR-CraftingOverhaulReqtified.esp'
-  - name: 'COR-WetAndCold.esp'
-    req:
-      - 'COR-CraftingOverhaulReqtified.esp'
-  - name: 'COR-WoodenBows.esp'
-    req:
-      - 'COR-CraftingOverhaulReqtified.esp'
   - name: 'Requiem - Guard Dialogue & Open Helmets.esp'
     after:
       - 'KFR-Kryptopyr''sFixesReqtified.esp'
@@ -9589,6 +9563,12 @@ plugins:
       - 'Requiem.esp'
   - name: 'No Vendor or Loot Spells - Riverwood Trader Requiem.esp'
     req:
+      - 'Requiem.esp'
+  - name: 'Realistic AI Detection 2.*\.esp'
+    after:
+      - 'Requiem.esp'
+  - name: 'Requiem - Realistic Darkness.esp'
+    after:
       - 'Requiem.esp'
 ### End of Requiem's rules ###
   - name: 'Skyrim Hardcore Overhaul.esp'
@@ -26973,9 +26953,3 @@ plugins:
       - <<: *alreadyInX
         condition: 'active("Immersive Horses - Hearthfire Patch.esp") and version("Requiem - Immersive Horses - SkyTEST.esp", "1.63", >=)'
         subs: [ 'Requiem - Immersive Horses - SkyTEST.esp' ]
-  - name: 'Realistic AI Detection 2.*\.esp'
-    after:
-      - 'Requiem.esp'
-  - name: 'Requiem - Realistic Darkness.esp'
-    after:
-      - 'Requiem.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9479,14 +9479,13 @@ plugins:
   - name: 'Requiem - WRF_MinorArcana_MortalEnemies_TG.esp'
     after:
       - 'Requiem_Minor_Arcana.esp'
-  - name: 'Requiem - Immersive Horses.esp'
+  - name: 'Requiem - Immersive Horses( - SkyTEST)?\.esp'
     after:
       - 'REQMOD.esp'
+      - 'Requiem_Minor_Arcana.esp'
   - name: 'Requiem - Immersive Horses - SkyTEST.esp'
     req:
       - 'Requiem - SkyTEST.esp'
-    after:
-      - 'REQMOD.esp'
   - name: 'Requiem - Craftable Horse Barding.esp'
     after:
       - 'Requiem - Immersive Horses.esp'


### PR DESCRIPTION
There are now seven groups for Requiem and its patches

Group | Name | Purpose
--- | --- | ---
`&requiemGroup` | Requiem | Must be loaded near the end of the load order
`&requiemBugsmasherGroup`  | Requiem - Bugsmasher | Must be loaded directly after Requiem
`&requiemDLCGroup` | Requiem - DLC Patches | Must be loaded directly after the Bugsmasher
`&requiemWAFRGroup` | Requiem - WAFR & CCR Patches | Should be loaded before all other patches
`&requiemCCORGroup` | Requiem - CCOR Patches | Should be loaded before all other patches but after WAFR & CCR patches
`&requiemEarlyGroup` | Requiem - Early Patches | Should lose conflicts against most other patches
`&requiemPatchesGroup` | Requiem - Misc. Patches | The bulk of Requiem patches

At the moment `&requiemEarlyGroup` includes AOS, ISC, CRF and Height Adjusted Races.

Further changes:
- Removed `after` metadata that is superseded by the new groups.
- Removed severals comments that are essentially superseded by the new groups. E.g. there is little reason to have `# Must be loaded directly after Requiem.esp` before the Bugsmasher because the group `&requiemBugsmasherGroup` tells you exactly that.
- Moved some metadata to provide a more coherent overview of the rules for Requiem. This helped me while updating the metadata.

These changes are ready to be merged but they won't be enough to ensure that LOOT v0.13.1 creates a decent Requiem based load order. Two problems remain:

1. Any mod that must be loaded after Requiem will be loaded directly after Requiem, i.e. before the `&requiemBugsmasherGroup`. This isn't where such mods should be loaded. They should be loaded in or after `&requiemPatchesGroup`. They could be added to `&requiemPatchesGroup` but this has the disadvantage that they will always be loaded at the end of the load order even if Requiem isn't present.
2. Every single Requiem patch/addon/tweak must be manually added to `&requiemPatchesGroup` or it'll be loaded directly after Requiem, i.e. before the `&requiemBugsmasherGroup`. There over 100 such plugins floating around on the Nexus and I'm likely to miss some if I were to undertake this quest. And such an approach doesn't feel very LOOT-like.

I think LOOT is missing functionality here. `groups` are a great replacement for `global priority` but I don't see a replacement for `priority`. All that had to be done is to give `&requiemBugsmasherGroup`, `&requiemDLCGroup`, `&requiemWAFRGroup`, `&requiemCCORGroup` and `&requiemEarlyGroup` some kind of negative priority.
Or in different words: I want to stick `&requiemGroup`, `&requiemBugsmasherGroup`, `&requiemDLCGroup`, `&requiemWAFRGroup`, `&requiemCCORGroup` and `&requiemEarlyGroup` together so that no plugin from a different group may be loaded between them.
With such a feature `&requiemPatchesGroup` could be dropped entirely because every Requiem patch has Requiem.esp as master anyway.
Thoughts?