### PR TITLE
Fix - Cyclic interaction with alt start group mods.

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -509,11 +509,17 @@ groups:
   - name: &requiemPatchesGroup Requiem - Misc. Patches
     after: [ *requiemDragonbornGroup ]
 
-  - name: &alternateStartGroup Alternate Start & Requiem
+  - name: &ocsGroup Open Cities Skyrim
     after: [ *requiemPatchesGroup ]
 
-  - name: &lightingGroup Lighting
+  - name: &alternateStartGroup Alternate Start & Requiem
+    after: [ *ocsGroup ]
+
+  - name: &unlockedGroup Skyrim Unlocked
     after: [ *alternateStartGroup ]
+
+  - name: &lightingGroup Lighting
+    after: [ *unlockedGroup ]
 
   - name: &dynamicPatchGroup Dynamic Patches
     after: [ *lightingGroup ]
@@ -19076,7 +19082,7 @@ plugins:
         <<: *dirtyPlugin
         itm: 4
   - name: 'Open Cities Skyrim.esp'
-    group: *alternateStartGroup
+    group: *ocsGroup
     after:
       - 'Unique Region Names.esp'
       - 'URN+CoT Patch.esp'
@@ -26761,7 +26767,7 @@ plugins:
   - name: 'No Vendor or Loot Spells.esp'
     group: *reproccerGroup
   - name: 'Skyrim Unlocked.esp'
-    group: *alternateStartGroup
+    group: *unlockedGroup
     msg:
       - <<: *reqPatchForX
         condition: 'active("Open Cities Skyrim.esp") and not active("Skyrim Unlocked - Open Cities Skyrim Patch.esp")'
@@ -26788,8 +26794,6 @@ plugins:
       - 'Skyrim Unlocked.esp'
   - name: 'Open Cities Skyrim - Skyrim Unlocked Patch.esp'
     msg: [ *obsolete ]
-  - name: 'Requiem - Skyrim Unlocked.esp'
-    group: *alternateStartGroup
   - name: 'Craftable Horse Barding.esp'
     msg:
       - <<: *reqRequiemPatch

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -26786,11 +26786,17 @@ plugins:
   - name: 'Skyrim Unlocked - Immersive College of Winterhold Patch.esp'
     req:
       - 'Skyrim Unlocked.esp'
+    after:
+      - 'Skyrim Unlocked.esp'
   - name: 'Skyrim Unlocked - ESF Companions Patch.esp'
     req:
       - 'Skyrim Unlocked.esp'
+    after:
+      - 'Skyrim Unlocked.esp'
   - name: 'Skyrim Unlocked - Live Another Life Patch.esp'
     req:
+      - 'Skyrim Unlocked.esp'
+    after:
       - 'Skyrim Unlocked.esp'
   - name: 'Open Cities Skyrim - Skyrim Unlocked Patch.esp'
     msg: [ *obsolete ]


### PR DESCRIPTION
### [New Groups] Open Cities & Skyrim Unlocked 
To resolve the below conflict.

Cyclic interaction detected between "RE_OCS Patch.esp" and "Alternate Start - Live Another Life.esp". Back cycle: Alternate Start - Live Another Life.esp, Requiem - Live Another Life.esp, Open Cities Skyrim.esp, RE_OCS Patch.esp, RE_OCS Patch.esp #970


### Skyrim Unlocked - patches with load after main file rule.
Missing master so load after is required.