### PR TITLE
No needless message about body mods

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -8235,16 +8235,6 @@ plugins:
     msg:
       - <<: *patchOutSub
         condition: 'not checksum("SeraphimStandAlone.esp",556E0B68)'
-  - name: 'SeraphineHuntedArmor.esp'
-    msg:
-      - type: say
-        content:
-          - lang: en
-            text: 'Be sure you have the correct body mod for the esp. [DIMONIZED UNP](http://www.nexusmods.com/skyrim/mods/6709) or [CBBE](http://www.nexusmods.com/skyrim/mods/2666).'
-          - lang: ru
-            text: 'Убедитесь, что используете корректный реплейсер тел для этого esp. [DIMONIZED UNP](http://www.nexusmods.com/skyrim/mods/6709) или [CBBE](http://www.nexusmods.com/skyrim/mods/2666).'
-          - lang: ja
-            text: '必ず[DIMONIZED UNP](http://www.nexusmods.com/skyrim/mods/6709)か[CBBE](http://www.nexusmods.com/skyrim/mods/2666)のうち、インストールされている体型Modと同じバージョンのEspを使用してください。.'
   - name: 'SeraticArmor.esp'
     tag:
       - name: Deactivate
@@ -23610,14 +23600,6 @@ plugins:
     msg:
       - <<: *corrupt
         condition: 'checksum("Illdi.esp",B941754D)'
-      - type: say
-        content:
-          - lang: en
-            text: 'Be sure you have the correct body mod for the esp. [DIMONIZED UNP](http://www.nexusmods.com/skyrim/mods/6709) or [CBBE](http://www.nexusmods.com/skyrim/mods/2666).'
-          - lang: ru
-            text: 'Убедитесь, что используете корректный реплейсер тел для этого esp. [DIMONIZED UNP](http://www.nexusmods.com/skyrim/mods/6709) или [CBBE](http://www.nexusmods.com/skyrim/mods/2666).'
-          - lang: ja
-            text: '必ず[DIMONIZED UNP](http://www.nexusmods.com/skyrim/mods/6709)か[CBBE](http://www.nexusmods.com/skyrim/mods/2666)のうち、インストールされている体型Modと同じバージョンのEspを使用してください。.'
   - name: 'ImaniSuda.esp'
     msg:
       - <<: *corrupt
@@ -23725,16 +23707,6 @@ plugins:
         condition: 'checksum("Kitana.esp",BCF5969B) or checksum("Kitana.esp",2077B972)'
   - name: 'KMM_2a.esp'
     msg: [ *obsolete ]
-  - name: 'Lia.esp'
-    msg:
-      - type: say
-        content:
-          - lang: en
-            text: 'Be sure you have the correct body mod for the esp. [DIMONIZED UNP](http://www.nexusmods.com/skyrim/mods/6709) or [CBBE](http://www.nexusmods.com/skyrim/mods/2666).'
-          - lang: ru
-            text: 'Убедитесь, что используете корректный реплейсер тел для этого esp. [DIMONIZED UNP](http://www.nexusmods.com/skyrim/mods/6709) или [CBBE](http://www.nexusmods.com/skyrim/mods/2666).'
-          - lang: ja
-            text: '必ず[DIMONIZED UNP](http://www.nexusmods.com/skyrim/mods/6709)か[CBBE](http://www.nexusmods.com/skyrim/mods/2666)のうち、インストールされている体型Modと同じバージョンのEspを使用してください。.'
   - name: 'LianVera-v2.1.esp'
     msg: [ *obsolete ]
     dirty:


### PR DESCRIPTION
Removed the following warning.

> Be sure you have the correct body mod for the esp. DIMONIZED UNP or CBBE.

This message is nothing but spam. It basically says "Be sure to install the correct version". This advice could be added to virtually any mod. Depending on the consequences of installing a wrong version such a warning might be appropriate, but this is certainly not the case. The worst thing that can happen are mismatching boob sizes.