### PR TITLE
Additional Lanterns of Skyrim presets

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4481,11 +4481,11 @@ plugins:
     msg:
       - <<: *corrupt
         condition: 'checksum("Langsam wirkende Tränke.esp",163A3470)'
-  - name: 'Lanterns Of Skyrim - All In One - (Vivida ENB)?(The Goddess ENB|The Goddess v2dot2)?(Somber ENB)?(RLO)?(Cold Skyrim ENB)?(Climates of Tamriel - )?(1_5x Brighter|2x Brighter|Default)?(RCRN )?(Magic Light|lvl-\d|Hyper Purist|Classic|Legacy|Pure)?(Skylight)?\.esp'
+  - name: '(LanternsOfSkyrimELFXpatch|Vivid Weathers - Lanterns of Skyrim Preset|Vividian - Lanterns of Skyrim Preset|Lanterns Of Skyrim - All In One - (Vivida ENB)?(The Goddess ENB|The Goddess v2dot2)?(Somber ENB)?(RLO)?(Cold Skyrim ENB)?(Climates of Tamriel - )?(1_5x Brighter|2x Brighter|Default)?(RCRN )?(Magic Light|lvl-\d|Hyper Purist|Classic|Legacy|Pure)?(Skylight)?)\.esp'
     msg:
       - <<: *useOnlyOneX
-        condition: 'many("Lanterns Of Skyrim - All In One - (Vivida ENB)?(The Goddess ENB|The Goddess v2dot2)?(Somber ENB)?(RLO)?(Cold Skyrim ENB)?(Climates of Tamriel - )?(1_5x Brighter|2x Brighter|Default)?(RCRN )?(Magic Light|lvl-\d|Hyper Purist|Classic|Legacy|Pure)?(Skylight)?\.esp")'
-        subs: [ 'Lanterns Of Skyrim - All In One .esp file' ]
+        condition: 'many("(LanternsOfSkyrimELFXpatch|Vivid Weathers - Lanterns of Skyrim Preset|Vividian - Lanterns of Skyrim Preset|Lanterns Of Skyrim - All In One - (Vivida ENB)?(The Goddess ENB|The Goddess v2dot2)?(Somber ENB)?(RLO)?(Cold Skyrim ENB)?(Climates of Tamriel - )?(1_5x Brighter|2x Brighter|Default)?(RCRN )?(Magic Light|lvl-\d|Hyper Purist|Classic|Legacy|Pure)?(Skylight)?)\.esp")'
+        subs: [ 'Lanterns Of Skyrim Preset' ]
   - name: 'leazeropenlock.esp'
     dirty:
       - crc: 0x952ceb17


### PR DESCRIPTION
Includs Lanterns of Skyrim presets for ELFX, Vivid Weathers and Vividian ENB in the corresponding `useOnlyOneX` warning.