### PR TITLE
Update Scarcity Less Loot

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4622,8 +4622,8 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrim/mods/49496/' ]
     group: *dynamicPatchGroup
     clean:
-      - crc: 0x9B2CE1BD # v1.3.0
-        util: 'SSEEdit v3.2.70 EXPERIMENTAL'
+      - crc: 0x9B2CE1BD # v1.30
+        util: 'TES5Edit v3.2.70 EXPERIMENTAL'
   - name: 'Scarcity - (2|4|6|8|10)x Merchant Item Rarity\.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/49496/' ]
     group: *dynamicPatchGroup

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4630,8 +4630,11 @@ plugins:
     after: [ 'Scarcity - Less Loot Mod.esp' ]
     msg:
       - <<: *useOnlyOneX
-        condition: 'many("(Scarcity - (2|4|6|8|10)x (Loot|Merchant Item) Rarity)\.esp")'
-        subs: [ 'Scarcity - Less Loot Mod' ]
+        condition: 'many("(Scarcity - (2|4|6|8|10)x Merchant Item Rarity)\.esp")'
+        subs: [ 'Scarcity - Merchant Item Rarity' ]
+      - <<: *useOnlyOneX
+        condition: 'many("(Scarcity - (2|4|6|8|10)x Loot Rarity)\.esp")'
+        subs: [ 'Scarcity - Loot Rarity' ]
   - name: 'UnlimitedBookshelves.esp'
     group: *underridesGroup
 ## This edits the object bounds of many items, so it should load before any other mod that also edits those items.

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4624,7 +4624,7 @@ plugins:
     clean:
       - crc: 0x9B2CE1BD # v1.3.0
         util: 'SSEEdit v3.2.70 EXPERIMENTAL'
-  - name: 'Scarcity - (2|4|6|8|10)x (Loot|Merchant Item) Rarity\.esp'
+  - name: 'Scarcity - (2|4|6|8|10)x Merchant Item Rarity\.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/49496/' ]
     group: *dynamicPatchGroup
     after: [ 'Scarcity - Less Loot Mod.esp' ]
@@ -4632,6 +4632,11 @@ plugins:
       - <<: *useOnlyOneX
         condition: 'many("(Scarcity - (2|4|6|8|10)x Merchant Item Rarity)\.esp")'
         subs: [ 'Scarcity - Merchant Item Rarity' ]
+  - name: 'Scarcity - (2|4|6|8|10)x Loot Rarity\.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/49496/' ]
+    group: *dynamicPatchGroup
+    after: [ 'Scarcity - Less Loot Mod.esp' ]
+    msg:
       - <<: *useOnlyOneX
         condition: 'many("(Scarcity - (2|4|6|8|10)x Loot Rarity)\.esp")'
         subs: [ 'Scarcity - Loot Rarity' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4619,10 +4619,19 @@ plugins:
       - Delev
       - Relev
   - name: 'Scarcity - Less Loot Mod.esp'
-    dirty:
-      - crc: 0xcea93ccb
-        <<: *dirtyPlugin
-        itm: 1
+    url: [ 'https://www.nexusmods.com/skyrim/mods/49496/' ]
+    group: *dynamicPatchGroup
+    clean:
+      - crc: 0x9B2CE1BD # v1.3.0
+        util: 'SSEEdit v3.2.70 EXPERIMENTAL'
+  - name: 'Scarcity - (2|4|6|8|10)x (Loot|Merchant Item) Rarity\.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/49496/' ]
+    group: *dynamicPatchGroup
+    after: [ 'Scarcity - Less Loot Mod.esp' ]
+    msg:
+      - <<: *useOnlyOneX
+        condition: 'many("(Scarcity - (2|4|6|8|10)x (Loot|Merchant Item) Rarity)\.esp")'
+        subs: [ 'Scarcity - Less Loot Mod' ]
   - name: 'UnlimitedBookshelves.esp'
     group: *underridesGroup
 ## This edits the object bounds of many items, so it should load before any other mod that also edits those items.
@@ -26151,6 +26160,7 @@ plugins:
   - name: 'Bashed Patch.*\.esp'
     group: *dynamicPatchGroup
     after:
+      - 'Scarcity - .*\.esp'
       - 'TES5Merged.esp'
     msg:
       - <<: *SmashedVsBashedPatch


### PR DESCRIPTION

This will add changes suggested in issue #143 

- Add load after rule to optional plugins, not all versions have main module as a master.
- Add error message (only one Loot Rarity and only one Merchant Item Rarity .esp should be active)
- Add Cleaning Information