### PR TITLE
Replace replacerPluginForX with more appropriate message

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -221,13 +221,6 @@ common:
     content:
       - lang: en
         text: 'When using **%1%**, it''s recommended that you deactivate or delete this plugin, but keep the assets (e.g. meshes, textures) installed with this mod as they''re still required by **%1%**.'
-  - &replacerPluginForX
-    type: error
-    content:
-      - lang: en
-        text: 'This replaces %1%. Delete or deactivate %1% but keep its resources.'
-      - lang: ja
-        text: '%1%を置き換えます。%1%のプラグインを削除するか非アクティブにし、他のファイルはそのままにしておいてください。'
   - &SmashedVsBashedPatch
     type: say
     content:
@@ -9502,40 +9495,8 @@ plugins:
     group: *requiemEarlyGroup
   - name: 'Requiem - Height Adjusted Races with True Giants.esp'
     group: *requiemEarlyGroup
-    msg:
-      - <<: *replacerPluginForX
-        condition: 'file("Height Adjusted Races.esp")'
-        subs: [ 'Height Adjusted Races.esp' ]
-      - <<: *replacerPluginForX
-        condition: 'file("Height Adjusted Races - Morrowind Lore Heights.esp")'
-        subs: [ 'Height Adjusted Races - Morrowind Lore Heights.esp' ]
-      - <<: *replacerPluginForX
-        condition: 'file("Height Adjusted Races - Oblivion Lore Heights.esp")'
-        subs: [ 'Height Adjusted Races - Oblivion Lore Heights.esp' ]
-      - <<: *replacerPluginForX
-        condition: 'file("Height Adjusted Races - Player Races Only.esp")'
-        subs: [ 'Height Adjusted Races - Player Races Only.esp' ]
-      - <<: *replacerPluginForX
-        condition: 'file("Height Adjusted Races - Player Races Only - Oblivion Lore Heights.esp")'
-        subs: [ 'Height Adjusted Races - Player Races Only - Oblivion Lore Heights.esp' ]
-      - <<: *replacerPluginForX
-        condition: 'file("Height Adjusted Races - Player Races Only - Morrowind Lore Heights.esp")'
-        subs: [ 'Height Adjusted Races - Player Races Only - Morrowind Lore Heights.esp' ]
-      - <<: *replacerPluginForX
-        condition: 'file("Height Adjusted Races with True Giants.esp")'
-        subs: [ 'Height Adjusted Races with True Giants.esp' ]
-      - <<: *replacerPluginForX
-        condition: 'file("Height Adjusted Races with True Giants - Smaller Giant Edition.esp")'
-        subs: [ 'Height Adjusted Races with True Giants - Smaller Giant Edition.esp' ]
   - name: 'Requiem - True Giants and Mammoths.esp'
     group: *requiemEarlyGroup
-    msg:
-      - <<: *replacerPluginForX
-        condition: 'file("Height Adjusted Races - True Giants and Mammoths.esp")'
-        subs: [ 'Height Adjusted Races - True Giants and Mammoths.esp' ]
-      - <<: *replacerPluginForX
-        condition: 'file("Height Adjusted Races - True Giants and Mammoths - Smaller Giant Edition.esp")'
-        subs: [ 'Height Adjusted Races - True Giants and Mammoths - Smaller Giant Edition.esp' ]
   - name: 'Requiem - Guard Dialogue & Open Helmets.esp'
     after:
       - 'KFR-Kryptopyr''sFixesReqtified.esp'
@@ -9571,33 +9532,6 @@ plugins:
   - name: 'Requiem - Deadly Dragons( - AOS)?\.esp'
     after:
       - 'Requiem - Wild World.esp'
-  - name: 'Requiem - 83Willows 101Bugs.esp'
-    msg:
-      - <<: *replacerPluginForX
-        condition: 'file("83Willows_101BUGS_V4_LowRes.esp")'
-        subs: [ '83Willows_101BUGS_V4_LowRes.esp' ]
-      - <<: *replacerPluginForX
-        condition: 'file("83Willows_101BUGS_V4_HighRes.esp")'
-        subs: [ '83Willows_101BUGS_V4_HighRes.esp' ]
-      - <<: *replacerPluginForX
-        condition: 'file("83Willows_101BUGS_V4_LowerRes_HighSpawn.esp")'
-        subs: [ '83Willows_101BUGS_V4_LowerRes_HighSpawn.esp' ]
-      - <<: *replacerPluginForX
-        condition: 'file("83Willows_101BUGS_V4_HighRes_HighSpawn.esp")'
-        subs: [ '83Willows_101BUGS_V4_HighRes_HighSpawn.esp' ]
-  - name: 'Requiem - Explosive Bolts Visualized.esp'
-    msg:
-      - <<: *replacerPluginForX
-        condition: 'file("ExplosiveBoltsVisualized.esp")'
-        subs: [ 'ExplosiveBoltsVisualized.esp' ]
-  - name: 'Requiem - Rustic Soulgems( - ISC)?\.esp'
-    msg:
-      - <<: *replacerPluginForX
-        condition: 'file("RUSTIC SOULGEMS - Sorted.esp")'
-        subs: [ 'RUSTIC SOULGEMS - Sorted.esp' ]
-      - <<: *replacerPluginForX
-        condition: 'file("RUSTIC SOULGEMS - Unsorted.esp")'
-        subs: [ 'RUSTIC SOULGEMS - Unsorted.esp' ]
   - name: 'Requiem - Timing Is Everything.esp'
     after:
       - 'Requiem_Minor_Arcana.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -24529,6 +24529,7 @@ plugins:
   - name: 'Height Adjusted Skyrim(.+)?\.esp'
     msg: [ *obsolete ]
   - name: 'Height Adjusted Races.*\.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/7587' ]
     msg:
       - <<: *useOnlyOneX
         condition: 'many("Height Adjusted Races.*\.esp")'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -10933,11 +10933,6 @@ plugins:
   - name: 'REQ Tribunal Robes by Zairaam.esp'
     msg:
       - *installOriginalResources
-  - name: 'ExplosiveBoltsVisualized-SkyRe.esp'
-    msg:
-      - <<: *deleteOrDeactivateX
-        condition: 'active("ExplosiveBoltsVisualized.esp")'
-        subs: [ 'ExplosiveBoltsVisualized.esp' ]
 #
 # All mods that add or change quests,
 # add player houses,
@@ -27043,6 +27038,9 @@ plugins:
       - <<: *deletePlugin
         condition: 'active("ExplosiveBoltsVisualized.esp") and active("Requiem - Explosive Bolts Visualized.esp")'
         subs: [ 'the Requiem patch for Explosive Bolts Visualized' ]
+      - <<: *deletePlugin
+        condition: 'active("ExplosiveBoltsVisualized.esp") and active("ExplosiveBoltsVisualized-SkyRe.esp")'
+        subs: [ 'the SkyRe patch for Explosive Bolts Visualized' ]
   - name: 'DeadlyDragons.esp'
     msg:
       - <<: *reqRequiemPatch

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -966,6 +966,7 @@ plugins:
     url:
       - 'http://www.nexusmods.com/skyrim/mods/4955'
   - name: '83Willows_101BUGS_V4_.+\.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/4955' ]
     msg:
       - <<: *useOnlyOneX
         condition: 'many("83Willows_101BUGS_V4_.+\.esp")'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27105,6 +27105,9 @@ plugins:
     msg:
       - <<: *reqRequiemPatch
         condition: 'active("Requiem.esp") and not active("Requiem - Explosive Bolts Visualized.esp")'
+      - <<: *deletePlugin
+        condition: 'active("ExplosiveBoltsVisualized.esp") and active("Requiem - Explosive Bolts Visualized.esp")'
+        subs: [ 'the Requiem patch for Explosive Bolts Visualized' ]
   - name: 'DeadlyDragons.esp'
     msg:
       - <<: *reqRequiemPatch

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27102,6 +27102,7 @@ plugins:
       - crc: 0x6859FBEB
         util: 'TES5Edit v4.0.1'
   - name: 'ExplosiveBoltsVisualized.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/21922' ]
     msg:
       - <<: *reqRequiemPatch
         condition: 'active("Requiem.esp") and not active("Requiem - Explosive Bolts Visualized.esp")'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -24528,10 +24528,10 @@ plugins:
         itm: 4
   - name: 'Height Adjusted Skyrim(.+)?\.esp'
     msg: [ *obsolete ]
-  - name: 'Height Adjusted Races( .+)?\.esp'
+  - name: 'Height Adjusted Races.*\.esp'
     msg:
       - <<: *useOnlyOneX
-        condition: 'many("Height Adjusted Races( .+)?\.esp")'
+        condition: 'many("Height Adjusted Races.*\.esp")'
         subs: [ 'Height Adjusted Races .esp file' ]
       - <<: *reqRequiemPatch
         condition: 'active("Requiem.esp") and not active("Requiem - Height Adjusted Races with True Giants.esp") and not active("Requiem - True Giants and Mammoths.esp")'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -24535,6 +24535,12 @@ plugins:
         subs: [ 'Height Adjusted Races .esp file' ]
       - <<: *reqRequiemPatch
         condition: 'active("Requiem.esp") and not active("Requiem - Height Adjusted Races with True Giants.esp") and not active("Requiem - True Giants and Mammoths.esp")'
+      - <<: *alreadyInX
+        condition: 'active("Height Adjusted Races.*\.esp") and active("Requiem - Height Adjusted Races with True Giants.esp")'
+        subs: [ 'Requiem - Height Adjusted Races with True Giants.esp' ]
+      - <<: *alreadyInX
+        condition: 'active("Height Adjusted Races.*\.esp") and active("Requiem - True Giants and Mammoths.esp")'
+        subs: [ 'Requiem - True Giants and Mammoths.esp' ]
   - name: 'True Giants( v\d)?\.esp'
     msg:
       - type: say

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27211,6 +27211,7 @@ plugins:
       - crc: 0xBDE8703C
         util: 'TES5Edit v4.0.1'
   - name: 'RUSTIC SOULGEMS - (Uns|S)orted\.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/63766' ]
     msg:
       - <<: *reqRequiemPatch
         condition: 'active("Requiem.esp") and not active("Requiem - Rustic Soulgems.esp") and not active("Requiem - Rustic Soulgems - ISC.esp")'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -965,10 +965,10 @@ plugins:
       - Relev
     url:
       - 'http://www.nexusmods.com/skyrim/mods/4955'
-  - name: '(83Willows_101BUGS_V4_).+\.esp'
+  - name: '83Willows_101BUGS_V4_.+\.esp'
     msg:
       - <<: *useOnlyOneX
-        condition: 'many("(83Willows_101BUGS_V4_).+.esp")'
+        condition: 'many("83Willows_101BUGS_V4_.+\.esp")'
         subs: [ '83Willows_101BUGS_V4_ .esp file' ]
       - <<: *reqRequiemPatch
         condition: 'active("Requiem.esp") and not active("Requiem - 83Willows 101Bugs.esp")'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27214,6 +27214,9 @@ plugins:
     msg:
       - <<: *reqRequiemPatch
         condition: 'active("Requiem.esp") and not active("Requiem - Rustic Soulgems.esp") and not active("Requiem - Rustic Soulgems - ISC.esp")'
+      - <<: *deletePlugin
+        condition: 'active("RUSTIC SOULGEMS - (Uns|S)orted\.esp") and active("Requiem - Rustic Soulgems( - ISC)?.esp")'
+        subs: [ 'the Requiem patch for Rustic Soulgems' ]
     tag:
       - Names
   - name: 'ScopedBows.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -973,6 +973,9 @@ plugins:
         subs: [ '83Willows 101Bugs plugin' ]
       - <<: *reqRequiemPatch
         condition: 'active("Requiem.esp") and not active("Requiem - 83Willows 101Bugs.esp")'
+      - <<: *deletePlugin
+        condition: 'active("83Willows_101BUGS_V4_.+\.esp") and active("Requiem - 83Willows 101Bugs.esp")'
+        subs: [ 'the Requiem patch for 83Willows 101Bugs' ]
   - name: 'actorEvents.esm'
     req:
       - *SKSE

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -969,7 +969,7 @@ plugins:
     msg:
       - <<: *useOnlyOneX
         condition: 'many("83Willows_101BUGS_V4_.+\.esp")'
-        subs: [ '83Willows_101BUGS_V4_ .esp file' ]
+        subs: [ '83Willows 101Bugs plugin' ]
       - <<: *reqRequiemPatch
         condition: 'active("Requiem.esp") and not active("Requiem - 83Willows 101Bugs.esp")'
   - name: 'actorEvents.esm'


### PR DESCRIPTION
The `replacerPluginForX` message is unnecessary because there are other messages that say the same in an arguably better manner.
- Height Adjusted Races has no assets beside the plugin. Thus the `alreadyInX` message is appropriate.
- The Requiem patches for 83Willows 101Bugs, Explosive Bolts Visualized and Rustic Soulgems replace the original plugins, but the assets are still required. Thus the `deletePlugin` message is appropriate.
- The SkyRe patch for Explosive Bolts Visualized replaces the original plugin, but the assets are still required. Thus the `deletePlugin` message is appropriate more than `deleteOrDeactivateX.`

I also added a better substitute in the `useOnlyOneX` warning of 83Willow 101Bugs because I was editing the entry anyway.