### PR TITLE
Improvements to hasWildEdits warning

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -303,10 +303,10 @@ common:
     util: '[TES5Edit](http://www.nexusmods.com/skyrim/mods/25859)'
     info: 'A cleaning guide is available [here](http://www.creationkit.com/index.php?title=TES5Edit_Cleaning_Guide_-_TES5Edit).'
   - &hasWildEdits
-    type: say
+    type: warn
     content:
       - lang: en
-        text: "This plug-in %1% contains wild edits. A manual [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) cleaning guide is available here: %2%"
+        text: "This plugin contains wild edits. A manual [TES5Edit](http://www.nexusmods.com/skyrim/mods/25859) cleaning guide is available here: %1%"
 
 bash_tags:
   - 'Actors.ACBS'
@@ -641,7 +641,6 @@ plugins:
     msg:
       - <<: *hasWildEdits
         subs:
-          - 'Dawnguard.esm'
           - '[Manual Cleaning Guide](https://afkmods.iguanadons.net/index.php?/topic/4110-manual-cleaning-skyrim-and-skyrim-se-master-files/)'
         condition: 'checksum("Dawnguard.esm",94A47F31)'
     dirty:


### PR DESCRIPTION
- This should be a warning not just a message.
- "plugin" not "plug-in"
- There is no need to mention the name of the plugin again.