### PR TITLE
Babette.esp from The Eyes of Beauty is corrupt

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -16109,7 +16109,7 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrim/mods/13722' ]
     msg:
       - <<: *corrupt
-        condition: 'checksum("Babette.esp",32DB97E2)'
+        condition: 'checksum("Babette.esp", 32DB97E2) or checksum("Babette.esp", 6596E3CF)'
     dirty:
       - crc: 0x6596e3cf
         <<: *dirtyPlugin

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -16110,10 +16110,6 @@ plugins:
     msg:
       - <<: *corrupt
         condition: 'checksum("Babette.esp", 32DB97E2) or checksum("Babette.esp", 6596E3CF)'
-    dirty:
-      - crc: 0x6596e3cf
-        <<: *dirtyPlugin
-        itm: 8
   - name: 'BalancedHeroWeps.esp'
     msg:
       - <<: *corrupt

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -16106,6 +16106,7 @@ plugins:
       - crc: 0x0C80954F
         util: 'TES5Edit v4.0.1'
   - name: 'Babette.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/13722' ]
     msg:
       - <<: *corrupt
         condition: 'checksum("Babette.esp",32DB97E2)'


### PR DESCRIPTION
The plugin contains unexpected (or out of order) records. Removed the cleaning info as well because there is no point in adding cleaning info when the plugin is corrupt. Cleaning the plugin only suppresses the `corrupt` warning because the checksum changed.