### PR TITLE
Warning for old version of Better College Application

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27063,3 +27063,7 @@ plugins:
   - name: 'Dr_BandolierDG.esp'
     msg:
       - <<: *alreadyInCompleteCraftingOverhaulRemade
+  - name: 'CollegeApplication.esp'
+    msg:
+      - <<: *obsolete
+        condition: 'checksum("CollegeApplication.esp", 314DD5F6)'


### PR DESCRIPTION
Display a warning if old, bugged version of Better College Application is installed. It's easy to miss the update because the download section is rather confusing.