### PR TITLE
ITMs in improved closefaced helmets shouldn't be cleaned

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -26933,6 +26933,7 @@ plugins:
         condition: 'file("Requiem.esp") and not active("Requiem - Immersive Sounds Compendium.esp")'
   - name: 'imp_helm_legend.esp'
     msg:
+      - *doNotClean
       - <<: *reqRequiemPatch
         condition: 'file("Requiem.esp") and not active("Requiem - Improved Closefaced Helmets.esp")'
     tag:


### PR DESCRIPTION
Whether its ITMs are truly required is debatable, but they're (very likely) intentional and cleaning them has no benefit.