### PR TITLE
Additions to Underridesgroup

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -16900,6 +16900,7 @@ plugins:
         <<: *dirtyPlugin
         itm: 3
   - name: 'Guard Dialogue Overhaul.esp'
+    group: *underridesGroup
     after:
       - 'Hothtrooper44_ArmorCompilation.esp'
       - 'Hothtrooper44_Armor_Ecksstra.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -16181,6 +16181,7 @@ plugins:
       - <<: *corrupt
         condition: 'checksum("BetterNordHeroWeapons.esp",0B39EBC1)'
   - name: 'BetterQuestObjectives.esp'
+    group: *underridesGroup
     msg:
       - type: warn
         content:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2455,6 +2455,7 @@ plugins:
           - lang: ja
             text: 'このModは人間種族（インペリアル、ブレトン、ノルド、レッドガード）を改変するModとは両立できません。また、バベットのfacegenデータ(0001D4B7.NIF)を含むModとは互換性がありません。'
   - name: 'Weapons & Armor Fixes_Remade.esp'
+    group: *underridesGroup
     after:
       - 'Guard Dialogue Overhaul.esp'
     msg:
@@ -2466,6 +2467,7 @@ plugins:
       - Relev
       - Stats
   - name: 'Clothing & Clutter Fixes.esp'
+    group: *underridesGroup
     after:
       - 'Weapons & Armor Fixes_Remade.esp'
     msg:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27066,3 +27066,7 @@ plugins:
   - name: 'Dr_BandolierDG.esp'
     msg:
       - <<: *alreadyInCompleteCraftingOverhaulRemade
+  - name: 'Quest Markers Restored.esp'
+    group: *underridesGroup
+    after:
+      - 'BetterQuestObjectives.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -488,7 +488,7 @@ groups:
     after: [ *newLandsGroup ]
 
   - name: default
-    after: [ *newLandsGroup ]
+    after: [ *underridesGroup ]
 
   - name: &ordinatorGroup Ordinator
     after: [ default ]


### PR DESCRIPTION
- Set `underridesGroup` to load after default. This group makes no sense otherwise. The only mod previously contained in this group was Unlimited Bookshelves and this mod is supposed to lose all conflicts.
- Added Weapons & Armor Fixes Remade and Clothing & Clutter Fixes to `underridesGroup`. The description states they should be be loaded at the top of the load order.
- Added Even Better Quest Objectives to `underridesGroup`. This mod should never win a conflict.
- Added Quest Markers Restored to `underridesGroup`. The description states it should be be loaded at the top of the load order.
- Quest Markers Restored must be loaded after Even Better Quest Objectives as stated in its description.