### PR TITLE
Update already in Unofficial Patch Messages

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -34,10 +34,6 @@ common:
     <<: *alreadyInX
     condition: 'active("Unofficial High Resolution Patch.esp")'
     subs: [ 'Unofficial High Resolution Patch.esp' ]
-  - &alreadyInUDBP
-    <<: *alreadyInX
-    condition: 'active("Unofficial Dragonborn Patch.esp")'
-    subs: [ 'Unofficial Dragonborn Patch.esp' ]
   - &alreadyInUDGP
     <<: *alreadyInX
     condition: 'active("Unofficial Dawnguard Patch.esp")'
@@ -2242,7 +2238,7 @@ plugins:
   - name: 'sapphire_speak_fix.esp'
     msg: [ *alreadyInUSLEEP ]
   - name: 'Severin Manor Music.esp'
-    msg: [ *alreadyInUDBP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'Shrine of Azura LOD Fix.esp'
     msg: [ *alreadyInUSLEEP ]
   - name: 'Silent Moons Enchantment Fix.*\.esp'
@@ -2352,9 +2348,9 @@ plugins:
 # ## RaceComp is explicit master; USKP is implicit
 # ## IFNOT VAR(USKP) REQ: Unofficial Skyrim Patch.esp
   - name: 'ancient-nordic-pickaxe-smith-fix.esp'
-    msg: [ *alreadyInUDBP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'BoundDaggerFix.esp'
-    msg: [ *alreadyInUDBP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'BreezhomeAlchemyLabFix.esp'
     msg: [ *alreadyInUDGP ]
   - name: 'chopping_block_wood_fires.esp'
@@ -2379,7 +2375,7 @@ plugins:
   - name: 'dghorsepatch.esp'
     msg: [ *alreadyInUDGP ]
   - name: 'Dragonborn Spell Absorb Fix.esp'
-    msg: [ *alreadyInUDBP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'HDtextures01.esp'
     msg:
       - <<: *fixedInOfficialPatchX
@@ -2415,7 +2411,7 @@ plugins:
       - name: 'HighResTexturePack02.esp'
         condition: 'not file("HighResTexturePack01.esp")'
   - name: 'Stahlrim Arrow Projectile Fix.esp'
-    msg: [ *alreadyInUDBP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'Vampire Face Fixes.esp'
     msg:
       - type: say

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -34,10 +34,6 @@ common:
     <<: *alreadyInX
     condition: 'active("Unofficial High Resolution Patch.esp")'
     subs: [ 'Unofficial High Resolution Patch.esp' ]
-  - &alreadyInUDGP
-    <<: *alreadyInX
-    condition: 'active("Unofficial Dawnguard Patch.esp")'
-    subs: [ '[Unofficial Dawnguard Patch](http://www.nexusmods.com/skyrim/mods/23491)' ]
   - &alreadyInPerkUpArchery
     <<: *alreadyInX
     condition: 'file("PerkUP-Archery.esp")'
@@ -2250,7 +2246,7 @@ plugins:
   - name: 'Spell Absorb Fix.esp'
     msg:
       - *alreadyInUSLEEP
-      - *alreadyInUDGP
+      - *alreadyInUSLEEP
   - name: 'SolitudeProudspireManorFix.esp'
     msg: [ *alreadyInUSLEEP ]
   - name: 'StaggerFix.esp'
@@ -2302,7 +2298,7 @@ plugins:
   - name: 'VampiresHoodFix.esp'
     msg: [ *alreadyInUSLEEP ]
   - name: 'vampirelorddrainlifefix.esp'
-    msg: [ *alreadyInUDGP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'Vampire Orcs Welcome in Strongholds.esp'
     msg: [ *alreadyInUSLEEP ]
   - name: 'VampireRaceDetection.esp'
@@ -2352,7 +2348,7 @@ plugins:
   - name: 'BoundDaggerFix.esp'
     msg: [ *alreadyInUSLEEP ]
   - name: 'BreezhomeAlchemyLabFix.esp'
-    msg: [ *alreadyInUDGP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'chopping_block_wood_fires.esp'
     msg:
       - <<: *fixedInOfficialPatchX
@@ -2361,19 +2357,19 @@ plugins:
 # ## correctdoucebriseALCH.esp
 # ## french patch to allow the purchase of alchemy lab in Breezehome under DG
   - name: 'CraftableBoneHawkRings.esp'
-    msg: [ *alreadyInUDGP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'Dawnguard Breezehome Fix.esp'
-    msg: [ *alreadyInUDGP ]
+    msg: [ *alreadyInUSLEEP ]
     dirty:
       - crc: 0x330aed25
         <<: *dirtyPlugin
         itm: 2
   - name: 'Dawnguard Summons Fixed.esp'
-    msg: [ *alreadyInUDGP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'DawnguardDrainVitalityFix.esp'
-    msg: [ *alreadyInUDGP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'dghorsepatch.esp'
-    msg: [ *alreadyInUDGP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'Dragonborn Spell Absorb Fix.esp'
     msg: [ *alreadyInUSLEEP ]
   - name: 'HDtextures01.esp'
@@ -2382,7 +2378,7 @@ plugins:
         condition: 'version("../TESV.exe", "1.8", >=)'
         subs: [ '1.8' ]
   - name: 'Headtracking Fix - Dawnguard.esp'
-    msg: [ *alreadyInUDGP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'HF-MoveSpouse.esp'
     msg: [ *corrupt ]
     dirty:
@@ -2394,7 +2390,7 @@ plugins:
   - name: 'invisible_shield_fix.esp'
     msg: [ *alreadyInUSLEEP ]
   - name: 'Krill_AurielsBowFix.esp'
-    msg: [ *alreadyInUDGP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'Prodspire Cooking pot hearthfire bugfix.esp'
     msg:
       - <<: *alreadyInX
@@ -2425,7 +2421,7 @@ plugins:
           - lang: ja
             text: 'このModは吸血鬼のキャラクタークラスを改変するModとは両立できません。'
   - name: 'USKP Dawnguard vampire face & eye fix.esp'
-    msg: [ *alreadyInUDGP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'EveryVampireEyesGrow.esp'
     msg:
       - type: say

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -26,10 +26,10 @@ common:
         text: '删除。已包含在%1%中。'
       - lang: ja
         text: '削除してください。既に%1%に含まれています。'
-  - &AlreadyInUSKP
+  - &alreadyInUSLEEP
     <<: *alreadyInX
-    condition: 'active("Unofficial Skyrim Patch.esp")'
-    subs: [ 'Unofficial Skyrim Patch.esp' ]
+    subs: [ '[Unofficial Skyrim Legendary Edition Patch](https://www.nexusmods.com/skyrim/mods/71214/)' ]
+    condition: 'active("Unofficial Skyrim Legendary Edition Patch.esp")'
   - &alreadyInUHRP
     <<: *alreadyInX
     condition: 'active("Unofficial High Resolution Patch.esp")'
@@ -1867,63 +1867,63 @@ plugins:
         <<: *dirtyPlugin
         itm: 1
   - name: 'AerinRestrainingOrder.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'AmuletOfArticulationFix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'Amulet of Articulation Leveling Fix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
     tag:
       - Relev
   - name: 'AmuletofJulianosFix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'Ancient Knowledge Fix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'Ancient Shrouded Cowl Fix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'Ancient Shrouded Cowl Beast Race Fix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'Annoying Clipping Remover.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'ArdwenToGildergreen.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'Argonian Disarming Bash Bug Fix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'Ash Pile Expiration.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'AspectOfTerrorFixv1.0.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'AtronachEffectFix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'AtronachForgeBootsFix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'aventus aretino fix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
     dirty:
       - crc: 0x80e1299c
         <<: *dirtyPlugin
         itm: 6
   - name: 'Back off, Barbas!.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'Bardfix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'bardsfix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'bard''s_college_quests_fix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'Belethor Vendor Fix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'blackreachgeodefix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'BM_Bench.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'brandsheiprisonfix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'brawlbug-plugin.esp'
     msg: [ *obsolete ]
   - name: 'Brawl Bugs CE.esp'
     msg: [ *alreadyInSkyRe ]
   - name: 'breezehomelightfix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'BreezehomeLadderFixJP.esp'
     dirty:
       - crc: 0xF2BAA689
@@ -1935,7 +1935,7 @@ plugins:
     inc:
       - 'BreezehomeLadderFix.esp'
   - name: 'BreezehomeLightingFix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'breezehomeshadowfix.esp'
     dirty:
       - crc: 0xf416a7c9
@@ -1944,107 +1944,107 @@ plugins:
   - name: 'Breezehome-hf-CTD-fix.esp'
     msg: [ *obsolete ]
   - name: 'Brynjolf Dialogue Fix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'bug_description.blessing_of_talos.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'Bugfix-NoFollowerTrespassDialog.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
 # ## DSAMG - Miraak Music Fixes.esp
 # ## author instructions to place above UDBP: should cut some DB "can''t absorb dragon souls" reports
 # ## DSAMG proper is just bunch of scripts and music files, no esp- possibly why load order troubleshooting comes up empty -LD
   - name: 'bugfixalchemynoregeneration.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'bugfixenchanmentnoregeneration.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'Bugfixrobesenchantments.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'Bullseye Perk Fix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'Civil War Neutrality Fix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'Chesko_MatchingSetPerkFix.esp'
     msg:
       - <<: *fixedInOfficialPatchX
         condition: 'version("../TESV.exe", "1.9", >=)'
         subs: [ '1.9' ]
   - name: 'Cloak Fix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'CombatMusicFix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'Conjuration Fix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'CriticalChargeFix.esp'
     msg:
-      - *AlreadyInUSKP
+      - *alreadyInUSLEEP
       - <<: *obsolete
         condition: 'not checksum("CriticalChargeFix.esp",A35E7560)'
       - <<: *alreadyInX
         condition: 'file("PerkUP-TwoHanded.esp")'
         subs: [ 'PerkUP-TwoHanded.esp' ]
   - name: 'CTD Fellglow Keep Dungeon Fix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'DaedricBowBashFix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'DaedricShieldHiResFix.esp'
     msg: [ *alreadyInUHRP ]
   - name: 'Daggers acts like blades.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'DaggerBowEnchantPotionFixes.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'Deflect Arrows Perk Fix.esp'
     msg:
       - <<: *fixedInOfficialPatchX
         condition: 'version("../TESV.exe", "1.5", >=)'
         subs: [ '1.5' ]
   - name: 'Derkeethus_fix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'DialogueWithAVampireOrWhatever.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'Dragon Shout - Marked for Death.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
     dirty:
       - crc: 0xc9ab8c3e
         <<: *dirtyPlugin
         itm: 9
   - name: 'Dreagonsreach bottle fix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'EbonyArmorMatchingSetFix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'EbonyBladeFixed.*\.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'Farengar.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'FalmerHelmetFix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'Falmer Helmet Fixed.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'Farm Wheat Height Fix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'FemaleVampireEyeFix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'fix-BelethorUnlocked.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'Floating Cabbage fix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'followerhuntingbowfix.esp'
     msg:
-      - *AlreadyInUSKP
+      - *alreadyInUSLEEP
       - *alreadyInBDO
       - <<: *alreadyInX
         condition: 'file("Better Followers - [SBNP].*\.esp")'
         subs: [ 'Better Followers' ]
   - name: 'FollowerHuntingBow12.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'FoodRestoreHealthFix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'forsworn boots fix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'FrostMagicBugFixes.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'furrycommentfix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'GhorzaGraBagolInvestmentFix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'GiantPhysicsFix.esp'
     msg:
       - <<: *fixedInOfficialPatchX
@@ -2053,23 +2053,23 @@ plugins:
   - name: 'GM-KhajiitDSHFix.esp'
     msg:
       - *corrupt
-      - *AlreadyInUSKP
+      - *alreadyInUSLEEP
   - name: 'gourmetFix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'greatweapon_speedfix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'Greatsword Attack speed Fix 1.3.esp'
     msg:
       - *corrupt
-      - *AlreadyInUSKP
+      - *alreadyInUSLEEP
   - name: 'HeadsmansAxeFixed.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'Headtracking Fix - Skyrim.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'HelmetStackFix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'hjerim chest fix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
     dirty:
       - crc: 0x560f7c1c
         <<: *dirtyPlugin
@@ -2077,33 +2077,33 @@ plugins:
   - name: 'Hjerimfix.esp'
     msg:
       - *corrupt
-      - *AlreadyInUSKP
+      - *alreadyInUSLEEP
     dirty:
       - crc: 0x9b9b0581
         <<: *dirtyPlugin
         udr: 9
   - name: 'HjerimMessFix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'HM DB CookQuestFix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'imperialhelmetfix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'ImperialHelmetHeavyFix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'invinciblehawkfix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'Invisibility Eyes Fix.esp'
     req: [ *SKSE ]
   - name: 'KarliahFix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'Kataous'' Bug Fixes for Player Homes.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'KeeningFix.*\.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'KeeningSmithing.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'KillThemGenerals.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'LCBM.esp'
     msg:
       - <<: *fixedInOfficialPatchX
@@ -2144,9 +2144,9 @@ plugins:
             text: 'lightingfix.espをRelighting Skyrim - Dawnguard.espと併用すると光源が不自然になることがあります。.'
         condition: 'file("lightingfix.esp")'
   - name: 'lydia chair fix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'MageRobesCommentFix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'Magnus20.esp'
     msg:
       - <<: *fixedInOfficialPatchX
@@ -2169,46 +2169,46 @@ plugins:
       - <<: *preCKSharlikranPatch
         condition: 'not checksum("Magnus100.esp",37C6B07A)'
   - name: 'Mannequinfix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'markedfordeathfix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'MatchingSetFixes.esp'
     msg:
       - <<: *fixedInOfficialPatchX
         condition: 'version("../TESV.exe", "1.9", >=)'
         subs: [ '1.9' ]
   - name: 'Miner''s Clothes Variant Fix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'Minor Miner Fixes.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'MorokeiFix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'Muiri''s Problem.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'Nightingale Blade fix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'nightingalebladefix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'Nightingale Bow and Nord Hero Bow silenced.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'Nirnroot Placement Fix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'NoFortifyFortifyResto.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'NordHeroBowTemperFix.esp'
     msg:
       - <<: *fixedInOfficialPatchX
         condition: 'version("../TESV.exe", "1.9", >=)'
         subs: [ '1.9.26' ]
   - name: 'onehandeddagger.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
 # ## Orc&ElfFix4TBBP.esp
 # ## This is a fix for TBBP meshes, I believe.
   - name: 'Potema and Mjoll Quest Fix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'Proudspire Manor Bug Fixes.esp'
     msg:
-      - *AlreadyInUSKP
+      - *alreadyInUSLEEP
       - <<: *alreadyInX
         condition: 'file("ProudspireManorImprovements.esp")'
         subs: [ 'ProudspireManorImprovements.esp' ]
@@ -2218,17 +2218,17 @@ plugins:
         condition: 'version("../TESV.exe", "1.5", >=)'
         subs: [ '1.5' ]
   - name: 'Prowler.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'Quick Orc Fixes.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'Regain Winterhold Bugfix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'Repairing the Phial fix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'RiftenJailVisualFix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'riften jail test 2.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'RiverwoodTraderInvestorFix.esp'
     msg:
       - <<: *fixedInOfficialPatchX
@@ -2240,25 +2240,25 @@ plugins:
         condition: 'version("../TESV.exe", "1.5", >=)'
         subs: [ '1.5' ]
   - name: 'sapphire_speak_fix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'Severin Manor Music.esp'
     msg: [ *alreadyInUDBP ]
   - name: 'Shrine of Azura LOD Fix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'Silent Moons Enchantment Fix.*\.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'SkyrimFixes.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'Smallest Mod EVER.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'Spell Absorb Fix.esp'
     msg:
-      - *AlreadyInUSKP
+      - *alreadyInUSLEEP
       - *alreadyInUDGP
   - name: 'SolitudeProudspireManorFix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'StaggerFix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'StaffOfMagnusFix.esp'
     msg:
       - <<: *fixedInOfficialPatchX
@@ -2275,67 +2275,67 @@ plugins:
         condition: 'version("../TESV.exe", "1.9", >=)'
         subs: [ '1.9.26' ]
   - name: 'SybilleStentorFix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'TalosShrineFix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'TemperSkyforgeDaggers.esp'
     msg:
       - *corrupt
-      - *AlreadyInUSKP
+      - *alreadyInUSLEEP
   - name: 'terramend.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
     dirty:
       - crc: 0x2aa40114
         <<: *dirtyPlugin
         itm: 8
         udr: 7
   - name: 'Thalmor Embassy Disguise Fix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'Thief armor fix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'Thorald.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'towerofstrength.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'Treebugfix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'Vampire Eyes Fix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'VampireInvisibleItemsFix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'VampiresHoodFix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'vampirelorddrainlifefix.esp'
     msg: [ *alreadyInUDGP ]
   - name: 'Vampire Orcs Welcome in Strongholds.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'VampireRaceDetection.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
 # ## VampireRaceDetection.esp
 # ## As per thread on the mod''s Steam Workshop page: "http://steamcommunity.com/sharedfiles/filedetails/?id=89925318"
 # ## Vulkanglas statt Malachit.esp
   - name: 'Wandering Dupe Mannequin Fix v1.2 SPODUM Vanilla.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'whiterun bug fixes.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'Whiterun Field Fix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'Whiterun Lighting Fix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'WhitePhialFireplace.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'whitrun stair fix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'Winterhold Shields.esp'
     msg:
       - *corrupt
-      - *AlreadyInUSKP
+      - *alreadyInUSLEEP
   - name: 'wolfqueenfix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'Wuuthrad fix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'YngolFix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
 # ## Unofficial Patches
 # ## Unofficial Skyrim Patch that is not false flagged
 # ## maybe need better place for this file. also need to correct english message (tokcdk)
@@ -2396,7 +2396,7 @@ plugins:
   - name: 'HighResTexturePackFix.esp'
     msg: [ *alreadyInUHRP ]
   - name: 'invisible_shield_fix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'Krill_AurielsBowFix.esp'
     msg: [ *alreadyInUDGP ]
   - name: 'Prodspire Cooking pot hearthfire bugfix.esp'
@@ -3246,7 +3246,7 @@ plugins:
 # Removed REGEX because specific load order is needed
   - name: 'Weapons and Armor fixes.esp'
     msg:
-      - *AlreadyInUSKP
+      - *alreadyInUSLEEP
       - <<: *patchOutSub
         condition: 'not checksum("Weapons and Armor fixes.esp",D27D2F2)'
       - type: say
@@ -3804,7 +3804,7 @@ plugins:
   - name: 'Conjuration & Summoning fixes.esp'
     msg:
       - *corrupt
-      - *AlreadyInUSKP
+      - *alreadyInUSLEEP
       - <<: *alreadyInX
         condition: 'file("SpellFix.esp")'
         subs: [ 'SpellFix.esp' ]
@@ -17772,7 +17772,7 @@ plugins:
   - name: 'PermanentWerewolfNightEye.esp'
     msg: [ *obsolete ]
   - name: 'posesivecorpses.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'PowerOfBlood.esp'
     dirty:
       - crc: 0x9572b55c
@@ -20654,7 +20654,7 @@ plugins:
         <<: *dirtyPlugin
         itm: 2
   - name: 'conjureatronarchfix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'cremation.esp'
     dirty:
       - crc: 0x849d7480
@@ -21274,7 +21274,7 @@ plugins:
   - name: 'MorePowerfulNecromancy.esp'
     msg: [ *obsolete ]
   - name: 'More Visible Soul Trap Effect.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'Paralysis in Illusion.esp'
     dirty:
       - crc: 0x7a14834a
@@ -25121,7 +25121,7 @@ plugins:
         condition: 'many("WiS IV( -)? Blood Coins( slow| normal| Insane)?\.esp")'
         subs: [ 'Blood Coins .esp file' ]
   - name: 'ChickenNestFix.esp'
-    msg: [ *AlreadyInUSKP ]
+    msg: [ *alreadyInUSLEEP ]
   - name: 'MD - WMTBNDE .+\.esp'
     msg:
       - <<: *useOnlyOneX


### PR DESCRIPTION
Since Unofficial Skyrim, Dawnguard & Dragonborn Patches were made obsolete by Unofficial Skyrim Legendary Edition Patch. Already in x messages should be updated to reflect this change.