### PR TITLE
Metadata from my load order

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -26980,6 +26980,9 @@ plugins:
     msg:
       - <<: *reqRequiemPatch
         condition: 'active("Requiem.esp") and not active("Requiem - Craftable Horse Barding.esp")'
+    clean:
+      - crc: 0x6859FBEB
+        util: TES5Edit v3.2.2
   - name: 'ExplosiveBoltsVisualized.esp'
     msg:
       - <<: *reqRequiemPatch

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27179,3 +27179,7 @@ plugins:
     clean:
       - crc: 0xECE5043D
         util: TES5Edit v3.2.2
+  - name: 'RSChildren.esp'
+    clean:
+      - crc: 0x80590F46
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27876,3 +27876,7 @@ plugins:
     clean:
       - crc: 0xB29E4940
         util: TES5Edit v3.2.2
+  - name: 'CTR_Patch_UniqueUniques.esp'
+    clean:
+      - crc: 0xEC92873B
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27371,3 +27371,7 @@ plugins:
     clean:
       - crc: 0x7417983A
         util: TES5Edit v3.2.2
+  - name: 'Skyshards.esp'
+    clean:
+      - crc: 0x06337759
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3753,6 +3753,9 @@ plugins:
       - crc: 0xa451e273
         <<: *dirtyPlugin
         itm: 1
+    clean:
+      - crc: 0x74CFC818
+        util: TES5Edit v3.2.2
   - name: 'Chesko_WearableLantern_Candle_DG.esp'
     inc:
       - 'Chesko_WearableLantern_Candle.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9679,6 +9679,12 @@ plugins:
   - name: 'Requiem - Realistic Darkness.esp'
     after:
       - 'Requiem.esp'
+  - name: 'Clairvoyance.esp'
+    after:
+      - 'Requiem.esp'
+    clean:
+      - crc: 0x51B691B1
+        util: TES5Edit v3.2.2
 ### End of Requiem's rules ###
   - name: 'Skyrim Hardcore Overhaul.esp'
     tag:
@@ -27957,8 +27963,4 @@ plugins:
   - name: 'Gildergreen Regrown.esp'
     clean:
       - crc: 0x5111AD5F
-        util: TES5Edit v3.2.2
-  - name: 'Clairvoyance.esp'
-    clean:
-      - crc: 0x51B691B1
         util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27725,3 +27725,11 @@ plugins:
     clean:
       - crc: 0xB99342D4
         util: TES5Edit v3.2.2
+  - name: 'Old Dusty travels again.esp'
+    dirty:
+      - <<: *dirtyPlugin
+        crc: 0x0104C73C
+        itm: 4
+    clean:
+      - crc: 0x3BAF6713
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27643,7 +27643,7 @@ plugins:
   - name: 'Ashes.esp'
     dirty:
       - <<: *dirtyPlugin
-        crc: 0x75d8b080
+        crc: 0x75D8B080
         itm: 2
     clean:
       - crc: 0x97235797
@@ -27656,7 +27656,7 @@ plugins:
     clean:
       - crc: 0xE3994512
         util: TES5Edit v3.2.2
-  - name: 'vividian - Wearable Lanterns Preset.esp'
+  - name: 'Vividian - Wearable Lanterns Preset.esp'
     clean:
       - crc: 0x38A6BDEA
         util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27360,3 +27360,7 @@ plugins:
     clean:
       - crc: 0xF56364D6
         util: TES5Edit v3.2.2
+  - name: 'Skysan_ELFX_SMIM_Fix.esp'
+    clean:
+      - crc: 0xE00C98FB
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27237,7 +27237,7 @@ plugins:
   - name: 'Helsmyrr.esp'
     dirty:
       - <<: *dirtyPlugin
-        crc: 0x9c56e282
+        crc: 0xB9BF0C74
         itm: 157
         udr: 58
   - name: 'Sea of Spirits.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27229,3 +27229,8 @@ plugins:
         <<: *dirtyPlugin
         itm: 157
         udr: 58
+  - name: 'Sea of Spirits.esp'
+    dirty:
+      - crc: 0xDCD3E352
+        <<: *dirtyPlugin
+        itm: 123

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27223,3 +27223,9 @@ plugins:
     clean:
       - crc: 0xEB33640C
         util: TES5Edit v3.2.2
+  - name: 'Helsmyrr.esp'
+    dirty:
+      - crc: 0x9c56e282
+        <<: *dirtyPlugin
+        itm: 157
+        udr: 58

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27744,3 +27744,7 @@ plugins:
     clean:
       - crc: 0x24F346A6
         util: TES5Edit v3.2.2
+  - name: 'goldpilesyum.esp'
+    clean:
+      - crc: 0x24F346A6
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -19245,6 +19245,9 @@ plugins:
         <<: *dirtyPlugin
         itm: 6
         udr: 0
+    clean:
+      - crc: 0xB7EB16BF
+        util: TES5Edit v3.2.2
   - name: 'ELFX - Moonpath.esp'
     after:
       - 'rcrnShaders.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27861,6 +27861,9 @@ plugins:
   - name: 'more idle markers.esp'
     after:
       - 'Immersive Citizens - AI Overhaul.esp'
+    clean:
+      - crc: 0xC5DC3E93
+        util: TES5Edit v3.2.2
   - name: 'Tes Arena -Skyrim Cities.esp'
     clean:
       - crc: 0x39D0E506

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27289,3 +27289,7 @@ plugins:
     clean:
       - crc: 0xD4355BE5
         util: TES5Edit v3.2.2
+  - name: 'Holidays.esp'
+    clean:
+      - crc: 0x8B93B372
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2790,6 +2790,9 @@ plugins:
         <<: *dirtyPlugin
         itm: 7
         udr: 0
+    clean:
+      - crc: 0x5B5430F7
+        util: TES5Edit v3.2.2
   - name: 'AOS2_DD Patch.esp'
     msg:
       - <<: *alreadyInX

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27773,3 +27773,8 @@ plugins:
     clean:
       - crc: 0x3383968A
         util: TES5Edit v3.2.2
+  - name: 'RoleplayNotes.esp'
+    dirty:
+      - <<: *dirtyPlugin
+        crc: 0x9440F010
+        itm: 8

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27968,3 +27968,7 @@ plugins:
     clean:
       - crc: 0x6E6C7E2D
         util: TES5Edit v3.2.2
+  - name: 'Quest Markers Restored.esp'
+    group: *underridesGroup
+    after:
+      - 'BetterQuestObjectives.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27737,3 +27737,7 @@ plugins:
     clean:
       - crc: 0xEF373FDB
         util: TES5Edit v3.2.2
+  - name: 'Laundry.esp'
+    clean:
+      - crc: 0x24F346A6
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27524,3 +27524,7 @@ plugins:
     clean:
       - crc: 0x517413C4
         util: TES5Edit v3.2.2
+  - name: 'AshRocks.esp'
+    clean:
+      - crc: 0x64EB9F73
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27946,3 +27946,7 @@ plugins:
     clean:
       - crc: 0xE4C85756
         util: TES5Edit v3.2.2
+  - name: 'Sensible Hardcore Compass.esp'
+    clean:
+      - crc: 0x4BB71F58
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -26577,6 +26577,9 @@ plugins:
       - crc: 0x1C59B53A
         <<: *dirtyPlugin
         itm: 17
+    clean:
+      - crc: 0x59963275
+        util: TES5Edit v3.2.2
     url: [ 'http://www.nexusmods.com/skyrim/mods/62886' ]
   - name: 'MoreBanditCamps(Explorer''sEdition).esp'
     dirty:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27151,3 +27151,7 @@ plugins:
     clean:
       - crc: 0x097D7FB3
         util: TES5Edit v3.2.2
+  - name: 'attack commitment movement speed fluid 3.esp'
+    clean:
+      - crc: 0x4530C736
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27085,6 +27085,10 @@ plugins:
       - <<: *alreadyInX
         condition: 'active("Requiem - Inconsequential NPCs - Enhancement.esp")'
         subs: [ 'Requiem - Inconsequential NPCs - Enhancement.esp' ]
+  - name: 'Inconsequential NPCs - CRF Compatibility Patch.esp'
+    clean:
+      - crc: 0xBDE8703C
+        util: TES5Edit v3.2.2
   - name: 'RUSTIC SOULGEMS - (Uns|S)orted\.esp'
     msg:
       - <<: *reqRequiemPatch

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -24546,8 +24546,6 @@ plugins:
           - lang: ja
             text: 'Live Another Life.espが見つかりました。新バージョンを使う前に古いバージョンをアンインストールしてください。'
         condition: 'file("Live Another Life.esp")'
-      - <<: *reqRequiemPatch
-        condition: 'active("Requiem.esp") and not active("Requiem - Live Another Life.esp")'
     tag:
       - C.Location
     clean:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7360,6 +7360,9 @@ plugins:
       - crc: 0x3A0B75F5
         <<: *dirtyPlugin
         itm: 2
+    clean:
+      - crc: 0x0E41D31D
+        util: TES5Edit v3.2.2
   - name: 'imp_helm.esp'
     dirty:
       - crc: 0xb5cc3f9d

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9618,6 +9618,9 @@ plugins:
       - <<: *replacerPluginForX
         condition: 'file("RUSTIC SOULGEMS - Unsorted.esp")'
         subs: [ 'RUSTIC SOULGEMS - Unsorted.esp' ]
+  - name: 'Requiem - Timing Is Everything.esp'
+    after:
+      - 'Requiem_Minor_Arcana.esp'
   - name: 'Requiem - Difficulty Bar Restored.esp'
     inc:
       - 'Requiem - Difficulty Bar Restored - Nightmare.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -22836,7 +22836,9 @@ plugins:
         <<: *dirtyPlugin
         itm: 8
   - name: 'SeaPointSettlement.esp'
-    msg: [ *doNotClean ]
+    clean:
+      - crc: 0x0CA559AA
+        util: TES5Edit v3.2.2
   - name: 'SerenitySeapointPatch.esp'
     dirty:
       - crc: 0x74F86411

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -20898,6 +20898,9 @@ plugins:
   - name: 'DeadlySpellImpacts.esp'
     after:
       - 'balanceddestructionv4.esp'
+    clean:
+      - crc: 0x455C0C6A
+        util: TES5Edit v3.2.2
   - name: 'DeadlySpellImpacts - Two Fire.esp'
     after:
       - 'DeadlySpellImpacts.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2713,6 +2713,9 @@ plugins:
       - crc: 0x2cc974e4
         <<: *dirtyPlugin
         itm: 4
+    clean:
+      - crc: 0xFD718044
+        util: TES5Edit v3.2.2
   - name: 'PNENB.esp'
     msg:
       - type: say

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27446,3 +27446,7 @@ plugins:
     clean:
       - crc: 0x2C24D5A5
         util: TES5Edit v3.2.2
+  - name: 'Undriel_Everlight.esp'
+    clean:
+      - crc: 0xDE8C3380
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27693,3 +27693,7 @@ plugins:
     clean:
       - crc: 0x7DB8A4C3
         util: TES5Edit v3.2.2
+  - name: 'WM Shahvee Fix.esp'
+    clean:
+      - crc: 0x7405C5A4
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27484,3 +27484,7 @@ plugins:
     clean:
       - crc: 0x1F81BED9
         util: TES5Edit v3.2.2
+  - name: 'FireBurns.esp'
+    clean:
+      - crc: 0x0A36ACF2
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -26752,7 +26752,6 @@ plugins:
     clean:
       - crc: 0xB536FDD0
         util: TES5Edit v3.1.3
-    clean:
       - crc: 0x321C14B7
         util: TES5Edit v3.2.2
   - name: 'CompanionArissa.esm'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27752,3 +27752,7 @@ plugins:
     clean:
       - crc: 0xE7FEF2BC
         util: TES5Edit v3.2.2
+  - name: 'LessCharitableNPCs.esp'
+    clean:
+      - crc: 0x276EDB97
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -26975,6 +26975,9 @@ plugins:
     msg:
       - <<: *reqRequiemPatch
         condition: 'active("Requiem.esp") and not active("Requiem - Immersive Sounds Compendium.esp")'
+    clean:
+      - crc: 0x82A29913
+        util: TES5Edit v3.2.2
   - name: 'imp_helm_legend.esp'
     msg:
       - <<: *reqRequiemPatch

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27500,3 +27500,7 @@ plugins:
     clean:
       - crc: 0x3EE05DD0
         util: TES5Edit v3.2.2
+  - name: 'UniqueBarbas.esp'
+    clean:
+      - crc: 0x32B261A7
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -26958,13 +26958,19 @@ plugins:
       - 'Civil War Repairs.esp'
       - 'EnhancedLightsandFX.esp'
       - 'ESFCompanions.esp'
+      - 'Hidden Hideouts of Skyrim City Edition - Merged.esp'
+      - 'Hidden Hideouts of Skyrim City Edition - Merged - No Map Markers.esp'
+      - 'Hidden Hideouts of Skyrim City Edition - Merged - Deep Immersion.esp'
+      - '3DNPC.esp'
+      - 'RayeksEnd.esp'
       - 'Requiem.esp'
-      - 'Thane''s Breezehome.esp'
-      - 'Thornrock.esp'
       - 'Routa.esp'
       - 'Routa Non-Stormcloak.esp'
+      - 'SkyfallEstateBuildable.esp'
+      - 'Thane''s Breezehome.esp'
+      - 'Thornrock.esp'
+      - 'Whiterun Complete.esp'
       - 'nTr4nc3 - Whiterun Mansion.esp'
-      - '3DNPC.esp'
     tag:
       - C.Owner
     clean:
@@ -27407,6 +27413,8 @@ plugins:
       - crc: 0x4D36AC80
         util: TES5Edit v3.2.2
   - name: 'Arthmoor''s Skyrim Villages - All In One.esp'
+    after:
+      - 'Immersive Citizens - AI Overhaul.esp'
     clean:
       - crc: 0x5E034168
         util: TES5Edit v3.2.2
@@ -27848,3 +27856,6 @@ plugins:
     clean:
       - crc: 0x01B6B69D
         util: TES5Edit v3.2.2
+  - name: 'more idle markers.esp'
+    after:
+      - 'Immersive Citizens - AI Overhaul.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27856,3 +27856,7 @@ plugins:
   - name: 'more idle markers.esp'
     after:
       - 'Immersive Citizens - AI Overhaul.esp'
+  - name: 'Tes Arena -Skyrim Cities.esp'
+    clean:
+      - crc: 0x39D0E506
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27821,3 +27821,7 @@ plugins:
     clean:
       - crc: 0x6DBF6EA1
         util: TES5Edit v3.2.2
+  - name: 'Sinking Bodies.esp'
+    clean:
+      - crc: 0x3F9A636F
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -12143,6 +12143,9 @@ plugins:
       - crc: 0x350cacf3
         <<: *dirtyPlugin
         itm: 10
+    clean:
+      - crc: 0xCE70123B
+        util: TES5Edit v3.2.2
   - name: 'CWIDragonbornPatch.esp'
     after:
       - 'CollegeOfWinterholdImmersive.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27814,3 +27814,7 @@ plugins:
     clean:
       - crc: 0xD26D9030
         util: TES5Edit v3.2.2
+  - name: 'GuardAnimationsGDO.esp'
+    clean:
+      - crc: 0x6DBF6EA1
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27264,3 +27264,7 @@ plugins:
     clean:
       - crc: 0x81FBA022
         util: TES5Edit v3.2.2
+  - name: 'LOS ELFX Consistency Patch.esp'
+    clean:
+      - crc: 0x86CC1C61
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27515,9 +27515,6 @@ plugins:
         crc: 0x7CAE947E
         itm: 26
         udr: 17
-    clean:
-      - crc: 0xE318D109
-        util: TES5Edit v3.2.2
   - name: 'Understone Keep Repair.esp'
     clean:
       - crc: 0xF56364D6

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -26753,6 +26753,8 @@ plugins:
     clean:
       - crc: 0xA2139F9F
         util: TES5Edit v3.1.3
+      - crc: 0x19F37A2F
+        util: TES5Edit v3.2.2
   - name: 'UsefulDogs.esp'
     clean:
       - crc: 0x1CF6B89B

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27103,3 +27103,7 @@ plugins:
     clean:
       - crc: 0xC6E86A52
         util: TES5Edit v3.2.2
+  - name: 'honedmetal.esp'
+    clean:
+      - crc: 0x60DCC06C
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -16317,7 +16317,7 @@ plugins:
   - name: 'Book Covers Skyrim - Lost Library.esp'
     clean:
       - crc: 0x8F56DE23
-        util: TES5Edit v3.1.3
+        util: TES5Edit v3.2.2
   - name: 'Headbomb''s Better Sorting - Ammo.esp'
     msg:
       - <<: *patchOutSub

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27022,6 +27022,13 @@ plugins:
     msg:
       - <<: *reqRequiemPatch
         condition: 'active("Requiem.esp") and not active("Requiem - Inconsequential NPCs.esp")'
+    dirty:
+      - <<: *dirtyPlugin
+        crc: 0x773D467E
+        itm: 2
+    clean:
+      - crc: 0xF79D853E
+        util: TES5Edit v3.2.2
   - name: 'Inconsequential NPCs - Enhancement.esp'
     msg:
       - <<: *reqRequiemPatch

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27504,3 +27504,7 @@ plugins:
     clean:
       - crc: 0x32B261A7
         util: TES5Edit v3.2.2
+  - name: 'BentPines_for_SFO2.0.esp'
+    clean:
+      - crc: 0x5D4989D3
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -12759,6 +12759,9 @@ plugins:
         itm: 15
         udr: 0
         nav: 16
+    clean:
+      - crc: 0x0FFF5BB1
+        util: TES5Edit v3.2.2
   - name: 'Fantasy Markarth.esp'
     dirty:
       - crc: 0x5794a36f

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27356,3 +27356,7 @@ plugins:
     clean:
       - crc: 0xE318D109
         util: TES5Edit v3.2.2
+  - name: 'Understone Keep Repair.esp'
+    clean:
+      - crc: 0xF56364D6
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27070,3 +27070,7 @@ plugins:
   - name: 'No Snow Under The Roof - CRF Patch.esp'
     after:
       - 'CRF - Lighting Overhaul.esp'
+  - name: 'CRF - Lighting Overhaul.esp'
+    clean:
+      - crc: 0x2B77F815
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27921,3 +27921,16 @@ plugins:
     clean:
       - crc: 0x3D6CFB11
         util: TES5Edit v3.2.2
+  - name: 'HallgarthsforNPCs.esp'
+    msg:
+      - <<: *hasWildEdits
+        subs:
+          - '[Manual Cleaning Guide](https://www.nexusmods.com/skyrim/mods/93719)'
+        condition: 'checksum("HallgarthsforNPCs.esp", C62D0DBD)'
+    dirty:
+      - <<: *dirtyPlugin
+        crc: 0x058841E0
+        itm: 3
+    clean:
+      - crc: 0x9FE950EF
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2704,6 +2704,9 @@ plugins:
       - crc: 0x541965a9
         <<: *dirtyPlugin
         itm: 6
+    clean:
+      - crc: 0x1A5860EB
+        util: TES5Edit v3.2.2
   - name: 'Morning Fogs.esp'
     ## very old versions incompatible with 'Supreme Fog.esp' but unlikely to be used anymore
     dirty:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27472,3 +27472,7 @@ plugins:
     clean:
       - crc: 0xD9020262
         util: TES5Edit v3.2.2
+  - name: 'Ravengate.esp'
+    clean:
+      - crc: 0x1F5051F9
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -26964,6 +26964,9 @@ plugins:
     msg:
       - <<: *reqRequiemPatch
         condition: 'active("Requiem.esp") and not active("RDO - Requiem Patch.esp")'
+    clean:
+      - crc: 0x6EA57C0D
+        util: TES5Edit v3.2.2
   - name: 'CFTO.esp'
     after:
       - 'Immersive Citizens - AI Overhaul.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -5417,6 +5417,9 @@ plugins:
       - crc: 0xfab40701
         <<: *dirtyPlugin
         itm: 8
+    clean:
+      - crc: 0x5C2E5564
+        util: TES5Edit v3.2.2
   - name: 'Skyrim Scaling Stopper - Misc Edits.esp'
     msg:
       - type: warn

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1355,6 +1355,9 @@ plugins:
         crc: 0x1E83E045
         itm: 24
         udr: 0
+    clean:
+      - crc: 0xAC4A653A
+        util: TES5Edit v3.2.2
   - name: 'LB_MuchAdoSnowElves.esm'
     msg:
       - type: warn

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27383,3 +27383,8 @@ plugins:
     clean:
       - crc: 0x138FAF5E
         util: TES5Edit v3.2.2
+  - name: 'skycity3.esp'
+    dirty:
+      - <<: *dirtyPlugin
+        crc: 0xD31A8590
+        itm: 20

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27994,3 +27994,7 @@ plugins:
     clean:
       - crc: 0x75647A7E
         util: TES5Edit v3.2.2
+  - name: 'FNIS.esp'
+    clean:
+      - crc: 0xB1685AD7
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27250,3 +27250,7 @@ plugins:
     clean:
       - crc: 0x159E003B
         util: TES5Edit v3.2.2
+  - name: 'Better Series - All in one.esp'
+    clean:
+      - crc: 0x210D0753
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27092,3 +27092,7 @@ plugins:
     clean:
       - crc: 0x3C97A13F
         util: TES5Edit v3.2.2
+  - name: 'Footprints.esp'
+    clean:
+      - crc: 0xE87C93C0
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27998,3 +27998,19 @@ plugins:
     clean:
       - crc: 0xB1685AD7
         util: TES5Edit v3.2.2
+  - name: 'WSCO - OcciFemaleUNP.esp'
+    dirty:
+      - <<: *dirtyPlugin
+        crc: 0xF5522805
+        itm: 1
+    clean:
+      - crc: 0x33778607
+        util: TES5Edit v3.2.2
+  - name: 'WSCO - OcciBetterMale.esp'
+    clean:
+      - crc: 0x4A060D3A
+        util: TES5Edit v3.2.2
+  - name: 'WSCO - Better NPCs.esp'
+    clean:
+      - crc: 0xBDF72EB9
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27178,6 +27178,10 @@ plugins:
     clean:
       - crc: 0x74155306
         util: TES5Edit v3.2.2
+  - name: 'NotSoFast-MainQuest.esp'
+    clean:
+      - crc: 0x91C64D49
+        util: TES5Edit v3.2.2
   - name: 'NotSoFast-MageGuild.esp'
     clean:
       - crc: 0xECE5043D

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27840,3 +27840,11 @@ plugins:
     clean:
       - crc: 0xB59266B3
         util: TES5Edit v3.2.2
+  - name: 'DoorAnswersSolvable.esp'
+    dirty:
+      - <<: *dirtyPlugin
+        crc: 0x8F8299D3
+        itm: 1
+    clean:
+      - crc: 0x01B6B69D
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -26748,6 +26748,9 @@ plugins:
   - name: 'GuardAnimationsGDO.esp'
     after:
       - 'Guard Dialogue Overhaul.esp'
+    clean:
+      - crc: 0x6DBF6EA1
+        util: TES5Edit v3.2.2
   - name: 'GuardAnimations.esp'
     msg:
       - type: warn
@@ -27816,10 +27819,6 @@ plugins:
   - name: 'AnonymousPeople.esp'
     clean:
       - crc: 0xD26D9030
-        util: TES5Edit v3.2.2
-  - name: 'GuardAnimationsGDO.esp'
-    clean:
-      - crc: 0x6DBF6EA1
         util: TES5Edit v3.2.2
   - name: 'Sinking Bodies.esp'
     clean:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27810,3 +27810,7 @@ plugins:
     clean:
       - crc: 0x7FBFA8F4
         util: TES5Edit v3.2.2
+  - name: 'AnonymousPeople.esp'
+    clean:
+      - crc: 0xD26D9030
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27685,3 +27685,7 @@ plugins:
     clean:
       - crc: 0x209727D0
         util: TES5Edit v3.2.2
+  - name: 'SmartNoMoreStupidDogDGHF.esp'
+    clean:
+      - crc: 0xA218BECA
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27806,3 +27806,7 @@ plugins:
     clean:
       - crc: 0xE3A89A78
         util: TES5Edit v3.2.2
+  - name: 'MoreThugsForPettyThieves.esp'
+    clean:
+      - crc: 0x7FBFA8F4
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27756,3 +27756,7 @@ plugins:
     clean:
       - crc: 0x276EDB97
         util: TES5Edit v3.2.2
+  - name: 'Give Beggars Food.esp'
+    clean:
+      - crc: 0x20EF9B40
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27203,3 +27203,7 @@ plugins:
     clean:
       - crc: 0x40FA36B0
         util: TES5Edit v3.2.2
+  - name: '360WalkandRunPlus-RunBackwardSpeedAdjust.esp'
+    clean:
+      - crc: 0xB2AF9437
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27453,3 +27453,7 @@ plugins:
     clean:
       - crc: 0xDE8C3380
         util: TES5Edit v3.2.2
+  - name: 'Windhelm's Ancient Lighthouse.esp'
+    clean:
+      - crc: 0x9BC1D211
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27207,3 +27207,7 @@ plugins:
     clean:
       - crc: 0xB2AF9437
         util: TES5Edit v3.2.2
+  - name: 'Campfire BDS Patch.esp'
+    clean:
+      - crc: 0x3F8BB3E9
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27892,3 +27892,7 @@ plugins:
     clean:
       - crc: 0xE0AE72B7
         util: TES5Edit v3.2.2
+  - name: 'Palaces Castles Enhanced.esp'
+    clean:
+      - crc: 0xC1A5DE76
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27717,3 +27717,11 @@ plugins:
     clean:
       - crc: 0xDD298BEE
         util: TES5Edit v3.2.2
+  - name: 'Farmers Sell Produce - Skyrim.esp'
+    dirty:
+      - <<: *dirtyPlugin
+        crc: 0x3B13F994
+        itm: 38
+    clean:
+      - crc: 0xB99342D4
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27837,3 +27837,7 @@ plugins:
     clean:
       - crc: 0x867372A2
         util: TES5Edit v3.2.2
+  - name: 'TGBC.esp'
+    clean:
+      - crc: 0xB59266B3
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27954,3 +27954,7 @@ plugins:
     clean:
       - crc: 0x1AC40D82
         util: TES5Edit v3.2.2
+  - name: 'Gildergreen Regrown.esp'
+    clean:
+      - crc: 0x5111AD5F
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27746,7 +27746,7 @@ plugins:
         util: TES5Edit v3.2.2
   - name: 'goldpilesyum.esp'
     clean:
-      - crc: 0x24F346A6
+      - crc: 0xD9F2A807
         util: TES5Edit v3.2.2
   - name: 'OH GOD BEES.esp'
     clean:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27464,3 +27464,7 @@ plugins:
     clean:
       - crc: 0xDFF70AC9
         util: TES5Edit v3.2.2
+  - name: 'ThiefsHideout.esp'
+    clean:
+      - crc: 0xEBCD3A30
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -17130,6 +17130,9 @@ plugins:
         subs: [ '[RSChildren USKP Patch](http://www.nexusmods.com/skyrim/mods/55555/)' ]
       - <<: *reqRequiemPatch
         condition: 'active("Requiem.esp") and not active("Requiem - RS Children Overhaul.esp")'
+    clean:
+      - crc: 0x2A38FA45
+        util: TES5Edit v3.2.2
   - name: 'RSChildren - Complete.esp'
     msg:
       - <<: *reqRequiemPatch

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27010,6 +27010,9 @@ plugins:
     msg:
       - <<: *reqRequiemPatch
         condition: 'active("Requiem.esp") and not active("Requiem - Immersive Horses.esp") and not active("Requiem - Immersive Horses - SkyTEST.esp")'
+    clean:
+      - crc: 0x04F12565
+        util: TES5Edit v3.2.2
   - name: 'Immersive Patrols II.esp'
     msg:
       - <<: *reqRequiemPatch

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -805,7 +805,7 @@ plugins:
       - Relev
       - Stats
     dirty:
-      ## (TES5EDIT v3.2.1) Version 1.9.32.0 - Original 
+      ## (TES5EDIT v3.2.1) Version 1.9.32.0 - Original
       - <<: *dirtyPlugin
         crc: 0xA9F83BFF
         itm: 61
@@ -883,7 +883,7 @@ plugins:
         util: TES5Edit v3.1.3
         # v3.0.13a
       - crc: 0xF92F6237
-        util: TES5EDIT v3.2.2
+        util: TES5EDIT v3.2.1
 # Falskaar is stated to be an "unofficial DLC", it should be loaded right after the Beth DLCs, logically. - William
   - name: 'Falskaar.esm'
     group: *newLandsGroup
@@ -2514,10 +2514,6 @@ plugins:
     clean:
       - crc: 0xFC447339
         util: TES5Edit v3.2.2
-  - name: 'The Eyes Of Beauty - Elves Edition.esp'
-    clean:
-      - crc: 0xAFF2DA5E
-        util: TES5Edit v3.2.2
   - name: 'ColourEyesNoDGHF.esp'
     dirty:
       - crc: 0x3b2f32fc
@@ -2848,10 +2844,6 @@ plugins:
         udr: 0
     clean:
       - crc: 0xEA312F01
-        util: TES5Edit v3.2.2
-  - name: 'Prometheus_NSUTR BDS Patch.esp'
-    clean:
-      - crc: 0x0513DEE7
         util: TES5Edit v3.2.2
   - name: 'DFG''s Blade & Dagger Sheathe Sounds.esp'
     dirty:
@@ -5710,13 +5702,13 @@ plugins:
       - 'SKSE Hotkeys.esp'
     clean:
       - crc: 0x762DC693
-        util: TES5Edit v3.2.2
+        util: TES5Edit v3.1.3
   - name: 'WetandCold - Ashes.esp'
     after:
       - 'SKSE Hotkeys.esp'
     clean:
       - crc: 0x3D7CC687
-        util: TES5Edit v3.2.2
+        util: TES5Edit v3.1.3
   - name: 'Where''s My Horse Gone Essential Horses.esp'
     inc:
       - 'Where''s My Horse Gone.esp'
@@ -6061,12 +6053,12 @@ plugins:
         condition: 'version("SkyUI.esp", "4", >=) and version("Fhaarkas Font Mod - SkyUI.esp", "4.0", ==)'
     clean:
       - crc: 0xBEA2DC76
-        util: TES5Edit v3.2.2
+        util: TES5Edit v3.1.3
   - name: 'iHUD.esp'
     req: [ *SKSE ]
     clean:
       - crc: 0x6098B756
-        util: TES5Edit v3.2.2
+        util: TES5Edit v3.1.3
   - name: 'LessIntrusiveHUD.esp'
     req:
       - *SKSE
@@ -8310,6 +8302,16 @@ plugins:
     msg:
       - <<: *patchOutSub
         condition: 'not checksum("SeraphimStandAlone.esp",556E0B68)'
+  - name: 'SeraphineHuntedArmor.esp'
+    msg:
+      - type: say
+        content:
+          - lang: en
+            text: 'Be sure you have the correct body mod for the esp. [DIMONIZED UNP](http://www.nexusmods.com/skyrim/mods/6709) or [CBBE](http://www.nexusmods.com/skyrim/mods/2666).'
+          - lang: ru
+            text: 'Убедитесь, что используете корректный реплейсер тел для этого esp. [DIMONIZED UNP](http://www.nexusmods.com/skyrim/mods/6709) или [CBBE](http://www.nexusmods.com/skyrim/mods/2666).'
+          - lang: ja
+            text: '必ず[DIMONIZED UNP](http://www.nexusmods.com/skyrim/mods/6709)か[CBBE](http://www.nexusmods.com/skyrim/mods/2666)のうち、インストールされている体型Modと同じバージョンのEspを使用してください。.'
   - name: 'SeraticArmor.esp'
     tag:
       - name: Deactivate
@@ -16350,10 +16352,6 @@ plugins:
       - <<: *alreadyInX
         condition: 'file("Book Covers Skyrim.esp") and checksum("Book Covers Skyrim.esp",B8DA5EF5)'
         subs: [ 'Book Covers Skyrim.esp' ]
-  - name: 'Book Covers Skyrim - Lost Library.esp'
-    clean:
-      - crc: 0x8F56DE23
-        util: TES5Edit v3.2.2
   - name: 'Headbomb''s Better Sorting - Ammo.esp'
     msg:
       - <<: *patchOutSub
@@ -23769,6 +23767,14 @@ plugins:
     msg:
       - <<: *corrupt
         condition: 'checksum("Illdi.esp",B941754D)'
+      - type: say
+        content:
+          - lang: en
+            text: 'Be sure you have the correct body mod for the esp. [DIMONIZED UNP](http://www.nexusmods.com/skyrim/mods/6709) or [CBBE](http://www.nexusmods.com/skyrim/mods/2666).'
+          - lang: ru
+            text: 'Убедитесь, что используете корректный реплейсер тел для этого esp. [DIMONIZED UNP](http://www.nexusmods.com/skyrim/mods/6709) или [CBBE](http://www.nexusmods.com/skyrim/mods/2666).'
+          - lang: ja
+            text: '必ず[DIMONIZED UNP](http://www.nexusmods.com/skyrim/mods/6709)か[CBBE](http://www.nexusmods.com/skyrim/mods/2666)のうち、インストールされている体型Modと同じバージョンのEspを使用してください。.'
   - name: 'ImaniSuda.esp'
     msg:
       - <<: *corrupt
@@ -23876,6 +23882,16 @@ plugins:
         condition: 'checksum("Kitana.esp",BCF5969B) or checksum("Kitana.esp",2077B972)'
   - name: 'KMM_2a.esp'
     msg: [ *obsolete ]
+  - name: 'Lia.esp'
+    msg:
+      - type: say
+        content:
+          - lang: en
+            text: 'Be sure you have the correct body mod for the esp. [DIMONIZED UNP](http://www.nexusmods.com/skyrim/mods/6709) or [CBBE](http://www.nexusmods.com/skyrim/mods/2666).'
+          - lang: ru
+            text: 'Убедитесь, что используете корректный реплейсер тел для этого esp. [DIMONIZED UNP](http://www.nexusmods.com/skyrim/mods/6709) или [CBBE](http://www.nexusmods.com/skyrim/mods/2666).'
+          - lang: ja
+            text: '必ず[DIMONIZED UNP](http://www.nexusmods.com/skyrim/mods/6709)か[CBBE](http://www.nexusmods.com/skyrim/mods/2666)のうち、インストールされている体型Modと同じバージョンのEspを使用してください。.'
   - name: 'LianVera-v2.1.esp'
     msg: [ *obsolete ]
     dirty:
@@ -27031,8 +27047,6 @@ plugins:
         util: TES5Edit v3.2.2
   - name: 'Relationship Dialogue Overhaul.esp'
     after:
-      - 'Alternate Start - Live Another Life.esp'
-      - 'Guard Dialogue Overhaul.esp'
       - 'Immersive Citizens - AI Overhaul.esp'
       - 'Inconsequential NPCs.esp'
     msg:
@@ -27191,7 +27205,6 @@ plugins:
         util: TES5Edit v3.2.2
   - name: 'imp_helm_legend.esp'
     msg:
-      - *doNotClean
       - <<: *reqRequiemPatch
         condition: 'active("Requiem.esp") and not active("Requiem - Improved Closefaced Helmets.esp")'
     tag:
@@ -27214,10 +27227,6 @@ plugins:
       - <<: *alreadyInX
         condition: 'active("Requiem - Inconsequential NPCs - Enhancement.esp")'
         subs: [ 'Requiem - Inconsequential NPCs - Enhancement.esp' ]
-  - name: 'Inconsequential NPCs - CRF Compatibility Patch.esp'
-    clean:
-      - crc: 0xBDE8703C
-        util: TES5Edit v3.2.2
   - name: 'RUSTIC SOULGEMS - (Uns|S)orted\.esp'
     msg:
       - <<: *reqRequiemPatch
@@ -27361,6 +27370,9 @@ plugins:
     group: *underridesGroup
     after:
       - 'BetterQuestObjectives.esp'
+    clean:
+      - crc: 0x6816E897
+        util: TES5Edit v3.2.2
   - name: 'Serana Dialogue Edit.esp'
     after:
       - name: 'Relationship Dialogue Overhaul.esp'
@@ -27373,86 +27385,6 @@ plugins:
       - 'CRF - Lighting Overhaul.esp'
     clean:
       - crc: 0xF05588E3
-        util: TES5Edit v3.2.2
-  - name: 'CRF - Lighting Overhaul.esp'
-    clean:
-      - crc: 0x2B77F815
-        util: TES5Edit v3.2.2
-  - name: 'BlackHorseCourier.esp'
-    clean:
-      - crc: 0x3C97A13F
-        util: TES5Edit v3.2.2
-  - name: 'Footprints.esp'
-    clean:
-      - crc: 0xE87C93C0
-        util: TES5Edit v3.2.2
-  - name: 'SafeAutoSave.esp'
-    clean:
-      - crc: 0xC6E86A52
-        util: TES5Edit v3.2.2
-  - name: 'honedmetal.esp'
-    clean:
-      - crc: 0x60DCC06C
-        util: TES5Edit v3.2.2
-  - name: 'HeartBreaker.esp'
-    clean:
-      - crc: 0xCDACB771
-        util: TES5Edit v3.2.2
-  - name: 'LanternsOfSkyrimELFXpatch.esp'
-    clean:
-      - crc: 0x80BED226
-        util: TES5Edit v3.2.2
-  - name: 'Realistic-Voice.esp'
-    clean:
-      - crc: 0xB8DF8C55
-        util: TES5Edit v3.2.2
-  - name: 'WondersofWeather.esp'
-    clean:
-      - crc: 0x94835DDD
-        util: TES5Edit v3.2.2
-  - name: 'Castle Volkihar Rebuilt.esp'
-    clean:
-      - crc: 0xFD481790
-        util: TES5Edit v3.2.2
-  - name: 'SimplyKnock.esp'
-    clean:
-      - crc: 0x097D7FB3
-        util: TES5Edit v3.2.2
-  - name: 'attack commitment movement speed fluid 3.esp'
-    clean:
-      - crc: 0x4530C736
-        util: TES5Edit v3.2.2
-  - name: 'NPCWaterAIScripted.esp'
-    clean:
-      - crc: 0x74155306
-        util: TES5Edit v3.2.2
-  - name: 'NotSoFast-MainQuest.esp'
-    clean:
-      - crc: 0x91C64D49
-        util: TES5Edit v3.2.2
-  - name: 'NotSoFast-MageGuild.esp'
-    clean:
-      - crc: 0xECE5043D
-        util: TES5Edit v3.2.2
-  - name: 'RSChildren.esp'
-    clean:
-      - crc: 0x80590F46
-        util: TES5Edit v3.2.2
-  - name: 'RealisticHuskySounds.esp'
-    clean:
-      - crc: 0x40FA36B0
-        util: TES5Edit v3.2.2
-  - name: '360WalkandRunPlus-RunBackwardSpeedAdjust.esp'
-    clean:
-      - crc: 0xB2AF9437
-        util: TES5Edit v3.2.2
-  - name: 'Campfire BDS Patch.esp'
-    clean:
-      - crc: 0x3F8BB3E9
-        util: TES5Edit v3.2.2
-  - name: 'Blues Skyrim.esp'
-    clean:
-      - crc: 0xEB33640C
         util: TES5Edit v3.2.2
   - name: 'Helsmyrr.esp'
     dirty:
@@ -27474,22 +27406,6 @@ plugins:
     clean:
       - crc: 0x5E034168
         util: TES5Edit v3.2.2
-  - name: 'Populated Skyrim Legendary.esp'
-    clean:
-      - crc: 0x159E003B
-        util: TES5Edit v3.2.2
-  - name: 'Better Series - All in one.esp'
-    clean:
-      - crc: 0x210D0753
-        util: TES5Edit v3.2.2
-  - name: 'Cidhna Mine Expanded.esp'
-    clean:
-      - crc: 0x81FBA022
-        util: TES5Edit v3.2.2
-  - name: 'LOS ELFX Consistency Patch.esp'
-    clean:
-      - crc: 0x86CC1C61
-        util: TES5Edit v3.2.2
   - name: 'SMIM-Merged-All.esp'
     dirty:
       - <<: *dirtyPlugin
@@ -27498,65 +27414,17 @@ plugins:
     clean:
       - crc: 0xD4355BE5
         util: TES5Edit v3.2.2
-  - name: 'Holidays.esp'
-    clean:
-      - crc: 0x8B93B372
-        util: TES5Edit v3.2.2
-  - name: 'JK''s Falkreath.esp'
-    clean:
-      - crc: 0xFFD6E99E
-        util: TES5Edit v3.2.2
-  - name: 'Point The Way.esp'
-    clean:
-      - crc: 0x91D53B8F
-        util: TES5Edit v3.2.2
-  - name: 'Immersive Encounters.esp'
-    clean:
-      - crc: 0x08B011F9
-        util: TES5Edit v3.2.2
-  - name: 'Immersive Encounters - RS Children Patch.esp'
-    clean:
-      - crc: 0xC4949683
-        util: TES5Edit v3.2.2
   - name: 'SkyrimUnhinged.esp'
     dirty:
       - <<: *dirtyPlugin
         crc: 0x2181ED1C
         itm: 15
-  - name: 'UniqueBorderGates-All.esp'
-    clean:
-      - crc: 0x7E6B19CA
-        util: TES5Edit v3.2.2
-  - name: 'UniqueBorderGates-All-BetterDGEntrance.esp'
-    clean:
-      - crc: 0xB4B9957A
-        util: TES5Edit v3.2.2
-  - name: 'UniqueBorderGates-All-PointTheWay.esp'
-    clean:
-      - crc: 0xFB5D20A4
-        util: TES5Edit v3.2.2
   - name: 'Vaults of Skyrim Palaces Patch.esp'
     dirty:
       - <<: *dirtyPlugin
         crc: 0x7CAE947E
         itm: 26
         udr: 17
-  - name: 'Understone Keep Repair.esp'
-    clean:
-      - crc: 0xF56364D6
-        util: TES5Edit v3.2.2
-  - name: 'Skysan_ELFX_SMIM_Fix.esp'
-    clean:
-      - crc: 0xE00C98FB
-        util: TES5Edit v3.2.2
-  - name: 'Bring Out Your Dead - Legendary Edition.esp'
-    clean:
-      - crc: 0x7417983A
-        util: TES5Edit v3.2.2
-  - name: 'Skyshards.esp'
-    clean:
-      - crc: 0x06337759
-        util: TES5Edit v3.2.2
   - name: 'Ducks and Swans.esp'
     dirty:
       - <<: *dirtyPlugin
@@ -27578,90 +27446,6 @@ plugins:
     clean:
       - crc: 0x6D912864
         util: TES5Edit v3.2.2
-  - name: 'Farm Animals_HF.esp'
-    clean:
-      - crc: 0x6190C05E
-        util: TES5Edit v3.2.2
-  - name: 'SolitudeTempleFrescoes.esp'
-    clean:
-      - crc: 0x450BD436
-        util: TES5Edit v3.2.2
-  - name: 'CaranthirTowerReborn.esp'
-    clean:
-      - crc: 0x0991A6A6
-        util: TES5Edit v3.2.2
-  - name: 'manny Lantern Caretakers.esp'
-    dirty:
-      - <<: *dirtyPlugin
-        crc: 0x4EB77E00
-        itm: 2
-    clean:
-      - crc: 0x20897014
-        util: TES5Edit v3.2.2
-  - name: 'EasierRidersDungeonPack.esp'
-    clean:
-      - crc: 0x60B973B2
-        util: TES5Edit v3.2.2
-  - name: 'Missives.esp'
-    clean:
-      - crc: 0x553737F7
-        util: TES5Edit v3.2.2
-  - name: 'PilgrimsDelight.esp'
-    clean:
-      - crc: 0x2C24D5A5
-        util: TES5Edit v3.2.2
-  - name: 'Undriel_Everlight.esp'
-    clean:
-      - crc: 0xDE8C3380
-        util: TES5Edit v3.2.2
-  - name: 'Windhelm''s Ancient Lighthouse.esp'
-    clean:
-      - crc: 0x9BC1D211
-        util: TES5Edit v3.2.2
-  - name: 'high hrothgar overhaul.esp'
-    clean:
-      - crc: 0xDFF70AC9
-        util: TES5Edit v3.2.2
-  - name: 'ThiefsHideout.esp'
-    clean:
-      - crc: 0xEBCD3A30
-        util: TES5Edit v3.2.2
-  - name: 'iNeed.esp'
-    clean:
-      - crc: 0xD9020262
-        util: TES5Edit v3.2.2
-  - name: 'Ravengate.esp'
-    clean:
-      - crc: 0x1F5051F9
-        util: TES5Edit v3.2.2
-  - name: 'PreventsAccidentPickUp.esp'
-    clean:
-      - crc: 0x1F81BED9
-        util: TES5Edit v3.2.2
-  - name: 'FireBurns.esp'
-    clean:
-      - crc: 0x0A36ACF2
-        util: TES5Edit v3.2.2
-  - name: 'Skyrim 2017 TPTC - Parallax Maps.esp'
-    clean:
-      - crc: 0x57708C9E
-        util: TES5Edit v3.2.2
-  - name: 'JZBai_PracticalFemaleArmors.esp'
-    clean:
-      - crc: 0x05345A0D
-        util: TES5Edit v3.2.2
-  - name: 'GQJ_DG_vampireamuletfix.esp'
-    clean:
-      - crc: 0x3EE05DD0
-        util: TES5Edit v3.2.2
-  - name: 'UniqueBarbas.esp'
-    clean:
-      - crc: 0x32B261A7
-        util: TES5Edit v3.2.2
-  - name: 'BentPines_for_SFO2.0.esp'
-    clean:
-      - crc: 0x5D4989D3
-        util: TES5Edit v3.2.2
   - name: 'NB-Scars.esp'
     dirty:
       - <<: *dirtyPlugin
@@ -27669,34 +27453,6 @@ plugins:
         itm: 1
     clean:
       - crc: 0x1DA6AE1A
-        util: TES5Edit v3.2.2
-  - name: 'Better Dynamic Ash.esp'
-    clean:
-      - crc: 0xD2E3193B
-        util: TES5Edit v3.2.2
-  - name: 'eggkilleryum.esp'
-    clean:
-      - crc: 0x517413C4
-        util: TES5Edit v3.2.2
-  - name: 'AshRocks.esp'
-    clean:
-      - crc: 0x64EB9F73
-        util: TES5Edit v3.2.2
-  - name: 'A Fitting Throne for Vyrthur.esp'
-    clean:
-      - crc: 0xD6C78911
-        util: TES5Edit v3.2.2
-  - name: 'SmartTraining.esp'
-    clean:
-      - crc: 0x2270F07E
-        util: TES5Edit v3.2.2
-  - name: 'KS Hairdos - HDT.esp'
-    clean:
-      - crc: 0x5AE02E2B
-        util: TES5Edit v3.2.2
-  - name: 'Watercolor_for_ENB_RWT.esp'
-    clean:
-      - crc: 0x6023FA83
         util: TES5Edit v3.2.2
   - name: 'Unique Flowers & Plants.esm'
     msg:
@@ -27715,18 +27471,6 @@ plugins:
     clean:
       - crc: 0x97235797
         util: TES5Edit v3.2.2
-  - name: 'Vividian - Lanterns of Skyrim Preset.esp'
-    clean:
-      - crc: 0x17CFB464
-        util: TES5Edit v3.2.2
-  - name: 'Vividian - Torches Preset.esp'
-    clean:
-      - crc: 0xE3994512
-        util: TES5Edit v3.2.2
-  - name: 'Vividian - Wearable Lanterns Preset.esp'
-    clean:
-      - crc: 0x38A6BDEA
-        util: TES5Edit v3.2.2
   - name: 'AshesOfTheRedMountain.esp'
     msg:
       - <<: *hasWildEdits
@@ -27735,42 +27479,6 @@ plugins:
         condition: 'checksum("AshesOfTheRedMountain.esp", 52B13664) or checksum("AshesOfTheRedMountain.esp", BDE2dA1A)'
     clean:
       - crc: 0x675E8C28
-        util: TES5Edit v3.2.2
-  - name: 'Aringoth Race - Sleep - Invisibility Potion Combo Patch.esp'
-    clean:
-      - crc: 0x28E7B278
-        util: TES5Edit v3.2.2
-  - name: 'Dead Body Collision.esp'
-    clean:
-      - crc: 0x8853B30B
-        util: TES5Edit v3.2.2
-  - name: 'dD-No Spinning Death Animation Merged.esp'
-    clean:
-      - crc: 0x23E4EB08
-        util: TES5Edit v3.2.2
-  - name: 'Skyrim Particle Patch for ENB - Flame Atronach Fix.esp'
-    clean:
-      - crc: 0x209727D0
-        util: TES5Edit v3.2.2
-  - name: 'SmartNoMoreStupidDogDGHF.esp'
-    clean:
-      - crc: 0xA218BECA
-        util: TES5Edit v3.2.2
-  - name: 'TavernAIFix.esp'
-    clean:
-      - crc: 0x7DB8A4C3
-        util: TES5Edit v3.2.2
-  - name: 'WM Shahvee Fix.esp'
-    clean:
-      - crc: 0x7405C5A4
-        util: TES5Edit v3.2.2
-  - name: 'AddressUnknown.esp'
-    clean:
-      - crc: 0xBC47E422
-        util: TES5Edit v3.2.2
-  - name: 'Basket Backpack.esp'
-    clean:
-      - crc: 0xDF7C2C18
         util: TES5Edit v3.2.2
   - name: 'CollegeApplication.esp'
     msg:
@@ -27803,34 +27511,6 @@ plugins:
     clean:
       - crc: 0x3BAF6713
         util: TES5Edit v3.2.2
-  - name: 'RandomClappingAnimations.esp'
-    clean:
-      - crc: 0xEF373FDB
-        util: TES5Edit v3.2.2
-  - name: 'Laundry.esp'
-    clean:
-      - crc: 0x24F346A6
-        util: TES5Edit v3.2.2
-  - name: 'goldpilesyum.esp'
-    clean:
-      - crc: 0xD9F2A807
-        util: TES5Edit v3.2.2
-  - name: 'OH GOD BEES.esp'
-    clean:
-      - crc: 0xE7FEF2BC
-        util: TES5Edit v3.2.2
-  - name: 'LessCharitableNPCs.esp'
-    clean:
-      - crc: 0x276EDB97
-        util: TES5Edit v3.2.2
-  - name: 'Give Beggars Food.esp'
-    clean:
-      - crc: 0x20EF9B40
-        util: TES5Edit v3.2.2
-  - name: 'Raven Rock - Fix Exit on Horseback.esp'
-    clean:
-      - crc: 0x36E1E4FF
-        util: TES5Edit v3.2.2
   - name: 'Covered in Bees.esp'
     dirty:
       - <<: *dirtyPlugin
@@ -27848,62 +27528,6 @@ plugins:
     clean:
       - crc: 0xF5D34F9E
         util: TES5Edit v3.2.2
-  - name: 'ImperialSoldiersEscortFix.esp'
-    clean:
-      - crc: 0x1F785711
-        util: TES5Edit v3.2.2
-  - name: 'HoldBorderBanners.esp'
-    clean:
-      - crc: 0x81A20CA2
-        util: TES5Edit v3.2.2
-  - name: 'Shadowmarks.esp'
-    clean:
-      - crc: 0xBFC44B8B
-        util: TES5Edit v3.2.2
-  - name: 'Where is the Cook.esp'
-    clean:
-      - crc: 0x36310FC3
-        util: TES5Edit v3.2.2
-  - name: 'WindhelmFR.esp'
-    clean:
-      - crc: 0x66A71AD4
-        util: TES5Edit v3.2.2
-  - name: 'SilverMapcsb.esp'
-    clean:
-      - crc: 0x51B461AB
-        util: TES5Edit v3.2.2
-  - name: 'LootParalyzedPeople.esp'
-    clean:
-      - crc: 0xE3A89A78
-        util: TES5Edit v3.2.2
-  - name: 'MoreThugsForPettyThieves.esp'
-    clean:
-      - crc: 0x7FBFA8F4
-        util: TES5Edit v3.2.2
-  - name: 'AnonymousPeople.esp'
-    clean:
-      - crc: 0xD26D9030
-        util: TES5Edit v3.2.2
-  - name: 'Sinking Bodies.esp'
-    clean:
-      - crc: 0x3F9A636F
-        util: TES5Edit v3.2.2
-  - name: 'suspiciouscityguards.esp'
-    clean:
-      - crc: 0x2F8ECD3D
-        util: TES5Edit v3.2.2
-  - name: 'Chesko_Step418_SN.esp'
-    clean:
-      - crc: 0x7A15383C
-        util: TES5Edit v3.2.2
-  - name: 'Moss Rocks.esp'
-    clean:
-      - crc: 0x867372A2
-        util: TES5Edit v3.2.2
-  - name: 'TGBC.esp'
-    clean:
-      - crc: 0xB59266B3
-        util: TES5Edit v3.2.2
   - name: 'DoorAnswersSolvable.esp'
     dirty:
       - <<: *dirtyPlugin
@@ -27918,38 +27542,6 @@ plugins:
     clean:
       - crc: 0xC5DC3E93
         util: TES5Edit v3.2.2
-  - name: 'Tes Arena -Skyrim Cities.esp'
-    clean:
-      - crc: 0x39D0E506
-        util: TES5Edit v3.2.2
-  - name: 'Beards.esp'
-    clean:
-      - crc: 0x5D189308
-        util: TES5Edit v3.2.2
-  - name: 'Coin Toss.esp'
-    clean:
-      - crc: 0xB29E4940
-        util: TES5Edit v3.2.2
-  - name: 'CTR_Patch_UniqueUniques.esp'
-    clean:
-      - crc: 0xEC92873B
-        util: TES5Edit v3.2.2
-  - name: 'RDO - Cutting Room Floor Patch.esp'
-    clean:
-      - crc: 0x827458D7
-        util: TES5Edit v3.2.2
-  - name: 'RDO - Requiem Patch.esp'
-    clean:
-      - crc: 0xE0AE72B7
-        util: TES5Edit v3.2.2
-  - name: 'Palaces Castles Enhanced.esp'
-    clean:
-      - crc: 0xC1A5DE76
-        util: TES5Edit v3.2.2
-  - name: 'Artful Dodger - Dynamic Pickpocket Cap.esp'
-    clean:
-      - crc: 0x3D6CFB11
-        util: TES5Edit v3.2.2
   - name: 'HallgarthsforNPCs.esp'
     msg:
       - <<: *hasWildEdits
@@ -27963,91 +27555,3 @@ plugins:
     clean:
       - crc: 0x9FE950EF
         util: TES5Edit v3.2.2
-  - name: 'HallgarthAdditionalHair.esp'
-    clean:
-      - crc: 0xB8AC0C85
-        util: TES5Edit v3.2.2
-  - name: 'HallgarthsforNPCs - USLEEP.esp'
-    clean:
-      - crc: 0xD47A21F7
-        util: TES5Edit v3.2.2
-  - name: 'Immersive Citizens - AI Overhaul Lite.esp'
-    clean:
-      - crc: 0xE4C85756
-        util: TES5Edit v3.2.2
-  - name: 'Sensible Hardcore Compass.esp'
-    clean:
-      - crc: 0x4BB71F58
-        util: TES5Edit v3.2.2
-  - name: 'Bee Hives.esp'
-    clean:
-      - crc: 0x1AC40D82
-        util: TES5Edit v3.2.2
-  - name: 'Gildergreen Regrown.esp'
-    clean:
-      - crc: 0x5111AD5F
-        util: TES5Edit v3.2.2
-  - name: 'AllThievesGuildJobsConcurrently.esp'
-    clean:
-      - crc: 0x6E6C7E2D
-        util: TES5Edit v3.2.2
-  - name: 'Quest Markers Restored.esp'
-    group: *underridesGroup
-    after:
-      - 'BetterQuestObjectives.esp'
-    clean:
-      - crc: 0x6816E897
-        util: TES5Edit v3.2.2
-  - name: 'Tentapalooza.esp'
-    clean:
-      - crc: 0x0BE7B239
-        util: TES5Edit v3.2.2
-  - name: 'HighHrothgarWindowGlow.esp'
-    clean:
-      - crc: 0x12F22C8E
-        util: TES5Edit v3.2.2
-  - name: 'WhiterunExterior.esp'
-    clean:
-      - crc: 0xB2CB7F84
-        util: TES5Edit v3.2.2
-  - name: 'SolitudeExterior.esp'
-    clean:
-      - crc: 0x75647A7E
-        util: TES5Edit v3.2.2
-  - name: 'FNIS.esp'
-    clean:
-      - crc: 0xB1685AD7
-        util: TES5Edit v3.2.2
-  - name: 'WSCO - OcciFemaleUNP.esp'
-    dirty:
-      - <<: *dirtyPlugin
-        crc: 0xF5522805
-        itm: 1
-    clean:
-      - crc: 0x33778607
-        util: TES5Edit v3.2.2
-  - name: 'WSCO - OcciBetterMale.esp'
-    clean:
-      - crc: 0x4A060D3A
-        util: TES5Edit v3.2.2
-  - name: 'WSCO - Better NPCs.esp'
-    clean:
-      - crc: 0xBDF72EB9
-        util: TES5Edit v3.2.2
-  - name: 'FNIS_PCEA2.esp'
-    clean:
-      - crc: 0x6A181424
-        util: TES5Edit v3.2.2
-  - name: 'Arthmoor''s Skyrim Villages - All In One.esp'
-    after:
-      - 'Immersive Citizens - AI Overhaul.esp'
-  - name: 'more idle markers.esp'
-    after:
-      - 'Immersive Citizens - AI Overhaul.esp'
-  - name: 'CollegeApplication.esp'
-    msg:
-      - <<: *obsolete
-        condition: 'checksum("CollegeApplication.esp", 314DD5F6)'
-  - name: 'No Snow Under The Roof - CRF Patch.esp'
-    after:
-      - 'CRF - Lighting Overhaul.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27880,3 +27880,15 @@ plugins:
     clean:
       - crc: 0xEC92873B
         util: TES5Edit v3.2.2
+  - name: 'RDO - Cutting Room Floor Patch.esp'
+    clean:
+      - crc: 0x827458D7
+        util: TES5Edit v3.2.2
+  - name: 'RDO - Immersive Horses Patch.esp'
+    clean:
+      - crc: 0xFEC52ACB
+        util: TES5Edit v3.2.2
+  - name: 'RDO - Requiem Patch.esp'
+    clean:
+      - crc: 0xE0AE72B7
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27697,3 +27697,7 @@ plugins:
     clean:
       - crc: 0x7405C5A4
         util: TES5Edit v3.2.2
+  - name: 'AddressUnknown.esp'
+    clean:
+      - crc: 0xBC47E422
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27942,3 +27942,7 @@ plugins:
     clean:
       - crc: 0xD47A21F7
         util: TES5Edit v3.2.2
+  - name: 'Immersive Citizens - AI Overhaul Lite.esp'
+    clean:
+      - crc: 0xE4C85756
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -8237,16 +8237,6 @@ plugins:
     msg:
       - <<: *patchOutSub
         condition: 'not checksum("SeraphimStandAlone.esp",556E0B68)'
-  - name: 'SeraphineHuntedArmor.esp'
-    msg:
-      - type: say
-        content:
-          - lang: en
-            text: 'Be sure you have the correct body mod for the esp. [DIMONIZED UNP](http://www.nexusmods.com/skyrim/mods/6709) or [CBBE](http://www.nexusmods.com/skyrim/mods/2666).'
-          - lang: ru
-            text: 'Убедитесь, что используете корректный реплейсер тел для этого esp. [DIMONIZED UNP](http://www.nexusmods.com/skyrim/mods/6709) или [CBBE](http://www.nexusmods.com/skyrim/mods/2666).'
-          - lang: ja
-            text: '必ず[DIMONIZED UNP](http://www.nexusmods.com/skyrim/mods/6709)か[CBBE](http://www.nexusmods.com/skyrim/mods/2666)のうち、インストールされている体型Modと同じバージョンのEspを使用してください。.'
   - name: 'SeraticArmor.esp'
     tag:
       - name: Deactivate
@@ -23613,14 +23603,6 @@ plugins:
     msg:
       - <<: *corrupt
         condition: 'checksum("Illdi.esp",B941754D)'
-      - type: say
-        content:
-          - lang: en
-            text: 'Be sure you have the correct body mod for the esp. [DIMONIZED UNP](http://www.nexusmods.com/skyrim/mods/6709) or [CBBE](http://www.nexusmods.com/skyrim/mods/2666).'
-          - lang: ru
-            text: 'Убедитесь, что используете корректный реплейсер тел для этого esp. [DIMONIZED UNP](http://www.nexusmods.com/skyrim/mods/6709) или [CBBE](http://www.nexusmods.com/skyrim/mods/2666).'
-          - lang: ja
-            text: '必ず[DIMONIZED UNP](http://www.nexusmods.com/skyrim/mods/6709)か[CBBE](http://www.nexusmods.com/skyrim/mods/2666)のうち、インストールされている体型Modと同じバージョンのEspを使用してください。.'
   - name: 'ImaniSuda.esp'
     msg:
       - <<: *corrupt
@@ -23728,16 +23710,6 @@ plugins:
         condition: 'checksum("Kitana.esp",BCF5969B) or checksum("Kitana.esp",2077B972)'
   - name: 'KMM_2a.esp'
     msg: [ *obsolete ]
-  - name: 'Lia.esp'
-    msg:
-      - type: say
-        content:
-          - lang: en
-            text: 'Be sure you have the correct body mod for the esp. [DIMONIZED UNP](http://www.nexusmods.com/skyrim/mods/6709) or [CBBE](http://www.nexusmods.com/skyrim/mods/2666).'
-          - lang: ru
-            text: 'Убедитесь, что используете корректный реплейсер тел для этого esp. [DIMONIZED UNP](http://www.nexusmods.com/skyrim/mods/6709) или [CBBE](http://www.nexusmods.com/skyrim/mods/2666).'
-          - lang: ja
-            text: '必ず[DIMONIZED UNP](http://www.nexusmods.com/skyrim/mods/6709)か[CBBE](http://www.nexusmods.com/skyrim/mods/2666)のうち、インストールされている体型Modと同じバージョンのEspを使用してください。.'
   - name: 'LianVera-v2.1.esp'
     msg: [ *obsolete ]
     dirty:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -26974,6 +26974,9 @@ plugins:
     msg:
       - <<: *reqRequiemPatch
         condition: 'active("Requiem.esp") and not active("Requiem - VioLens.esp")'
+    clean:
+      - crc: 0xB3094DDB
+        util: TES5Edit v3.2.2
   - name: 'WM Flora Fixes.esp'
     msg:
       - <<: *reqRequiemPatch

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4240,6 +4240,9 @@ plugins:
     after:
       - name: 'FISS.esp'
         condition: 'version("AMatterOfTime.esp", "2", >=)'
+    clean:
+      - crc: 0x512CD10C
+        util: TES5Edit v3.2.2
   - name: 'Harvest More Food & Ingredients.esp'
     tag:
       - Delev

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -5241,6 +5241,9 @@ plugins:
       - crc: 0x18DBC60E
         <<: *dirtyPlugin
         itm: 3
+    clean:
+      - crc: 0xF3206010
+        util: TES5Edit v3.2.2
   - name: 'SkyEx.esp'
     dirty:
       - crc: 0xfc694964

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27061,30 +27061,6 @@ plugins:
     clean:
       - crc: 0x2C01D8A0
         util: TES5Edit v3.2.2
-  - name: 'CFTO-CoveredCarriages.esp'
-    clean:
-      - crc: 0xD4E1FF07
-        util: TES5Edit v3.2.2
-  - name: 'CFTO-Lanterns.esp'
-    clean:
-      - crc: 0xDB37D153
-        util: TES5Edit v3.2.2
-  - name: 'CFTO-InconNPCs-Patch.esp'
-    clean:
-      - crc: 0xADE4F4F0
-        util: TES5Edit v3.2.2
-  - name: 'CFTO-JK-Patch.esp'
-    clean:
-      - crc: 0xBADB959A
-        util: TES5Edit v3.2.2
-  - name: 'CFTO-BetterTelMithryn-Patch.esp'
-    clean:
-      - crc: 0x678D1FAE
-        util: TES5Edit v3.2.2
-  - name: 'HFE-CFTO-Patch.esp'
-    clean:
-      - crc: 0xE2228FD3
-        util: TES5Edit v3.2.2
   - name: 'Immersive Ingestibles.esp'
     after:
       - 'ETaC - RESOURCES.esm'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27496,3 +27496,7 @@ plugins:
     clean:
       - crc: 0x05345A0D
         util: TES5Edit v3.2.2
+  - name: 'GQJ_DG_vampireamuletfix.esp'
+    clean:
+      - crc: 0x3EE05DD0
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27219,3 +27219,7 @@ plugins:
     clean:
       - crc: 0x3F8BB3E9
         util: TES5Edit v3.2.2
+  - name: 'Blues Skyrim.esp'
+    clean:
+      - crc: 0xEB33640C
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -28014,3 +28014,7 @@ plugins:
     clean:
       - crc: 0xBDF72EB9
         util: TES5Edit v3.2.2
+  - name: 'FNIS_PCEA2.esp'
+    clean:
+      - crc: 0x6A181424
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27790,3 +27790,7 @@ plugins:
     clean:
       - crc: 0xBFC44B8B
         util: TES5Edit v3.2.2
+  - name: 'Where is the Cook.esp'
+    clean:
+      - crc: 0x36310FC3
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -18136,6 +18136,9 @@ plugins:
       - crc: 0x99c43ba5
         <<: *dirtyPlugin
         itm: 4
+    clean:
+      - crc: 0x70ACDD02
+        util: TES5Edit v3.2.2
   - name: 'Trolls Loot.esp'
     dirty:
       - crc: 0x9c8f811b

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27438,3 +27438,7 @@ plugins:
     clean:
       - crc: 0x60B973B2
         util: TES5Edit v3.2.2
+  - name: 'Missives.esp'
+    clean:
+      - crc: 0x553737F7
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27778,6 +27778,9 @@ plugins:
       - <<: *dirtyPlugin
         crc: 0x9440F010
         itm: 8
+    clean:
+      - crc: 0xF5D34F9E
+        util: TES5Edit v3.2.2
   - name: 'ImperialSoldiersEscortFix.esp'
     clean:
       - crc: 0x1F785711

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27172,3 +27172,7 @@ plugins:
     clean:
       - crc: 0x74155306
         util: TES5Edit v3.2.2
+  - name: 'NotSoFast-MageGuild.esp'
+    clean:
+      - crc: 0xECE5043D
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -306,7 +306,7 @@ common:
     type: say
     content:
       - lang: en
-        text: "This plug-in %1% contains wild edits. A manual [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) cleaning guide is available here: %2%"
+        text: "This plugin contains wild edits. A manual [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) cleaning guide is available here: %1%"
 
 bash_tags:
   - 'Actors.ACBS'
@@ -641,7 +641,6 @@ plugins:
     msg:
       - <<: *hasWildEdits
         subs:
-          - 'Dawnguard.esm'
           - '[Manual Cleaning Guide](https://afkmods.iguanadons.net/index.php?/topic/4110-manual-cleaning-skyrim-and-skyrim-se-master-files/)'
         condition: 'checksum("Dawnguard.esm",94A47F31)'
     dirty:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27866,3 +27866,7 @@ plugins:
     clean:
       - crc: 0xA9B51B10
         util: TES5Edit v3.2.2
+  - name: 'Beards.esp'
+    clean:
+      - crc: 0x5D189308
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27354,6 +27354,9 @@ plugins:
       - 'Requiem - Immersive Horses.esp'
       - 'Requiem - Immersive Horses - SkyTEST.esp'
       - 'RDO - Requiem Patch.esp'
+    clean:
+      - crc: 0xFEC52ACB
+        util: TES5Edit v3.2.2
   - name: 'Quest Markers Restored.esp'
     group: *underridesGroup
     after:
@@ -27934,14 +27937,6 @@ plugins:
   - name: 'RDO - Cutting Room Floor Patch.esp'
     clean:
       - crc: 0x827458D7
-        util: TES5Edit v3.2.2
-  - name: 'RDO - Immersive Horses Patch.esp'
-    after:
-      - 'RDO - Requiem Patch.esp'
-      - 'Requiem - Immersive Horses.esp'
-      - 'Requiem - Immersive Horses - SkyTEST.esp'
-    clean:
-      - crc: 0xFEC52ACB
         util: TES5Edit v3.2.2
   - name: 'RDO - Requiem Patch.esp'
     clean:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3186,6 +3186,9 @@ plugins:
     clean:
       - crc: 0xB095E590
         util: TES5Edit v3.1.3
+    clean:
+      - crc: 0xDCFE8BC1
+        util: TES5Edit v3.2.2
   - name: 'BeastModels.esp'
     msg: [ *obsolete ]
   - name: 'BorderRegionsDisabled(EV)?\.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27306,7 +27306,7 @@ plugins:
     clean:
       - crc: 0x8B93B372
         util: TES5Edit v3.2.2
-  - name: 'JK's Falkreath.esp'
+  - name: 'JK''s Falkreath.esp'
     clean:
       - crc: 0xFFD6E99E
         util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -17959,6 +17959,9 @@ plugins:
       - <<: *dirtyPlugin
         crc: 0xFD8ABF04
         itm: 1
+    clean:
+      - crc: 0xD8504868
+        util: TES5Edit v3.2.2
   - name: 'dd - enhanced blood main dg.esp'
     msg: [ *obsolete ]
     url:
@@ -17971,6 +17974,9 @@ plugins:
       - crc: 0x4730f8bd
         <<: *dirtyPlugin
         itm: 1
+    clean:
+      - crc: 0xFB317E84
+        util: TES5Edit v3.2.2
   - name: 'dD-SkyrimMonsterMod EBT Patch.esp'
     inc:
       - 'dD-Dawnguard-EBT Patch.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -884,7 +884,7 @@ plugins:
         util: TES5Edit v3.1.3
         # v3.0.13a
       - crc: 0xF92F6237
-        util: TES5EDIT v3.2.1
+        util: TES5EDIT v3.2.2
 # Falskaar is stated to be an "unofficial DLC", it should be loaded right after the Beth DLCs, logically. - William
   - name: 'Falskaar.esm'
     group: *newLandsGroup

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27829,3 +27829,7 @@ plugins:
     clean:
       - crc: 0x2F8ECD3D
         util: TES5Edit v3.2.2
+  - name: 'Chesko_Step418_SN.esp'
+    clean:
+      - crc: 0x7A15383C
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9574,6 +9574,8 @@ plugins:
     after:
       - 'REQMOD.esp'
       - 'Requiem_Minor_Arcana.esp'
+      - 'Requiem - SkyTEST.esp'
+      - 'Requiem - Wild World.esp'
   - name: 'Requiem - Immersive Horses - SkyTEST.esp'
     req:
       - 'Requiem - SkyTEST.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27764,3 +27764,12 @@ plugins:
     clean:
       - crc: 0x36E1E4FF
         util: TES5Edit v3.2.2
+  - name: 'Covered in Bees.esp'
+    dirty:
+      - <<: *dirtyPlugin
+        crc: 0xe55146de
+        itm: 14
+        udr: 1
+    clean:
+      - crc: 0x3383968A
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27689,3 +27689,7 @@ plugins:
     clean:
       - crc: 0xA218BECA
         util: TES5Edit v3.2.2
+  - name: 'TavernAIFix.esp'
+    clean:
+      - crc: 0x7DB8A4C3
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27143,3 +27143,7 @@ plugins:
     clean:
       - crc: 0x94835DDD
         util: TES5Edit v3.2.2
+  - name: 'Castle Volkihar Rebuilt.esp'
+    clean:
+      - crc: 0xFD481790
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27364,3 +27364,7 @@ plugins:
     clean:
       - crc: 0xE00C98FB
         util: TES5Edit v3.2.2
+  - name: 'Bring Out Your Dead - Legendary Edition.esp'
+    clean:
+      - crc: 0x7417983A
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27782,3 +27782,7 @@ plugins:
     clean:
       - crc: 0x1F785711
         util: TES5Edit v3.2.2
+  - name: 'HoldBorderBanners.esp'
+    clean:
+      - crc: 0x81A20CA2
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27220,6 +27220,9 @@ plugins:
   - name: 'No Snow Under The Roof - CRF Patch.esp'
     after:
       - 'CRF - Lighting Overhaul.esp'
+    clean:
+      - crc: 0xF05588E3
+        util: TES5Edit v3.2.2
   - name: 'CRF - Lighting Overhaul.esp'
     clean:
       - crc: 0x2B77F815

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4006,6 +4006,9 @@ plugins:
     msg:
       - <<: *reqModX
         subs: [ 'Java Runtime Environment 7 update 17+' ]
+    clean:
+      - crc: 0x49778E0B
+        util: TES5Edit v3.2.2
   - name: 'Duke Patricks - FollowThatActor.esp'
     req: [ *SKSE ]
   - name: 'E0PortableBedroll.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2469,6 +2469,9 @@ plugins:
       - Graphics
       - Relev
       - Stats
+    clean:
+      - crc: 0xD852F825
+        util: TES5Edit v3.2.2
   - name: 'Clothing & Clutter Fixes.esp'
     group: *underridesGroup
     after:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2511,6 +2511,13 @@ plugins:
       - crc: 0xf84dc756
         <<: *dirtyPlugin
         itm: 2
+    clean:
+      - crc: 0xFC447339
+        util: TES5Edit v3.2.2
+  - name: 'The Eyes Of Beauty - Elves Edition.esp'
+    clean:
+      - crc: 0xAFF2DA5E
+        util: TES5Edit v3.2.2
   - name: 'ColourEyesNoDGHF.esp'
     dirty:
       - crc: 0x3b2f32fc

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27023,6 +27023,9 @@ plugins:
     msg:
       - <<: *reqRequiemPatch
         condition: 'active("Requiem.esp") and not active("Requiem - Immersive Patrols.esp") and not active("Requiem - Immersive Patrols - CWO.esp")'
+    clean:
+      - crc: 0xD72C4B48
+        util: TES5Edit v3.2.2
   - name: 'Immersive Sounds - Compendium.esp'
     msg:
       - <<: *reqRequiemPatch

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -26654,6 +26654,9 @@ plugins:
       - crc: 0xAC68717A
         <<: *dirtyPlugin
         itm: 1
+    clean:
+      - crc: 0x82959058
+        util: TES5Edit v3.2.2
     url: [ 'http://www.nexusmods.com/skyrim/mods/30411' ]
 # Load Ordinator after other perk mods so it has precedence.
   - name: 'Ordinator - Perks of Skyrim.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27314,3 +27314,7 @@ plugins:
     clean:
       - crc: 0x91D53B8F
         util: TES5Edit v3.2.2
+  - name: 'Immersive Encounters.esp'
+    clean:
+      - crc: 0xBF61E096
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27825,3 +27825,7 @@ plugins:
     clean:
       - crc: 0x3F9A636F
         util: TES5Edit v3.2.2
+  - name: 'suspiciouscityguards.esp'
+    clean:
+      - crc: 0x2F8ECD3D
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -5972,6 +5972,9 @@ plugins:
   - name: 'RaceMenu.esp'
     req:
       - *SKSE
+    clean:
+      - crc: 0x2765B7D0
+        util: TES5Edit v3.2.2
   - name: 'RaceMenuPlugin.esp'
     msg:
       - type: say
@@ -5984,7 +5987,9 @@ plugins:
             text: 'RaceMenuPlugin is optional and provides support to alter Height, Breast, Glute and Biceps. If you experience issues with it, disable RaceMenuPlugin.esp and inform the author.'
           - lang: ja
             text: 'RaceMenuPluginではオプション機能として身長、胸、尻、力こぶの調整に対応しています。調整によって問題が発生した場合はRaceMenuPlugin.espを無効にし、Modの製作者まで情報を伝えてください。'
-
+    clean:
+      - crc: 0x8A8A009F
+        util: TES5Edit v3.2.2
   - name: 'SkyRealism - Simple Save System.+\.esp'
     msg:
       - type: say

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27120,3 +27120,7 @@ plugins:
     clean:
       - crc: 0xCDACB771
         util: TES5Edit v3.2.2
+  - name: 'LanternsOfSkyrimELFXpatch.esp'
+    clean:
+      - crc: 0x80BED226
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3650,6 +3650,9 @@ plugins:
       - crc: 0x86981213
         <<: *dirtyPlugin
         itm: 32
+    clean:
+      - crc: 0x37A5E020
+        util: TES5Edit v3.2.2
   - name: 'bladesfactionfix.esp'
     dirty:
       - crc: 0xb487451d

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27964,3 +27964,7 @@ plugins:
     clean:
       - crc: 0x5111AD5F
         util: TES5Edit v3.2.2
+  - name: 'AllThievesGuildJobsConcurrently.esp'
+    clean:
+      - crc: 0x6E6C7E2D
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27975,3 +27975,7 @@ plugins:
     clean:
       - crc: 0x6816E897
         util: TES5Edit v3.2.2
+  - name: 'Tentapalooza.esp'
+    clean:
+      - crc: 0x0BE7B239
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27701,3 +27701,7 @@ plugins:
     clean:
       - crc: 0xBC47E422
         util: TES5Edit v3.2.2
+  - name: 'Basket Backpack.esp'
+    clean:
+      - crc: 0xDF7C2C18
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7223,6 +7223,9 @@ plugins:
       - crc: 0xf95218fd
         <<: *dirtyPlugin
         itm: 7
+    clean:
+      - crc: 0x0F782AFB
+        util: TES5Edit v3.2.2
   - name: 'SkyRe_Plugin_ImmersiveArmor_2.esp'
     msg: [ *installOriginalResources ]
   - name: 'Level List - Immersive Armor.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27862,3 +27862,7 @@ plugins:
     clean:
       - crc: 0x39D0E506
         util: TES5Edit v3.2.2
+  - name: 'ShowersInInns.esp'
+    clean:
+      - crc: 0xA9B51B10
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27460,3 +27460,7 @@ plugins:
     clean:
       - crc: 0x9BC1D211
         util: TES5Edit v3.2.2
+  - name: 'high hrothgar overhaul.esp'
+    clean:
+      - crc: 0xDFF70AC9
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27234,3 +27234,6 @@ plugins:
       - crc: 0xDCD3E352
         <<: *dirtyPlugin
         itm: 123
+    clean:
+      - crc: 0x4D36AC80
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27261,6 +27261,9 @@ plugins:
     after:
       - name: 'Relationship Dialogue Overhaul.esp'
         condition: 'version("Serana Dialogue Edit.esp", "1.0", >=)'
+    clean:
+      - crc: 0x19E50E3F
+        util: TES5Edit v3.2.2
   - name: 'No Snow Under The Roof - CRF Patch.esp'
     after:
       - 'CRF - Lighting Overhaul.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -11581,9 +11581,6 @@ plugins:
       - <<: *dirtyPlugin
         crc: 0x53EC5DE6
         itm: 7
-    clean:
-      - crc: 0xAA148B12
-        util: TES5Edit v3.2.2
   - name: 'BetterDwemerExteriors.esp'
     dirty:
       - crc: 0xc96424e

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27669,3 +27669,7 @@ plugins:
     clean:
       - crc: 0x675E8C28
         util: TES5Edit v3.2.2
+  - name: 'Aringoth Race - Sleep - Invisibility Potion Combo Patch.esp'
+    clean:
+      - crc: 0x28E7B278
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -16094,6 +16094,9 @@ plugins:
     tag:
       - Delev
       - Relev
+    clean:
+      - crc: 0xF861B2A2
+        util: TES5Edit v3.2.2
   - name: 'Babette.esp'
     msg:
       - <<: *corrupt

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27375,3 +27375,11 @@ plugins:
     clean:
       - crc: 0x06337759
         util: TES5Edit v3.2.2
+  - name: 'Ducks and Swans.esp'
+    dirty:
+      - <<: *dirtyPlugin
+        crc: 0x98F444CA
+        itm: 9
+    clean:
+      - crc: 0x138FAF5E
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27236,19 +27236,19 @@ plugins:
         util: TES5Edit v3.2.2
   - name: 'Helsmyrr.esp'
     dirty:
-      - crc: 0x9c56e282
-        <<: *dirtyPlugin
+      - <<: *dirtyPlugin
+        crc: 0x9c56e282
         itm: 157
         udr: 58
   - name: 'Sea of Spirits.esp'
     dirty:
-      - crc: 0xDCD3E352
-        <<: *dirtyPlugin
+      - <<: *dirtyPlugin
+        crc: 0xDCD3E352
         itm: 123
     clean:
       - crc: 0x4D36AC80
         util: TES5Edit v3.2.2
-  - name: 'Arthmoor's Skyrim Villages - All In One.esp'
+  - name: 'Arthmoor''s Skyrim Villages - All In One.esp'
     clean:
       - crc: 0x5E034168
         util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27488,3 +27488,7 @@ plugins:
     clean:
       - crc: 0x0A36ACF2
         util: TES5Edit v3.2.2
+  - name: 'Skyrim 2017 TPTC - Parallax Maps.esp'
+    clean:
+      - crc: 0x57708C9E
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -25468,6 +25468,13 @@ plugins:
       - 'Helgen Reborn.esp'
       - 'Immersive Citizens - AI Overhaul.esp'
       - 'Requiem.esp'
+    dirty:
+      - <<: *dirtyPlugin
+        crc: 0xA505BEA9
+        itm: 6
+    clean:
+      - crc: 0x2C0844CC
+        util: TES5Edit v3.2.2
   - name: 'RealisticWaterTwo - Legendary.esp'
     after:
       - 'SkyFalls + SkyMills.esp'
@@ -25494,6 +25501,21 @@ plugins:
       - 'SkyFalls Falskaar Small waterfalls.esp'
       - 'SkyFalls DB + FS Small Waterfalls.esp'
       - 'Immersive Citizens - AI Overhaul.esp'
+    dirty:
+      - <<: *dirtyPlugin
+        crc: 0xA0056AE4
+        itm: 4
+    clean:
+      - crc: 0xDB6449DB
+        util: TES5Edit v3.2.2
+  - name: 'RealisticWaterTwo - Waves.esp'
+    dirty:
+      - <<: *dirtyPlugin
+        crc: 0x3B4FFDF9
+        itm: 8
+    clean:
+      - crc: 0xD83757D6
+        util: TES5Edit v3.2.2
   - name: 'Better Mills Textures.esp'
     after:
       - 'SkyFalls + SkyMills.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27794,3 +27794,7 @@ plugins:
     clean:
       - crc: 0x36310FC3
         util: TES5Edit v3.2.2
+  - name: 'WindhelmFR.esp'
+    clean:
+      - crc: 0x66A71AD4
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27958,3 +27958,7 @@ plugins:
     clean:
       - crc: 0x5111AD5F
         util: TES5Edit v3.2.2
+  - name: 'Clairvoyance.esp'
+    clean:
+      - crc: 0x51B691B1
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -26603,6 +26603,9 @@ plugins:
     clean:
       - crc: 0xB536FDD0
         util: TES5Edit v3.1.3
+    clean:
+      - crc: 0x321C14B7
+        util: TES5Edit v3.2.2
   - name: 'CompanionArissa.esm'
     msg:
       - <<: *reqRequiemPatch

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2834,6 +2834,13 @@ plugins:
         <<: *dirtyPlugin
         itm: 1
         udr: 0
+    clean:
+      - crc: 0xEA312F01
+        util: TES5Edit v3.2.2
+  - name: 'Prometheus_NSUTR BDS Patch.esp'
+    clean:
+      - crc: 0x0513DEE7
+        util: TES5Edit v3.2.2
   - name: 'DFG''s Blade & Dagger Sheathe Sounds.esp'
     dirty:
       - crc: 0x3f16767e

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9230,6 +9230,9 @@ plugins:
     msg:
       - <<: *reqRequiemPatch
         condition: 'active("Requiem.esp") and not active("COR-CraftingOverhaulReqtified.esp")'
+    clean:
+      - crc: 0xD7E467D4
+        util: TES5Edit v3.2.2
   - name: 'CCO_Frostfall_Patch.esp'
     dirty:
       - crc: 0x7b3ce75d

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -12122,6 +12122,9 @@ plugins:
       - crc: 0xfb30c482
         <<: *dirtyPlugin
         itm: 5
+    clean:
+      - crc: 0x96DF9769
+        util: TES5Edit v3.2.2
   - name: 'CWIELnFXPatch.esp'
     dirty:
       - crc: 0x350cacf3

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27528,3 +27528,7 @@ plugins:
     clean:
       - crc: 0x64EB9F73
         util: TES5Edit v3.2.2
+  - name: 'A Fitting Throne for Vyrthur.esp'
+    clean:
+      - crc: 0xD6C7891
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9253,6 +9253,8 @@ plugins:
     clean:
       - crc: 0xD7E467D4
         util: TES5Edit v3.2.2
+      - crc: 0x985DA4BC
+        util: TES5Edit v3.2.2
   - name: 'CCO_Frostfall_Patch.esp'
     dirty:
       - crc: 0x7b3ce75d

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27468,3 +27468,7 @@ plugins:
     clean:
       - crc: 0xEBCD3A30
         util: TES5Edit v3.2.2
+  - name: 'iNeed.esp'
+    clean:
+      - crc: 0xD9020262
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27532,7 +27532,7 @@ plugins:
         util: TES5Edit v3.2.2
   - name: 'A Fitting Throne for Vyrthur.esp'
     clean:
-      - crc: 0xD6C7891
+      - crc: 0xD6C78911
         util: TES5Edit v3.2.2
   - name: 'SmartTraining.esp'
     clean:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -24536,6 +24536,9 @@ plugins:
         condition: 'active("Requiem.esp") and not active("Requiem - Live Another Life.esp")'
     tag:
       - C.Location
+    clean:
+      - crc: 0x855A5882
+        util: TES5Edit v3.2.2
   - name: 'Bandit Start.esp'
     dirty:
       - crc: 0x57d4e755

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27007,6 +27007,9 @@ plugins:
     msg:
       - <<: *reqRequiemPatch
         condition: 'active("Requiem.esp") and not active("Requiem - Frostfall.esp") and not active("RSE-RequiemSurvivalExperience.esp")'
+    clean:
+      - crc: 0x21E97089
+        util: TES5Edit v3.2.2
   - name: 'HothFollower.esp'
     msg:
       - <<: *reqRequiemPatch

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27786,3 +27786,7 @@ plugins:
     clean:
       - crc: 0x81A20CA2
         util: TES5Edit v3.2.2
+  - name: 'Shadowmarks.esp'
+    clean:
+      - crc: 0xBFC44B8B
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27660,3 +27660,12 @@ plugins:
     clean:
       - crc: 0x38A6BDEA
         util: TES5Edit v3.2.2
+  - name: 'AshesOfTheRedMountain.esp'
+    msg:
+      - <<: *hasWildEdits
+        subs:
+          - '[Manual Cleaning Guide](https://forums.nexusmods.com/index.php?/topic/2293580-ashes-of-the-red-mountain/?p=39638825)'
+        condition: 'checksum("AshesOfTheRedMountain.esp", 52B13664) or checksum("AshesOfTheRedMountain.esp", BDE2dA1A)'
+    clean:
+      - crc: 0x675E8C28
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27260,3 +27260,7 @@ plugins:
     clean:
       - crc: 0x210D0753
         util: TES5Edit v3.2.2
+  - name: 'Cidhna Mine Expanded.esp'
+    clean:
+      - crc: 0x81FBA022
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9683,7 +9683,7 @@ plugins:
     after:
       - 'Requiem.esp'
     clean:
-      - crc: 0x51B691B1
+      - crc: 0x8755BBC1
         util: TES5Edit v3.2.2
 ### End of Requiem's rules ###
   - name: 'Skyrim Hardcore Overhaul.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -16132,6 +16132,9 @@ plugins:
     tag:
       - Delev
       - Relev
+    clean:
+      - crc: 0x0C80954F
+        util: TES5Edit v3.2.2
   - name: 'Babette.esp'
     msg:
       - <<: *corrupt

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -5668,13 +5668,13 @@ plugins:
       - 'SKSE Hotkeys.esp'
     clean:
       - crc: 0x762DC693
-        util: TES5Edit v3.1.3
+        util: TES5Edit v3.2.2
   - name: 'WetandCold - Ashes.esp'
     after:
       - 'SKSE Hotkeys.esp'
     clean:
       - crc: 0x3D7CC687
-        util: TES5Edit v3.1.3
+        util: TES5Edit v3.2.2
   - name: 'Where''s My Horse Gone Essential Horses.esp'
     inc:
       - 'Where''s My Horse Gone.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27456,7 +27456,7 @@ plugins:
     clean:
       - crc: 0xDE8C3380
         util: TES5Edit v3.2.2
-  - name: 'Windhelm's Ancient Lighthouse.esp'
+  - name: 'Windhelm''s Ancient Lighthouse.esp'
     clean:
       - crc: 0x9BC1D211
         util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9418,7 +9418,7 @@ plugins:
             text: 'Delete MineOreScript.pex from Requiem. [CCOR](http://www.nexusmods.com/skyrim/mods/49791)''s script must take precedence.'
           - lang: ja
             text: 'RequiemのMineOreScript.pexは削除してください。[CCOR](http://www.nexusmods.com/skyrim/mods/49791)側のスクリプトを優先させる必要があります。'
-        condition: 'active("Complete Crafting Overhaul_Remade.esp") and (checksum("Scripts/MineOreScript.pex", 82F96995) or checksum("Scripts/MineOreScript.pex", 0332450B))'
+        condition: 'active("Complete Crafting Overhaul_Remade.esp") and (checksum("Scripts/MineOreScript.pex", 82F96995) or checksum("Scripts/MineOreScript.pex", 0332450B) or checksum("Scripts/MineOreScript.pex", 8FFEAA3B))'
     tag:
       - Delev
       - Relev

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27798,3 +27798,7 @@ plugins:
     clean:
       - crc: 0x66A71AD4
         util: TES5Edit v3.2.2
+  - name: 'SilverMapcsb.esp'
+    clean:
+      - crc: 0x51B461AB
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27155,3 +27155,7 @@ plugins:
     clean:
       - crc: 0x4530C736
         util: TES5Edit v3.2.2
+  - name: 'NPCWaterAIScripted.esp'
+    clean:
+      - crc: 0x74155306
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27478,7 +27478,7 @@ plugins:
         util: TES5Edit v3.2.2
   - name: 'Immersive Encounters.esp'
     clean:
-      - crc: 0xBF61E096
+      - crc: 0x08B011F9
         util: TES5Edit v3.2.2
   - name: 'Immersive Encounters - RS Children Patch.esp'
     clean:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27902,6 +27902,8 @@ plugins:
   - name: 'RDO - Immersive Horses Patch.esp'
     after:
       - 'RDO - Requiem Patch.esp'
+      - 'Requiem - Immersive Horses.esp'
+      - 'Requiem - Immersive Horses - SkyTEST.esp'
     clean:
       - crc: 0xFEC52ACB
         util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27077,6 +27077,9 @@ plugins:
       - <<: *reqRequiemPatch
         condition: 'active("Requiem.esp") and not active("Requiem - Immersive Jewelry( BTC| ISC)?\.esp")'
   - name: 'Wild World.esp'
+    msg:
+      - <<: *reqRequiemPatch
+        condition: 'active("Requiem.esp") and not active("Requiem - Wild World.esp")'
     clean:
       - crc: 0x71517780
         util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27868,10 +27868,6 @@ plugins:
     clean:
       - crc: 0x39D0E506
         util: TES5Edit v3.2.2
-  - name: 'ShowersInInns.esp'
-    clean:
-      - crc: 0xA9B51B10
-        util: TES5Edit v3.2.2
   - name: 'Beards.esp'
     clean:
       - crc: 0x5D189308

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -19229,6 +19229,9 @@ plugins:
         <<: *dirtyPlugin
         itm: 12
         udr: 0
+    clean:
+      - crc: 0x2C685F45
+        util: TES5Edit v3.2.2
   - name: 'EnhancedLightsandFX_CN.esp'
     after:
       - 'rcrnShaders.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9645,6 +9645,9 @@ plugins:
   - name: 'XPMSE.esp'
     after:
       - 'Requiem.esp'
+    clean:
+      - crc: 0x68388671
+        util: TES5Edit v3.2.2
   - name: 'RealisticRoomRental(-Basic)?.esp'
     after:
       - 'Requiem.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27950,3 +27950,7 @@ plugins:
     clean:
       - crc: 0x4BB71F58
         util: TES5Edit v3.2.2
+  - name: 'Bee Hives.esp'
+    clean:
+      - crc: 0x1AC40D82
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27323,3 +27323,15 @@ plugins:
       - <<: *dirtyPlugin
         crc: 0x2181ED1C
         itm: 15
+  - name: 'UniqueBorderGates-All.esp'
+    clean:
+      - crc: 0x7E6B19CA
+        util: TES5Edit v3.2.2
+  - name: 'UniqueBorderGates-All-BetterDGEntrance.esp'
+    clean:
+      - crc: 0xB4B9957A
+        util: TES5Edit v3.2.2
+  - name: 'UniqueBorderGates-All-PointTheWay.esp'
+    clean:
+      - crc: 0xFB5D20A4
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -16281,6 +16281,8 @@ plugins:
     clean:
       - crc: 0x18343B2E
         util: TES5Edit v3.1.3
+      - crc: 0x8AFD20DB
+        util: TES5Edit v3.2.2
   - name: 'Book Covers Dawnguard.esp'
     msg:
       - <<: *alreadyInX

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27124,3 +27124,7 @@ plugins:
     clean:
       - crc: 0x80BED226
         util: TES5Edit v3.2.2
+  - name: 'Realistic-Voice.esp'
+    clean:
+      - crc: 0xB8DF8C55
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27640,3 +27640,11 @@ plugins:
     clean:
       - crc: 0x81DB879A
         util: TES5Edit v3.2.2
+  - name: 'Ashes.esp'
+    dirty:
+      - <<: *dirtyPlugin
+        crc: 0x75d8b080
+        itm: 2
+    clean:
+      - crc: 0x97235797
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -17974,6 +17974,11 @@ plugins:
       - crc: 0x23f00d9a
         <<: *dirtyPlugin
         itm: 17
+  - name: 'SkyTEST-RealisticAnimals&Predators\.es(p|m)'
+    msg:
+      - <<: *useOnlyOneX
+        condition: 'many("SkyTEST-RealisticAnimals&Predators\.es(p|m)")'
+        subs: [ 'SkyTEST-RealisticAnimals&Predators plugin' ]
   - name: 'Convenient Horses.esp'
     msg: [ *doNotClean ]
   - name: 'Skyrim Horses Renewal.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -19201,6 +19201,9 @@ plugins:
       - crc: 0x6c30e0ba
         <<: *dirtyPlugin
         itm: 4
+    clean:
+      - crc: 0x255F7577
+        util: TES5Edit v3.2.2
   - name: 'Open Cities Skyrim.esp'
     group: *ocsGroup
     after:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -26987,6 +26987,22 @@ plugins:
     clean:
       - crc: 0xDB37D153
         util: TES5Edit v3.2.2
+  - name: 'CFTO-InconNPCs-Patch.esp'
+    clean:
+      - crc: 0xADE4F4F0
+        util: TES5Edit v3.2.2
+  - name: 'CFTO-JK-Patch.esp'
+    clean:
+      - crc: 0xBADB959A
+        util: TES5Edit v3.2.2
+  - name: 'CFTO-BetterTelMithryn-Patch.esp'
+    clean:
+      - crc: 0x678D1FAE
+        util: TES5Edit v3.2.2
+  - name: 'HFE-CFTO-Patch.esp'
+    clean:
+      - crc: 0xE2228FD3
+        util: TES5Edit v3.2.2
   - name: 'Immersive Ingestibles.esp'
     after:
       - 'ETaC - RESOURCES.esm'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27938,3 +27938,7 @@ plugins:
     clean:
       - crc: 0xB8AC0C85
         util: TES5Edit v3.2.2
+  - name: 'HallgarthsforNPCs - USLEEP.esp'
+    clean:
+      - crc: 0xD47A21F7
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3312,6 +3312,9 @@ plugins:
     tag:
       - Delev
       - Relev
+    clean:
+      - crc: 0xAC24F58B
+        util: TES5Edit v3.2.2
   - name: 'Economics of Skyrim.esp'
     tag:
       - Delev

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27648,3 +27648,15 @@ plugins:
     clean:
       - crc: 0x97235797
         util: TES5Edit v3.2.2
+  - name: 'Vividian - Lanterns of Skyrim Preset.esp'
+    clean:
+      - crc: 0x17CFB464
+        util: TES5Edit v3.2.2
+  - name: 'Vividian - Torches Preset.esp'
+    clean:
+      - crc: 0xE3994512
+        util: TES5Edit v3.2.2
+  - name: 'vividian - Wearable Lanterns Preset.esp'
+    clean:
+      - crc: 0x38A6BDEA
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27574,3 +27574,7 @@ plugins:
     clean:
       - crc: 0x5AE02E2B
         util: TES5Edit v3.2.2
+  - name: 'Watercolor_for_ENB_RWT.esp '
+    clean:
+      - crc: 0x6023FA83
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27099,3 +27099,7 @@ plugins:
     clean:
       - crc: 0xE87C93C0
         util: TES5Edit v3.2.2
+  - name: 'SafeAutoSave.esp'
+    clean:
+      - crc: 0xC6E86A52
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27538,3 +27538,7 @@ plugins:
     clean:
       - crc: 0x2270F07E
         util: TES5Edit v3.2.2
+  - name: 'KS Hairdos - HDT.esp'
+    clean:
+      - crc: 0x5AE02E2B
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27681,3 +27681,7 @@ plugins:
     clean:
       - crc: 0x23E4EB08
         util: TES5Edit v3.2.2
+  - name: 'Skyrim Particle Patch for ENB - Flame Atronach Fix.esp'
+    clean:
+      - crc: 0x209727D0
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6022,7 +6022,7 @@ plugins:
     req: [ *SKSE ]
     clean:
       - crc: 0x6098B756
-        util: TES5Edit v3.1.3
+        util: TES5Edit v3.2.2
   - name: 'LessIntrusiveHUD.esp'
     req:
       - *SKSE

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27833,3 +27833,7 @@ plugins:
     clean:
       - crc: 0x7A15383C
         util: TES5Edit v3.2.2
+  - name: 'Moss Rocks.esp'
+    clean:
+      - crc: 0x867372A2
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27304,9 +27304,6 @@ plugins:
   - name: 'Dr_BandolierDG.esp'
     msg:
       - <<: *alreadyInCompleteCraftingOverhaulRemade
-  - name: 'RDO - Immersive Horses Patch.esp'
-    after:
-      - 'RDO - Requiem Patch.esp'
   - name: 'Serana Dialogue Edit.esp'
     after:
       - name: 'Relationship Dialogue Overhaul.esp'
@@ -27885,6 +27882,8 @@ plugins:
       - crc: 0x827458D7
         util: TES5Edit v3.2.2
   - name: 'RDO - Immersive Horses Patch.esp'
+    after:
+      - 'RDO - Requiem Patch.esp'
     clean:
       - crc: 0xFEC52ACB
         util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -11557,10 +11557,16 @@ plugins:
         nav: 2
   - name: 'BetterDGEntrance.esp'
     dirty:
-      - crc: 0x2eb928ab
-        <<: *dirtyPlugin
+      - <<: *dirtyPlugin
+        crc: 0x2eb928ab
         itm: 14
         udr: 14
+      - <<: *dirtyPlugin
+        crc: 0x53EC5DE6
+        itm: 7
+    clean:
+      - crc: 0xAA148B12
+        util: TES5Edit v3.2.2
   - name: 'BetterDwemerExteriors.esp'
     dirty:
       - crc: 0xc96424e

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27492,3 +27492,7 @@ plugins:
     clean:
       - crc: 0x57708C9E
         util: TES5Edit v3.2.2
+  - name: 'JZBai_PracticalFemaleArmors.esp'
+    clean:
+      - crc: 0x05345A0D
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27088,3 +27088,7 @@ plugins:
     clean:
       - crc: 0x2B77F815
         util: TES5Edit v3.2.2
+  - name: 'BlackHorseCourier.esp'
+    clean:
+      - crc: 0x3C97A13F
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27442,3 +27442,7 @@ plugins:
     clean:
       - crc: 0x553737F7
         util: TES5Edit v3.2.2
+  - name: 'PilgrimsDelight.esp'
+    clean:
+      - crc: 0x2C24D5A5
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27748,3 +27748,7 @@ plugins:
     clean:
       - crc: 0x24F346A6
         util: TES5Edit v3.2.2
+  - name: 'OH GOD BEES.esp'
+    clean:
+      - crc: 0xE7FEF2BC
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27293,3 +27293,7 @@ plugins:
     clean:
       - crc: 0x8B93B372
         util: TES5Edit v3.2.2
+  - name: 'JK's Falkreath.esp'
+    clean:
+      - crc: 0xFFD6E99E
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27802,3 +27802,7 @@ plugins:
     clean:
       - crc: 0x51B461AB
         util: TES5Edit v3.2.2
+  - name: 'LootParalyzedPeople.esp'
+    clean:
+      - crc: 0xE3A89A78
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -19934,6 +19934,9 @@ plugins:
     req:
       - *SKSE
       - *SkyUI
+    clean:
+      - crc: 0x0DF2B11C
+        util: TES5Edit v3.2.2
   - name: 'Better Vampires DG.esp'
     msg: [ *obsolete ]
   - name: 'Better Vampires.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27876,3 +27876,7 @@ plugins:
     clean:
       - crc: 0x5D189308
         util: TES5Edit v3.2.2
+  - name: 'Coin Toss.esp'
+    clean:
+      - crc: 0xB29E4940
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27705,3 +27705,7 @@ plugins:
     clean:
       - crc: 0xDF7C2C18
         util: TES5Edit v3.2.2
+  - name: 'CollegeApplication.esp'
+    clean:
+      - crc: 0xA5BE7616
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27077,6 +27077,9 @@ plugins:
     msg:
       - <<: *reqRequiemPatch
         condition: 'active("Requiem.esp") and not active("Requiem - Unique Uniques.esp") and not active("Requiem - Unique Uniques - AOS.esp")'
+    clean:
+      - crc: 0x51024687
+        util: TES5Edit v3.2.2
   - name: 'VioLens.esp'
     msg:
       - <<: *reqRequiemPatch

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27339,6 +27339,10 @@ plugins:
     clean:
       - crc: 0xBF61E096
         util: TES5Edit v3.2.2
+  - name: 'Immersive Encounters - RS Children Patch.esp'
+    clean:
+      - crc: 0xC4949683
+        util: TES5Edit v3.2.2
   - name: 'SkyrimUnhinged.esp'
     dirty:
       - <<: *dirtyPlugin

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27733,3 +27733,7 @@ plugins:
     clean:
       - crc: 0x3BAF6713
         util: TES5Edit v3.2.2
+  - name: 'RandomClappingAnimations.esp'
+    clean:
+      - crc: 0xEF373FDB
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -26955,6 +26955,9 @@ plugins:
     msg:
       - <<: *reqRequiemPatch
         condition: 'active("Requiem.esp") and not active("Requiem - WM Flora Fixes.esp")'
+    clean:
+      - crc: 0xADF81090
+        util: TES5Edit v3.2.2
   - name: 'DawnguardArsenal.esp'
     msg:
       - <<: *reqRequiemPatch

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -26949,6 +26949,9 @@ plugins:
       - '3DNPC.esp'
     tag:
       - C.Owner
+    clean:
+      - crc: 0x7781895E
+        util: TES5Edit v3.2.2
   - name: 'Provincial Courier Service.esp'
     after:
       - 'Immersive Citizens - AI Overhaul.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27335,3 +27335,12 @@ plugins:
     clean:
       - crc: 0xFB5D20A4
         util: TES5Edit v3.2.2
+  - name: 'Vaults of Skyrim Palaces Patch.esp'
+    dirty:
+      - <<: *dirtyPlugin
+        crc: 0x7CAE947E
+        itm: 26
+        udr: 17
+    clean:
+      - crc: 0xE318D109
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27476,3 +27476,7 @@ plugins:
     clean:
       - crc: 0x1F5051F9
         util: TES5Edit v3.2.2
+  - name: 'PreventsAccidentPickUp.esp'
+    clean:
+      - crc: 0x1F81BED9
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27917,3 +27917,7 @@ plugins:
     clean:
       - crc: 0xC1A5DE76
         util: TES5Edit v3.2.2
+  - name: 'Artful Dodger - Dynamic Pickpocket Cap.esp'
+    clean:
+      - crc: 0x3D6CFB11
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -26979,6 +26979,14 @@ plugins:
     clean:
       - crc: 0x2C01D8A0
         util: TES5Edit v3.2.2
+  - name: 'CFTO-CoveredCarriages.esp'
+    clean:
+      - crc: 0xD4E1FF07
+        util: TES5Edit v3.2.2
+  - name: 'CFTO-Lanterns.esp'
+    clean:
+      - crc: 0xDB37D153
+        util: TES5Edit v3.2.2
   - name: 'Immersive Ingestibles.esp'
     after:
       - 'ETaC - RESOURCES.esm'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27076,6 +27076,10 @@ plugins:
     msg:
       - <<: *reqRequiemPatch
         condition: 'active("Requiem.esp") and not active("Requiem - Immersive Jewelry( BTC| ISC)?\.esp")'
+  - name: 'Wild World.esp'
+    clean:
+      - crc: 0x71517780
+        util: TES5Edit v3.2.2
   - name: 'ISC WAFR Patch.esp'
     msg:
       - <<: *alreadyInX

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27532,3 +27532,7 @@ plugins:
     clean:
       - crc: 0xD6C7891
         util: TES5Edit v3.2.2
+  - name: 'SmartTraining.esp'
+    clean:
+      - crc: 0x2270F07E
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27402,3 +27402,7 @@ plugins:
     clean:
       - crc: 0x6190C05E
         util: TES5Edit v3.2.2
+  - name: 'SolitudeTempleFrescoes.esp'
+    clean:
+      - crc: 0x450BD436
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27318,3 +27318,8 @@ plugins:
     clean:
       - crc: 0xBF61E096
         util: TES5Edit v3.2.2
+  - name: 'SkyrimUnhinged.esp'
+    dirty:
+      - <<: *dirtyPlugin
+        crc: 0x2181ED1C
+        itm: 15

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27199,3 +27199,7 @@ plugins:
     clean:
       - crc: 0x80590F46
         util: TES5Edit v3.2.2
+  - name: 'RealisticHuskySounds.esp'
+    clean:
+      - crc: 0x40FA36B0
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27434,3 +27434,7 @@ plugins:
     clean:
       - crc: 0x20897014
         util: TES5Edit v3.2.2
+  - name: 'EasierRidersDungeonPack.esp'
+    clean:
+      - crc: 0x60B973B2
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27516,3 +27516,7 @@ plugins:
     clean:
       - crc: 0x1DA6AE1A
         util: TES5Edit v3.2.2
+  - name: 'Better Dynamic Ash.esp'
+    clean:
+      - crc: 0xD2E3193B
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27673,3 +27673,7 @@ plugins:
     clean:
       - crc: 0x28E7B278
         util: TES5Edit v3.2.2
+  - name: 'Dead Body Collision.esp'
+    clean:
+      - crc: 0x8853B30B
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27620,3 +27620,12 @@ plugins:
     clean:
       - crc: 0x6023FA83
         util: TES5Edit v3.2.2
+  - name: 'Unique Flowers & Plants.esm'
+    msg:
+      - <<: *hasWildEdits
+        subs:
+          - '[Manual Cleaning Guide](https://forums.nexusmods.com/index.php?/topic/2101589-unique-flowers-and-plants/?p=63660816)'
+        condition: 'checksum("Unique Flowers & Plants.esm", 3966F8DD)'
+    clean:
+      - crc: 0x81DB879A
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27281,3 +27281,11 @@ plugins:
     clean:
       - crc: 0x86CC1C61
         util: TES5Edit v3.2.2
+  - name: 'SMIM-Merged-All.esp'
+    dirty:
+      - <<: *dirtyPlugin
+        crc: 0x26FC8290
+        udr: 1
+    clean:
+      - crc: 0xD4355BE5
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27107,3 +27107,7 @@ plugins:
     clean:
       - crc: 0x60DCC06C
         util: TES5Edit v3.2.2
+  - name: 'HeartBreaker.esp'
+    clean:
+      - crc: 0xCDACB771
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27778,3 +27778,7 @@ plugins:
       - <<: *dirtyPlugin
         crc: 0x9440F010
         itm: 8
+  - name: 'ImperialSoldiersEscortFix.esp'
+    clean:
+      - crc: 0x1F785711
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -303,7 +303,7 @@ common:
     util: '[TES5Edit](http://www.nexusmods.com/skyrim/mods/25859)'
     info: 'A cleaning guide is available [here](http://www.creationkit.com/index.php?title=TES5Edit_Cleaning_Guide_-_TES5Edit).'
   - &hasWildEdits
-    type: say
+    type: warn
     content:
       - lang: en
         text: "This plugin contains wild edits. A manual [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) cleaning guide is available here: %1%"

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27580,7 +27580,7 @@ plugins:
     clean:
       - crc: 0x5AE02E2B
         util: TES5Edit v3.2.2
-  - name: 'Watercolor_for_ENB_RWT.esp '
+  - name: 'Watercolor_for_ENB_RWT.esp'
     clean:
       - crc: 0x6023FA83
         util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27934,3 +27934,7 @@ plugins:
     clean:
       - crc: 0x9FE950EF
         util: TES5Edit v3.2.2
+  - name: 'HallgarthAdditionalHair.esp'
+    clean:
+      - crc: 0xB8AC0C85
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27406,3 +27406,7 @@ plugins:
     clean:
       - crc: 0x450BD436
         util: TES5Edit v3.2.2
+  - name: 'CaranthirTowerReborn.esp'
+    clean:
+      - crc: 0x0991A6A6
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27057,6 +27057,7 @@ plugins:
         util: TES5Edit v3.2.2
   - name: 'imp_helm_legend.esp'
     msg:
+      - *doNotClean
       - <<: *reqRequiemPatch
         condition: 'active("Requiem.esp") and not active("Requiem - Improved Closefaced Helmets.esp")'
     tag:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -26758,6 +26758,9 @@ plugins:
     url: [ 'http://www.nexusmods.com/skyrim/mods/59721' ]
   - name: 'DesyncBirdsOfPrey.esp'
     url: [ 'http://www.nexusmods.com/skyrim/mods/59721' ]
+    clean:
+      - crc: 0x34AC0072
+        util: TES5Edit v3.2.2
     tag:
       - NoMerge
   - name: 'SGR Enhanced Trees Activator.esp'
@@ -27978,4 +27981,16 @@ plugins:
   - name: 'Tentapalooza.esp'
     clean:
       - crc: 0x0BE7B239
+        util: TES5Edit v3.2.2
+  - name: 'HighHrothgarWindowGlow.esp'
+    clean:
+      - crc: 0x12F22C8E
+        util: TES5Edit v3.2.2
+  - name: 'WhiterunExterior.esp'
+    clean:
+      - crc: 0xB2CB7F84
+        util: TES5Edit v3.2.2
+  - name: 'SolitudeExterior.esp'
+    clean:
+      - crc: 0x75647A7E
         util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27499,10 +27499,18 @@ plugins:
       - crc: 0x138FAF5E
         util: TES5Edit v3.2.2
   - name: 'skycity3.esp'
+    msg:
+      - <<: *hasWildEdits
+        subs:
+          - '[Manual Cleaning Guide](https://forums.nexusmods.com/index.php?/topic/2127024-sky-city-markarth-evolved/?p=63661711)'
+        condition: 'checksum("skycity3.esp", 4947FD90)'
     dirty:
       - <<: *dirtyPlugin
         crc: 0xD31A8590
         itm: 20
+    clean:
+      - crc: 0x6D912864
+        util: TES5Edit v3.2.2
   - name: 'Farm Animals_HF.esp'
     clean:
       - crc: 0x6190C05E

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -26955,6 +26955,9 @@ plugins:
   - name: 'Provincial Courier Service.esp'
     after:
       - 'Immersive Citizens - AI Overhaul.esp'
+    clean:
+      - crc: 0xD6D01965
+        util: TES5Edit v3.2.2
   - name: 'Relationship Dialogue Overhaul.esp'
     after:
       - 'Alternate Start - Live Another Life.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -26970,6 +26970,9 @@ plugins:
   - name: 'CFTO.esp'
     after:
       - 'Immersive Citizens - AI Overhaul.esp'
+    clean:
+      - crc: 0x2C01D8A0
+        util: TES5Edit v3.2.2
   - name: 'Immersive Ingestibles.esp'
     after:
       - 'ETaC - RESOURCES.esm'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27709,3 +27709,11 @@ plugins:
     clean:
       - crc: 0xA5BE7616
         util: TES5Edit v3.2.2
+  - name: 'DarkSkyrim.esp'
+    dirty:
+      - <<: *dirtyPlugin
+        crc: 0xC761C6D2
+        itm: 21
+    clean:
+      - crc: 0xDD298BEE
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -8158,6 +8158,9 @@ plugins:
         condition: 'active("Requiem.esp") and not active("Requiem - Heavy Armory.esp")'
     tag:
       - Relev
+    clean:
+      - crc: 0x613D10C8
+        util: TES5Edit v3.2.2
   - name: 'PrvtI_HeavyArmory_DG_Addon.esp'
     tag:
       - Delev

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27520,3 +27520,7 @@ plugins:
     clean:
       - crc: 0xD2E3193B
         util: TES5Edit v3.2.2
+  - name: 'eggkilleryum.esp'
+    clean:
+      - crc: 0x517413C4
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27729,6 +27729,9 @@ plugins:
       - crc: 0xDF7C2C18
         util: TES5Edit v3.2.2
   - name: 'CollegeApplication.esp'
+    msg:
+      - <<: *obsolete
+        condition: 'checksum("CollegeApplication.esp", 314DD5F6)'
     clean:
       - crc: 0xA5BE7616
         util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27131,3 +27131,7 @@ plugins:
     clean:
       - crc: 0xB8DF8C55
         util: TES5Edit v3.2.2
+  - name: 'WondersofWeather.esp'
+    clean:
+      - crc: 0x94835DDD
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -16980,6 +16980,14 @@ plugins:
     after:
       - 'Hothtrooper44_ArmorCompilation.esp'
       - 'Hothtrooper44_Armor_Ecksstra.esp'
+    msg:
+      - <<: *hasWildEdits
+        subs:
+          - '[Manual Cleaning Guide](https://forums.nexusmods.com/index.php?/topic/771785-guard-dialogue-overhaul/?p=63659936)'
+        condition: 'checksum("Guard Dialogue Overhaul.esp", AFACD2E9)'
+    clean:
+      - crc: 0x46880DEB
+        util: TES5Edit v3.2.2
   - name: 'Guard Patrols.esp'
     dirty:
       - crc: 0x745dbcc

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -26390,6 +26390,13 @@ plugins:
   - name: 'Verdant - A Skyrim Grass Plugin.esp'
     after:
       - 'Skyrim Flora Overhaul.esp'
+    dirty:
+      - <<: *dirtyPlugin
+        crc: 0xE28C36AB
+        itm: 6
+    clean:
+      - crc: 0x77AA0309
+        util: TES5Edit v3.2.2
   - name: 'Immersive detection of NPC.esp'
     after:
       - 'Combat Evolved.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -25536,6 +25536,11 @@ plugins:
     clean:
       - crc: 0xD83757D6
         util: TES5Edit v3.2.2
+  - name: 'RealisticWaterTwo - (Dawnguard|Dragonborn|Waves( - Dawnguard)?)\.esp'
+    msg:
+      - <<: *alreadyInX
+        condition: 'active("RealisticWaterTwo - Legendary.esp")'
+        subs: [ 'RealisticWaterTwo - Legendary.esp' ]
   - name: 'Better Mills Textures.esp'
     after:
       - 'SkyFalls + SkyMills.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27246,3 +27246,7 @@ plugins:
     clean:
       - crc: 0x5E034168
         util: TES5Edit v3.2.2
+  - name: 'Populated Skyrim Legendary.esp'
+    clean:
+      - crc: 0x159E003B
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -18100,6 +18100,9 @@ plugins:
       - crc: 0x6cf96c54
         <<: *dirtyPlugin
         itm: 8
+    clean:
+      - crc: 0x3A570202
+        util: TES5Edit v3.2.2
   - name: 'the_god_auriel.esp'
     dirty:
       - crc: 0x44c9d999

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6008,7 +6008,7 @@ plugins:
         condition: 'version("SkyUI.esp", "4", >=) and version("Fhaarkas Font Mod - SkyUI.esp", "4.0", ==)'
     clean:
       - crc: 0xBEA2DC76
-        util: TES5Edit v3.1.3
+        util: TES5Edit v3.2.2
   - name: 'iHUD.esp'
     req: [ *SKSE ]
     clean:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2485,6 +2485,9 @@ plugins:
       - Sound
       - Relev
       - Stats
+    clean:
+      - crc: 0xBA9DB5D6
+        util: TES5Edit v3.2.2
   - name: 'Clothing Jewelry & Clutter Fixes.esp'
     tag:
       - Stats

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27508,3 +27508,11 @@ plugins:
     clean:
       - crc: 0x5D4989D3
         util: TES5Edit v3.2.2
+  - name: 'NB-Scars.esp'
+    dirty:
+      - <<: *dirtyPlugin
+        crc: 0x8A54FBB8
+        itm: 1
+    clean:
+      - crc: 0x1DA6AE1A
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -5253,8 +5253,13 @@ plugins:
       - crc: 0x18DBC60E
         <<: *dirtyPlugin
         itm: 3
+      - crc: 0x2FC92864
+        <<: *dirtyPlugin
+        itm: 1
     clean:
       - crc: 0xF3206010
+        util: TES5Edit v3.2.2
+      - crc: 0x3ABCD6A5
         util: TES5Edit v3.2.2
   - name: 'SkyEx.esp'
     dirty:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27972,3 +27972,6 @@ plugins:
     group: *underridesGroup
     after:
       - 'BetterQuestObjectives.esp'
+    clean:
+      - crc: 0x6816E897
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27677,3 +27677,7 @@ plugins:
     clean:
       - crc: 0x8853B30B
         util: TES5Edit v3.2.2
+  - name: 'dD-No Spinning Death Animation Merged.esp'
+    clean:
+      - crc: 0x23E4EB08
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27304,3 +27304,7 @@ plugins:
     clean:
       - crc: 0xFFD6E99E
         util: TES5Edit v3.2.2
+  - name: 'Point The Way.esp'
+    clean:
+      - crc: 0x91D53B8F
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27240,3 +27240,7 @@ plugins:
     clean:
       - crc: 0x4D36AC80
         util: TES5Edit v3.2.2
+  - name: 'Arthmoor's Skyrim Villages - All In One.esp'
+    clean:
+      - crc: 0x5E034168
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27760,3 +27760,7 @@ plugins:
     clean:
       - crc: 0x20EF9B40
         util: TES5Edit v3.2.2
+  - name: 'Raven Rock - Fix Exit on Horseback.esp'
+    clean:
+      - crc: 0x36E1E4FF
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27147,3 +27147,7 @@ plugins:
     clean:
       - crc: 0xFD481790
         util: TES5Edit v3.2.2
+  - name: 'SimplyKnock.esp'
+    clean:
+      - crc: 0x097D7FB3
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27391,3 +27391,7 @@ plugins:
       - <<: *dirtyPlugin
         crc: 0xD31A8590
         itm: 20
+  - name: 'Farm Animals_HF.esp'
+    clean:
+      - crc: 0x6190C05E
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27419,3 +27419,11 @@ plugins:
     clean:
       - crc: 0x0991A6A6
         util: TES5Edit v3.2.2
+  - name: 'manny Lantern Caretakers.esp'
+    dirty:
+      - <<: *dirtyPlugin
+        crc: 0x4EB77E00
+        itm: 2
+    clean:
+      - crc: 0x20897014
+        util: TES5Edit v3.2.2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3192,7 +3192,6 @@ plugins:
     clean:
       - crc: 0xB095E590
         util: TES5Edit v3.1.3
-    clean:
       - crc: 0xDCFE8BC1
         util: TES5Edit v3.2.2
   - name: 'BeastModels.esp'
@@ -16103,9 +16102,6 @@ plugins:
     tag:
       - Delev
       - Relev
-    clean:
-      - crc: 0xF861B2A2
-        util: TES5Edit v3.2.2
   - name: 'Babette.esp'
     msg:
       - <<: *corrupt
@@ -16200,6 +16196,9 @@ plugins:
         condition: 'checksum("BetterQuestObjectives.esp",BCD35920)'
     tag:
       - NoMerge
+    clean:
+      - crc: 0xF861B2A2
+        util: TES5Edit v3.2.2
   - name: 'BetterQuestObjectives-AlternateStartPatch.esp'
     msg:
       - <<: *alreadyInX


### PR DESCRIPTION
Metadata collected while setting up my load order. Summary:

- A lot of `clean` data. I verified that these mods are indeed clean and don't contain wild edits that aren't automatically cleaned by TES5Edit.
- `dirty` data for skyBirds USLEEP Performance Patches, Immersive Dawnguard Dayspring Pass, Realistic Water Two, Verdant - A Skyrim Grass Plugin, Inconsequential NPCs, Helsmyrr Village, Sea of Spirits, Static Mesh Improvement Mod, Skyrim Unhinged, Vaults of Skyrim, Ducks and Swans, SKY CITY - Markarth Rising, Lantern Caretakers, Northborn Scars, Ashes - A Simple and Configurable Death Mod, Skyrim Darkness Immersive corpse, Farmers Sell Produce, Old Dusty travels again, Covered in Bees, Roleplay Notes, Solvable Dragon Claw Doors, Hallgarth's Hair for NPCs and WSCO - Windsong Skyrim Character Overhaul.
-  Wild edits in Guard Dialogue Overhaul, SKY CITY - Markarth Rising, Unique Flowers And Plants, Ashes Of The Red Mountain and Hallgarth's Hair for NPCs that must be manually cleaned.
- Improved `hasWildEdits` message.
- Set `underridesGroup` to load after `default`. This group makes no sense otherwise. The only mod previously contained in this group was Unlimited Bookshelves and this mod is supposed to lose all conflicts.
- Added Weapons & Armor Fixes Remade and Clothing & Clutter Fixes to `underridesGroup`. The description states they should be be loaded at the top of the load order.
- Added Even Better Quest Objectives to `underridesGroup`. This mod should never win a conflict.
- Added Quest Markers Restored to `underridesGroup`. The description states it should be be loaded at the top of the load order.
- Warnings about missing Requiem patches are only displayed if Requiem.esp is active. Previously it was sufficient for Requiem.esp to exist.
- Included Lanterns of Skyrim presets for ELFX, Vivid Weathers and Vividian ENB in the corresponding `useOnlyOneX` warning.
- Removed the following warning (affects only three mods): 
'Be sure you have the correct body mod for the esp. [DIMONIZED UNP](http://www.nexusmods.com/skyrim/mods/6709) or [CBBE](http://www.nexusmods.com/skyrim/mods/2666).'
This message is nothing but spam. It basically says "Be sure to install the correct version". This advice could be added to virtually any mod. Depending on the consequences of installing a wrong version such a warning might be appropriate, but this is certainly not the case. The worst thing that can happen are mismatching boob sizes.
- Added CRC for MineOreScript.pex from Requiem 2.0.2.
- Requiem - Immersive Horses must be loaded after Requiem - SkyTEST and Requiem - Wild World as stated in its description.
- Requiem - Timing is Everything must be loaded after Requiem - Minor Arcana as stated in its description.
- Clairvoyance reveals Quest Markers must be loaded after Requiem as stated in its description.
- Added warning if both the .esp and .esm plugin of SkyTEST - Realistic Animals and Predators are present.
- Removed `doNotClean` message from SeaPoint Settlement. This mod contains no ITMs.
- Removed warning if Requiem patch for Live Another Life is missing. A patch isn't strictly required.
- Added warnings for plugins that are already included in RealisticWaterTwo - Legendary.
- Added Skyrim Unbound to `alternateStartGroup`.
- Added load order for Immersive Citizens - AI Overhaul as stated in its description.
- Added load order for Relationship Dialogue Overhaul as stated in its description.
- Added warning if Requiem patch for Relationship Dialogue Overhaul is missing.
- Added `doNotClean` message to Improved Closefaced Helmets. Whether its ITMs are truly required is debatable, but they're (very likely) intentional and cleaning them has no benefit.
- Added warning if Requiem patch for Wild World is missing.
- Cutting Room Floor - No Snow Under The Roof Patch must be loaded after Cutting Room Floor - Lighting Overhaul as stated in its description.
- Arthmoor's Skyrim Villages - All In One must be loaded after Immersive Citizens - AI Overhaul as stated in its readme.
- Warning if old, bugged version of Better College Application is installed. It's easy to miss the update because the download section is rather confusing.
- Quest Markers Restored must be loaded after Even Better Quest Objectives as stated in its description.