### PR TITLE
Remove Load after Open Cities from Immersive Citizens

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -26789,7 +26789,6 @@ plugins:
       - 'Civil War Repairs.esp'
       - 'EnhancedLightsandFX.esp'
       - 'ESFCompanions.esp'
-      - 'Open Cities Skyrim.esp'
       - 'Requiem.esp'
       - 'Thane''s Breezehome.esp'
       - 'Thornrock.esp'


### PR DESCRIPTION
Failed to sort plugins. Details: Cyclic interaction detected between "Open Cities Skyrim.esp" and "Immersive Citizens - AI Overhaul.esp". Back cycle: Immersive Citizens - AI Overhaul.esp, Requiem - Audio Overhaul for Skyrim.esp, Open Cities Skyrim.esp