### PR TITLE
Load order for Immersive Citizens - AI Overhaul

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -26810,13 +26810,19 @@ plugins:
       - 'Civil War Repairs.esp'
       - 'EnhancedLightsandFX.esp'
       - 'ESFCompanions.esp'
+      - 'Hidden Hideouts of Skyrim City Edition - Merged.esp'
+      - 'Hidden Hideouts of Skyrim City Edition - Merged - No Map Markers.esp'
+      - 'Hidden Hideouts of Skyrim City Edition - Merged - Deep Immersion.esp'
+      - '3DNPC.esp'
+      - 'RayeksEnd.esp'
       - 'Requiem.esp'
-      - 'Thane''s Breezehome.esp'
-      - 'Thornrock.esp'
       - 'Routa.esp'
       - 'Routa Non-Stormcloak.esp'
+      - 'SkyfallEstateBuildable.esp'
+      - 'Thane''s Breezehome.esp'
+      - 'Thornrock.esp'
+      - 'Whiterun Complete.esp'
       - 'nTr4nc3 - Whiterun Mansion.esp'
-      - '3DNPC.esp'
     tag:
       - C.Owner
   - name: 'Provincial Courier Service.esp'
@@ -27063,3 +27069,9 @@ plugins:
   - name: 'Dr_BandolierDG.esp'
     msg:
       - <<: *alreadyInCompleteCraftingOverhaulRemade
+  - name: 'Arthmoor''s Skyrim Villages - All In One.esp'
+    after:
+      - 'Immersive Citizens - AI Overhaul.esp'
+  - name: 'more idle markers.esp'
+    after:
+      - 'Immersive Citizens - AI Overhaul.esp'


### PR DESCRIPTION
Load order taken from compatibility page of Immersive Citizens.

Arthmoor's Skyrim Villages - All In One must be loaded after Immersive Citizens - AI Overhaul as stated in its readme.