### PR TITLE
Load ELE after Alt Start to resolve Cyclic interaction

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -19480,6 +19480,15 @@ plugins:
     tag:
       - C.ImageSpace
       - C.Light
+  - name: 'ELE_Legendary_Lite.esp'
+    group: *lightingGroup
+    after:
+      - 'Immersive Citizens - AI Overhaul.esp'
+      - 'RelightingSkyrim_Legendary.esp'
+      - 'RelightingSkyrim.esp'
+    tag:
+      - C.ImageSpace
+      - C.Light
   - name: 'SV - The Indoors.esp'
     dirty:
       - crc: 0x51b712e6

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -19490,6 +19490,15 @@ plugins:
     tag:
       - C.ImageSpace
       - C.Light
+    dirty:
+      - <<: *dirtyPlugin
+        crc: 0x5176EB29
+        itm: 197
+        udr: 0
+        nav: 0
+    clean:
+      - crc: 0xE6A6AF93 # 0.9.5e STEP Specific
+        util: TES5Edit v3.2.2
   - name: 'SV - The Indoors.esp'
     dirty:
       - crc: 0x51b712e6

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -19483,6 +19483,7 @@ plugins:
   - name: 'ELE_Legendary_Lite.esp'
     group: *lightingGroup
     after:
+      - 'Alternate Start - Live Another Life.esp'
       - 'Immersive Citizens - AI Overhaul.esp'
       - 'RelightingSkyrim_Legendary.esp'
       - 'RelightingSkyrim.esp'


### PR DESCRIPTION
Failed to sort plugins. Details: Cyclic interaction detected between "ELE_Legendary_Lite.esp" and "STEP Extended Patch.esp". Back cycle: STEP Extended Patch.esp, Alternate Start - Live Another Life.esp, ELE_Legendary_Lite.esp