### PR TITLE
Some updated metadata for Requiem

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -26825,6 +26825,9 @@ plugins:
   - name: 'Relationship Dialogue Overhaul.esp'
     after:
       - 'Immersive Citizens - AI Overhaul.esp'
+    msg:
+      - <<: *reqRequiemPatch
+        condition: 'active("Requiem.esp") and not active("RDO - Requiem Patch.esp")'
   - name: 'CFTO.esp'
     after:
       - 'Immersive Citizens - AI Overhaul.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9362,7 +9362,7 @@ plugins:
             text: 'Delete MineOreScript.pex from Requiem. [CCOR](http://www.nexusmods.com/skyrim/mods/49791)''s script must take precedence.'
           - lang: ja
             text: 'RequiemのMineOreScript.pexは削除してください。[CCOR](http://www.nexusmods.com/skyrim/mods/49791)側のスクリプトを優先させる必要があります。'
-        condition: 'active("Complete Crafting Overhaul_Remade.esp") and (checksum("Scripts/MineOreScript.pex", 82F96995) or checksum("Scripts/MineOreScript.pex", 0332450B))'
+        condition: 'active("Complete Crafting Overhaul_Remade.esp") and (checksum("Scripts/MineOreScript.pex", 82F96995) or checksum("Scripts/MineOreScript.pex", 0332450B) or checksum("Scripts/MineOreScript.pex", 8FFEAA3B))'
     tag:
       - Delev
       - Relev

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9509,6 +9509,8 @@ plugins:
     after:
       - 'REQMOD.esp'
       - 'Requiem_Minor_Arcana.esp'
+      - 'Requiem - SkyTEST.esp'
+      - 'Requiem - Wild World.esp'
   - name: 'Requiem - Immersive Horses - SkyTEST.esp'
     req:
       - 'Requiem - SkyTEST.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -24453,6 +24453,8 @@ plugins:
           - lang: ja
             text: 'Live Another Life.espが見つかりました。新バージョンを使う前に古いバージョンをアンインストールしてください。'
         condition: 'file("Live Another Life.esp")'
+      - <<: *reqRequiemPatch
+        condition: 'active("Requiem.esp") and not active("Requiem - Live Another Life.esp")'
     tag:
       - C.Location
   - name: 'Bandit Start.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -24435,8 +24435,6 @@ plugins:
           - lang: ja
             text: 'Live Another Life.espが見つかりました。新バージョンを使う前に古いバージョンをアンインストールしてください。'
         condition: 'file("Live Another Life.esp")'
-      - <<: *reqRequiemPatch
-        condition: 'file("Requiem.esp") and not active("Requiem - Live Another Life.esp")'
     tag:
       - C.Location
   - name: 'Bandit Start.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27110,13 +27110,11 @@ plugins:
     after:
       - 'Requiem - Immersive Horses.esp'
       - 'Requiem - Immersive Horses - SkyTEST.esp'
+      - 'RDO - Requiem Patch.esp'
   - name: 'Quest Markers Restored.esp'
     group: *underridesGroup
     after:
       - 'BetterQuestObjectives.esp'
-  - name: 'RDO - Immersive Horses Patch.esp'
-    after:
-      - 'RDO - Requiem Patch.esp'
   - name: 'Serana Dialogue Edit.esp'
     after:
       - name: 'Relationship Dialogue Overhaul.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9546,6 +9546,9 @@ plugins:
       - <<: *replacerPluginForX
         condition: 'file("RUSTIC SOULGEMS - Unsorted.esp")'
         subs: [ 'RUSTIC SOULGEMS - Unsorted.esp' ]
+  - name: 'Requiem - Timing Is Everything.esp'
+    after:
+      - 'Requiem_Minor_Arcana.esp'
   - name: 'Requiem - Difficulty Bar Restored.esp'
     inc:
       - 'Requiem - Difficulty Bar Restored - Nightmare.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9614,6 +9614,9 @@ plugins:
   - name: 'Requiem - Realistic Darkness.esp'
     after:
       - 'Requiem.esp'
+  - name: 'Clairvoyance.esp'
+    after:
+      - 'Requiem.esp'
 ### End of Requiem's rules ###
   - name: 'Skyrim Hardcore Overhaul.esp'
     tag:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27075,3 +27075,7 @@ plugins:
   - name: 'Dr_BandolierDG.esp'
     msg:
       - <<: *alreadyInCompleteCraftingOverhaulRemade
+  - name: 'RDO - Immersive Horses Patch.esp'
+    after:
+      - 'Requiem - Immersive Horses.esp'
+      - 'Requiem - Immersive Horses - SkyTEST.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -26985,6 +26985,10 @@ plugins:
     msg:
       - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Immersive Jewelry( BTC| ISC)?\.esp")'
+  - name: 'Wild World.esp'
+    msg:
+      - <<: *reqRequiemPatch
+        condition: 'active("Requiem.esp") and not active("Requiem - Wild World.esp")'
   - name: 'ISC WAFR Patch.esp'
     msg:
       - <<: *alreadyInX


### PR DESCRIPTION
- Clairvoyance reveals quest markers must be loaded after Requiem.
- RDO - Immersive Horses patch must be loaded after Requiem - Immersive Horses patch.
- Requiem - Immersive Horses must be loaded after Requiem - SkyTEST and Requiem - Wild World.
- Requiem - Timing is Everything must be loaded after Requiem - Minor Arcana.
- Added CRC for MineOreScript.pex from Requiem 2.0.2.
- Removed warning if Requiem patch for Live Another Life is missing. A patch isn't strictly required.