### PR TITLE
Requiem Patches Update

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9601,6 +9601,8 @@ plugins:
       - <<: *alreadyInX
         condition: 'active("Requiem - No Messages.esp")'
         subs: [ 'Requiem - No Messages.esp' ]
+  - name: 'Requiem - Werewolf and Vampire Rebalance.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/87420' ]
   - name: 'Open Face Guard Helmets.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/52602' ]
     after:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9566,6 +9566,10 @@ plugins:
     after:
       - 'Requiem - Audio Overhaul for Skyrim.esp'
       - 'AOS2_Requiem Patch.esp'
+  - name: 'Requiem - Rustic Soulgems - ISC.esp'
+    after:
+      - 'Requiem - Immersive Sounds Compendium.esp'
+      - 'ISC Requiem Patch.esp'
   - name: 'Requiem - No Overencumbered Messages.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/19281' ]
     msg:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -28766,3 +28766,7 @@ plugins:
         condition: 'active("Requiem.esp") and not active("Requiem - Book Of UUNP patch.esp")'
   - name: 'Requiem - Book Of UUNP patch.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/90507' ]
+    after:
+      - 'Requiem - Legendary Bugsmasher Edition.esp'
+      - 'KFR-Kryptopyr''sFixesReqtified.esp'
+      - 'COR-CraftingOverhaulReqtified.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9586,6 +9586,8 @@ plugins:
       - 'Requiem_Minor_Arcana.esp'
       - 'Requiem - Immersive Divine Blessings.esp'
       - 'Requiem - IDB WAFR CCF patch.esp'
+      - 'Requiem - Behind the Curtain.esp'
+      - 'Requiem - Breaking Bad.esp'
   - name: 'Requiem - ESF Companions.esp'
     after:
       - 'Requiem_Minor_Arcana.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9689,6 +9689,8 @@ plugins:
       - 'Requiem - Legendary Bugsmasher Edition.esp'
       - 'Requiem_Minor_Arcana.esp'
       - 'Requiem - Behind the Curtain.esp'
+    req:
+      - 'Fozars_Dragonborn_-_Requiem_Patch.esp'
   - name: 'Open Face Guard Helmets.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/52602' ]
     after:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9508,6 +9508,8 @@ plugins:
       - link: 'https://www.nexusmods.com/skyrim/mods/72865'
         name: Requiem - Minor Arcana
     after:
+      - 'Requiem - Bugsmasher Edition.esp'
+      - 'Requiem - Legendary Bugsmasher Edition.esp'
       - 'KFR-Kryptopyr''sFixesReqtified.esp'
       - 'COR-CraftingOverhaulReqtified.esp'
       - 'Open Face Guard Helmets.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9479,7 +9479,13 @@ plugins:
       - <<: *patchIncluded
         condition: 'active("Fozars_Dragonborn_-_Requiem_Patch.esp") and not active("KFR-FZR.esp")'
         subs: [ 'Fozar''s Dragonborn Patch' ]
-  - name: 'KFR-(?!Kryptopyr''sFixesReqtified).+\.esp'
+  - name: 'KFR-CircletsWithHoods.esp'
+    req:
+      - 'KFR-Kryptopyr''sFixesReqtified.esp'
+  - name: 'KFR-FZR.esp'
+    req:
+      - 'KFR-Kryptopyr''sFixesReqtified.esp'
+  - name: 'KFR-NoHeavyStormcloaks.esp'
     req:
       - 'KFR-Kryptopyr''sFixesReqtified.esp'
   - name: 'COR-CraftingOverhaulReqtified.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9615,7 +9615,6 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrim/mods/86504' ]
     after:
       - 'Requiem - Legendary Bugsmasher Edition.esp'
-      - 'Requiem - Hearthfire.esp'
       - 'Fozars_Dragonborn_-_Requiem_Patch.esp'
       - 'NRM_Dragonborn_Reqtified.esp'
       - 'KFR-Kryptopyr''sFixesReqtified.esp'
@@ -9624,7 +9623,6 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrim/mods/90714' ]
     after:
       - 'Requiem - Legendary Bugsmasher Edition.esp'
-      - 'Requiem - Hearthfire.esp'
       - 'Fozars_Dragonborn_-_Requiem_Patch.esp'
       - 'NRM_Dragonborn_Reqtified.esp'
       - 'KFR-Kryptopyr''sFixesReqtified.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -525,26 +525,8 @@ groups:
   - name: &requiemGroup Requiem
     after: [ *morrowlootGroup ]
 
-  - name: &requiemBugsmasherGroup Requiem - Bugsmasher
-    after: [ *requiemGroup ]
-
-  - name: &requiemDLCGroup Requiem - DLC Patches
-    after: [ *requiemBugsmasherGroup ]
-
-  - name: &requiemWAFRGroup Requiem - WAFR & CCR
-    after: [ *requiemDLCGroup ]
-
-  - name: &requiemCCORGroup Requiem - CCOR
-    after: [ *requiemWAFRGroup ]
-
-  - name: &requiemEarlyGroup Requiem - Early Patches
-    after: [ *requiemCCORGroup ]
-
-  - name: &requiemPatchesGroup Requiem - Misc. Patches
-    after: [ *requiemEarlyGroup ]
-
   - name: &ocsGroup Open Cities Skyrim
-    after: [ *requiemPatchesGroup ]
+    after: [ *requiemGroup ]
 
   - name: &alternateStartGroup Alternate Start & Requiem
     after: [ *ocsGroup ]
@@ -9461,73 +9443,44 @@ plugins:
         <<: *dirtyPlugin
         itm: 306
         udr: 10
-  - name: 'Requiem - Bugsmasher Edition.esp'
-    url: [ 'http://www.nexusmods.com/skyrim/mods/19281' ]
-    group: *requiemBugsmasherGroup
-  - name: 'Requiem - Legendary Bugsmasher Edition.esp'
-    url: [ 'http://www.nexusmods.com/skyrim/mods/19281' ]
-    group: *requiemBugsmasherGroup
   - name: 'Requiem - Hearthfire.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/61621' ]
-    group: *requiemDLCGroup
     msg:
       - <<: *alreadyInX
         condition: 'version("Requiem.esp", "2.0.0", >=)'
         subs: [ 'Requiem 2.0.0 and higher' ]
   - name: 'NRM_Dragonborn_Reqtified.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/60508' ]
-    group: *requiemDLCGroup
     inc:
       - 'Fozars_Dragonborn_-_Requiem_Patch.esp'
-  - name: 'Fozars_Dragonborn_-_Requiem_Patch.esp'
-    url: [ 'https://www.nexusmods.com/skyrim/mods/78139' ]
-    group: *requiemDLCGroup
   - name: 'Requiem - Vanilla Dragonborn DLC.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/19281' ]
-    group: *requiemDLCGroup
     msg:
       - <<: *alreadyInX
         condition: 'active("Fozars_Dragonborn_-_Requiem_Patch.esp")'
         subs: [ 'Fozar''s Requiem - Dragonborn Patch' ]
   - name: 'KFR-Kryptopyr''sFixesReqtified.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/61520' ]
-    group: *requiemWAFRGroup
     msg:
       - <<: *patchIncluded
         condition: 'active("Fozars_Dragonborn_-_Requiem_Patch.esp") and not active("KFR-FZR.esp")'
         subs: [ 'Fozar''s Dragonborn Patch' ]
   - name: 'KFR-(?!Kryptopyr''sFixesReqtified).+\.esp'
-    group: *requiemWAFRGroup
     req:
       - 'KFR-Kryptopyr''sFixesReqtified.esp'
   - name: 'COR-CraftingOverhaulReqtified.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/61569' ]
-    group: *requiemCCORGroup
     msg:
       - <<: *patchIncluded
         condition: 'active("Fozars_Dragonborn_-_Requiem_Patch.esp") and not active("COR-FZR.esp")'
         subs: [ 'Fozar''s Dragonborn patch' ]
   - name: 'COR-(?!CraftingOverhaulReqtified).+\.esp'
-    group: *requiemCCORGroup
     req:
       - 'COR-CraftingOverhaulReqtified.esp'
-  - name: 'Requiem - Cutting Room Floor.esp'
-    url: [ 'https://www.nexusmods.com/skyrim/mods/61621' ]
-    group: *requiemEarlyGroup
   - name: 'Requiem - Audio Overhaul for Skyrim.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/61621' ]
-    group: *requiemEarlyGroup
     after:
       - 'Requiem - Cutting Room Floor.esp'
-  - name: 'Requiem - Immersive Sounds Compendium.esp'
-    url: [ 'https://www.nexusmods.com/skyrim/mods/61621' ]
-    group: *requiemEarlyGroup
-  - name: 'Requiem - Height Adjusted Races with True Giants.esp'
-    url: [ 'https://www.nexusmods.com/skyrim/mods/58141' ]
-    group: *requiemEarlyGroup
-  - name: 'Requiem - True Giants and Mammoths.esp'
-    url: [ 'https://www.nexusmods.com/skyrim/mods/58141' ]
-    group: *requiemEarlyGroup
   - name: 'Requiem - Guard Dialogue & Open Helmets.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/52602' ]
     after:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9665,6 +9665,8 @@ plugins:
       - <<: *alreadyInX
         condition: 'active("Requiem - Immersive Divine Blessings.esp")'
         subs: [ 'Requiem - Immersive Divine Blessings' ]
+  - name: 'Requiem - Behind the Curtain.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/74330' ]
   - name: 'AZ Tweaks.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/81785' ]
     after:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9562,6 +9562,10 @@ plugins:
     after:
       - 'Requiem_Minor_Arcana.esp'
       - 'Requiem - Immersive Weapons.esp'
+  - name: 'Requiem - Unique Uniques - AOS.esp'
+    after:
+      - 'Requiem - Audio Overhaul for Skyrim.esp'
+      - 'AOS2_Requiem Patch.esp'
   - name: 'Requiem - No Overencumbered Messages.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/19281' ]
     msg:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9493,6 +9493,10 @@ plugins:
       - 'COR-CraftingOverhaulReqtified.esp'
   - name: 'CAR-ContentAddonReqtified.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/72562' ]
+    after:
+      - 'Requiem - Legendary Bugsmasher Edition.esp'
+      - 'NRM_Dragonborn_Reqtified.esp'
+      - 'KFR-Kryptopyr''sFixesReqtified.esp'
   - name: 'Requiem_Minor_Arcana.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrim/mods/90983'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -28764,3 +28764,5 @@ plugins:
       - <<: *patchRequiem3rdParty
         subs: [ '[Requiem - The Book of UUNP Patch](https://www.nexusmods.com/skyrim/mods/90507)' ]
         condition: 'active("Requiem.esp") and not active("Requiem - Book Of UUNP patch.esp")'
+  - name: 'Requiem - Book Of UUNP patch.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/90507' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9618,6 +9618,8 @@ plugins:
       - 'Requiem - Werewolf and Vampire Rebalance.esp'
   - name: 'Requiem - BDT Patch.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/95859' ]
+    after:
+      - 'Requiem - Legendary Bugsmasher Edition.esp'
   - name: 'Requiem - Alchemy Rebalance.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/86504' ]
     after:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9677,9 +9677,13 @@ plugins:
   - name: 'Bounty Gold.esp'
     after:
       - 'Requiem.esp'
+      - 'Requiem - Bugsmasher Edition.esp'
+      - 'Requiem - Legendary Bugsmasher Edition.esp'
   - name: 'dD - Realistic Ragdoll Force - (Realistic|Reduced|Medium|High)\.esp'
     after:
       - 'Requiem.esp'
+      - 'Requiem - Bugsmasher Edition.esp'
+      - 'Requiem - Legendary Bugsmasher Edition.esp'
     msg:
       - type: say
         content:
@@ -9695,6 +9699,8 @@ plugins:
   - name: 'XPMSE.esp'
     after:
       - 'Requiem.esp'
+      - 'Requiem - Bugsmasher Edition.esp'
+      - 'Requiem - Legendary Bugsmasher Edition.esp'
     clean:
       # version: 4.51
       - crc: 0x68388671
@@ -9702,28 +9708,44 @@ plugins:
   - name: 'RealisticRoomRental(-Basic)?.esp'
     after:
       - 'Requiem.esp'
+      - 'Requiem - Bugsmasher Edition.esp'
+      - 'Requiem - Legendary Bugsmasher Edition.esp'
   - name: 'Unlimited Training.esp'
     after:
       - 'Requiem.esp'
+      - 'Requiem - Bugsmasher Edition.esp'
+      - 'Requiem - Legendary Bugsmasher Edition.esp'
   - name: 'WerewolfPerksExpanded.esp'
     after:
       - 'Requiem.esp'
+      - 'Requiem - Bugsmasher Edition.esp'
+      - 'Requiem - Legendary Bugsmasher Edition.esp'
   - name: 'Religion.esp'
     after:
       - 'Requiem.esp'
+      - 'Requiem - Bugsmasher Edition.esp'
+      - 'Requiem - Legendary Bugsmasher Edition.esp'
   - name: 'No Vendor or Loot Spells - Riverwood Trader Requiem.esp'
     req:
       - 'Requiem.esp'
+      - 'Requiem - Bugsmasher Edition.esp'
+      - 'Requiem - Legendary Bugsmasher Edition.esp'
   - name: 'Realistic AI Detection 2.*\.esp'
     after:
       - 'Requiem.esp'
+      - 'Requiem - Bugsmasher Edition.esp'
+      - 'Requiem - Legendary Bugsmasher Edition.esp'
   - name: 'Requiem - Realistic Darkness.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/63297' ]
     after:
       - 'Requiem.esp'
+      - 'Requiem - Bugsmasher Edition.esp'
+      - 'Requiem - Legendary Bugsmasher Edition.esp'
   - name: 'Clairvoyance.esp'
     after:
       - 'Requiem.esp'
+      - 'Requiem - Bugsmasher Edition.esp'
+      - 'Requiem - Legendary Bugsmasher Edition.esp'
     clean:
       # version: 1.0.1
       - crc: 0x8755BBC1
@@ -20081,6 +20103,8 @@ plugins:
   - name: 'Better Vampires.esp'
     after:
       - 'Requiem.esp'
+      - 'Requiem - Bugsmasher Edition.esp'
+      - 'Requiem - Legendary Bugsmasher Edition.esp'
     msg:
       - <<: *patchIncluded
         condition: 'active("Requiem.esp") and not active("Requiem - Better Vampires Patch.esp")'
@@ -20137,6 +20161,8 @@ plugins:
   - name: 'mslVampiricThirst.esp'
     after:
       - 'Requiem.esp'
+      - 'Requiem - Bugsmasher Edition.esp'
+      - 'Requiem - Legendary Bugsmasher Edition.esp'
     req: [ *SKSE ]
     msg:
       - type: say
@@ -20343,6 +20369,8 @@ plugins:
       - 'Dwemer Certified.esp'
       - 'More Exp Chance.esp'
       - 'Requiem.esp'
+      - 'Requiem - Bugsmasher Edition.esp'
+      - 'Requiem - Legendary Bugsmasher Edition.esp'
       - name: 'Animated Weapon Enchants.esp'
         condition: 'file("EnchantingAwakenedAWEPatch.esp")'
       - name: 'SeeEnchs.esp'
@@ -25472,6 +25500,8 @@ plugins:
       - 'Helgen Reborn.esp'
       - 'Immersive Citizens - AI Overhaul.esp'
       - 'Requiem.esp'
+      - 'Requiem - Bugsmasher Edition.esp'
+      - 'Requiem - Legendary Bugsmasher Edition.esp'
     dirty:
       # version: 1.11
       - <<: *quickClean
@@ -27045,6 +27075,8 @@ plugins:
       - '3DNPC.esp'
       - 'RayeksEnd.esp'
       - 'Requiem.esp'
+      - 'Requiem - Bugsmasher Edition.esp'
+      - 'Requiem - Legendary Bugsmasher Edition.esp'
       - 'Routa.esp'
       - 'Routa Non-Stormcloak.esp'
       - 'SkyfallEstateBuildable.esp'
@@ -27120,6 +27152,8 @@ plugins:
       - 'ETaC - RESOURCES.esm'
       - 'Hunterborn.esp'
       - 'Requiem.esp'
+      - 'Requiem - Bugsmasher Edition.esp'
+      - 'Requiem - Legendary Bugsmasher Edition.esp'
       - 'NRM_Dragonborn_Reqtified.esp'
     req:
       - name: 'II EaTC Patch.esp'
@@ -28714,6 +28748,8 @@ plugins:
         condition: 'active("Requiem.esp") and not active("Sacrosanct Requiem Patch and Rebalance.esp")'
     after:
       - 'Requiem.esp'
+      - 'Requiem - Bugsmasher Edition.esp'
+      - 'Requiem - Legendary Bugsmasher Edition.esp'
   - name: 'BetterDeadThralls.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/58069' ]
     msg:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9685,6 +9685,10 @@ plugins:
       - 'COR-CraftingOverhaulReqtified.esp'
   - name: 'Requiem - Breaking Bad.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/88161' ]
+    after:
+      - 'Requiem - Legendary Bugsmasher Edition.esp'
+      - 'Requiem_Minor_Arcana.esp'
+      - 'Requiem - Behind the Curtain.esp'
   - name: 'Open Face Guard Helmets.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/52602' ]
     after:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9641,6 +9641,8 @@ plugins:
       - 'COR-CraftingOverhaulReqtified.esp'
       - 'Requiem_Minor_Arcana.esp'
       - 'Requiem - Alchemy Rebalance.esp'
+    inc:
+      - 'Requiem - Wintersun Patch.esp'
     msg:
       - <<: *patchProvided
         condition: 'active("KFR-Kryptopyr''sFixesReqtified.esp") and not active("Requiem - IDB WAFR CCF patch.esp")'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9670,6 +9670,10 @@ plugins:
     after:
       - 'Requiem - Bugsmasher Edition.esp'
       - 'Requiem - Legendary Bugsmasher Edition.esp'
+    msg:
+      - <<: *alreadyInX
+        condition: 'active("AZ Tweaks.esp")'
+        subs: [ 'AZ Tweaks' ]
   - name: 'AZ Tweaks.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/81785' ]
     after:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9563,6 +9563,7 @@ plugins:
       - 'Requiem_Minor_Arcana.esp'
       - 'Requiem - SkyTEST.esp'
       - 'Requiem - Wild World.esp'
+      - 'Requiem - Mortal Enemies.esp'
   - name: 'Requiem - Immersive Horses - SkyTEST.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/61621' ]
     req:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9665,6 +9665,8 @@ plugins:
       - <<: *alreadyInX
         condition: 'active("Requiem - Immersive Divine Blessings.esp")'
         subs: [ 'Requiem - Immersive Divine Blessings' ]
+  - name: 'AZ Tweaks.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/81785' ]
   - name: 'Open Face Guard Helmets.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/52602' ]
     after:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9526,7 +9526,9 @@ plugins:
       - 'Fozars_Dragonborn_-_Requiem_Patch.esp'
       - 'NRM_Dragonborn_Reqtified.esp'
       - 'KFR-Kryptopyr''sFixesReqtified.esp'
+      - 'KFR-FZR.esp'
       - 'COR-CraftingOverhaulReqtified.esp'
+      - 'COR-FZR.esp'
   - name: 'Requiem - Immersive Horses( - SkyTEST)?\.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/61621' ]
     after:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9631,6 +9631,10 @@ plugins:
       - 'COR-CraftingOverhaulReqtified.esp'
       - 'Requiem_Minor_Arcana.esp'
       - 'Requiem - Alchemy Rebalance.esp'
+    msg:
+      - <<: *patchProvided
+        condition: 'active("KFR-Kryptopyr''sFixesReqtified.esp") and not active("Requiem - IDB WAFR CCF patch.esp")'
+        subs: [ 'Kryptopyr''s Fixes Reqtified' ]
   - name: 'Requiem - Werewolf and Vampire Rebalance.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/87420' ]
     after:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9494,7 +9494,7 @@ plugins:
       - <<: *patchIncluded
         condition: 'active("Fozars_Dragonborn_-_Requiem_Patch.esp") and not active("COR-FZR.esp")'
         subs: [ 'Fozar''s Dragonborn patch' ]
-  - name: 'COR-(?!CraftingOverhaulReqtified).+\.esp'
+  - name: 'COR-(Campfire|CircletsWithHoods|Cloaks_LightGuardsOnly|FurCloaks_LightGuardsOnly|FZR|NoHeavyStormcloaks|WetAndCold|WoodenBows)\.esp'
     req:
       - 'COR-CraftingOverhaulReqtified.esp'
   - name: 'Requiem_Minor_Arcana.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9501,6 +9501,10 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrim/mods/61590' ]
     after:
       - 'Requiem - Legendary Bugsmasher Edition.esp'
+    msg:
+      - <<: *alreadyInX
+        condition: 'active("COR-CraftingOverhaulReqtified.esp")'
+        subs: [ 'Crafting Overhaul Reqtified' ]
   - name: 'Requiem_Minor_Arcana.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrim/mods/90983'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9499,6 +9499,8 @@ plugins:
       - 'KFR-Kryptopyr''sFixesReqtified.esp'
   - name: 'CFR-CloaksForRequiem.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/61590' ]
+    after:
+      - 'Requiem - Legendary Bugsmasher Edition.esp'
   - name: 'Requiem_Minor_Arcana.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrim/mods/90983'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9529,6 +9529,10 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrim/mods/61621' ]
     after:
       - 'Requiem - Cutting Room Floor.esp'
+  - name: 'Requiem - Immersive Sounds Compendium.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/61621' ]
+    after:
+      - 'Requiem - Cutting Room Floor.esp'
   - name: 'Requiem - Immersive Horses( - SkyTEST)?\.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/61621' ]
     after:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9607,6 +9607,10 @@ plugins:
       - <<: *alreadyInX
         condition: 'active("Requiem - No Messages.esp")'
         subs: [ 'Requiem - No Messages.esp' ]
+  - name: 'Requiem - Wintersun Patch.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/95859' ]
+    after:
+      - 'Requiem - Legendary Bugsmasher Edition.esp'
   - name: 'Requiem - Alchemy Rebalance.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/86504' ]
     after:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9472,6 +9472,9 @@ plugins:
         subs: [ 'Fozar''s Requiem - Dragonborn Patch' ]
   - name: 'KFR-Kryptopyr''sFixesReqtified.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/61520' ]
+    after:
+      - 'Requiem - Bugsmasher Edition.esp'
+      - 'Requiem - Legendary Bugsmasher Edition.esp'
     msg:
       - <<: *patchIncluded
         condition: 'active("Fozars_Dragonborn_-_Requiem_Patch.esp") and not active("KFR-FZR.esp")'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9488,6 +9488,8 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrim/mods/61569' ]
     after:
       - 'Requiem - Legendary Bugsmasher Edition.esp'
+      - 'NRM_Dragonborn_Reqtified.esp'
+      - 'KFR-Kryptopyr''sFixesReqtified.esp'
     msg:
       - <<: *patchIncluded
         condition: 'active("Fozars_Dragonborn_-_Requiem_Patch.esp") and not active("COR-FZR.esp")'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9557,6 +9557,9 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrim/mods/61621' ]
     after:
       - 'Requiem_Minor_Arcana.esp'
+  - name: 'Requiem - Improved Closefaced Helmets.esp'
+    after:
+      - 'Requiem_Minor_Arcana.esp'
   - name: 'Requiem - ESF Companions.esp'
     after:
       - 'Requiem - Immersive Weapons.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -28758,3 +28758,5 @@ plugins:
       - <<: *patchRequiem3rdParty
         subs: [ '[Seg''s Requiem Patches](https://www.nexusmods.com/skyrim/mods/95859)' ]
         condition: 'active("Requiem.esp") and not active("Requiem - BDT Patch.esp")'
+  - name: 'Book of UUNP Iron And Steel.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/75861' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9497,10 +9497,6 @@ plugins:
   - name: 'COR-(?!CraftingOverhaulReqtified).+\.esp'
     req:
       - 'COR-CraftingOverhaulReqtified.esp'
-  - name: 'Requiem - Audio Overhaul for Skyrim.esp'
-    url: [ 'https://www.nexusmods.com/skyrim/mods/61621' ]
-    after:
-      - 'Requiem - Cutting Room Floor.esp'
   - name: 'Requiem_Minor_Arcana.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrim/mods/90983'
@@ -9529,6 +9525,10 @@ plugins:
       - 'KFR-FZR.esp'
       - 'COR-CraftingOverhaulReqtified.esp'
       - 'COR-FZR.esp'
+  - name: 'Requiem - Audio Overhaul for Skyrim.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/61621' ]
+    after:
+      - 'Requiem - Cutting Room Floor.esp'
   - name: 'Requiem - Immersive Horses( - SkyTEST)?\.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/61621' ]
     after:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9499,10 +9499,6 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrim/mods/61621' ]
     after:
       - 'Requiem - Cutting Room Floor.esp'
-  - name: 'Requiem - Guard Dialogue & Open Helmets.esp'
-    url: [ 'https://www.nexusmods.com/skyrim/mods/52602' ]
-    after:
-      - 'KFR-Kryptopyr''sFixesReqtified.esp'
   - name: 'Requiem_Minor_Arcana.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrim/mods/90983'
@@ -9561,6 +9557,14 @@ plugins:
   - name: 'Open Face Guard Helmets.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/52602' ]
     after:
+      - 'Requiem - Bugsmasher Edition.esp'
+      - 'Requiem - Legendary Bugsmasher Edition.esp'
+      - 'KFR-Kryptopyr''sFixesReqtified.esp'
+  - name: 'Requiem - Guard Dialogue & Open Helmets.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/52602' ]
+    after:
+      - 'Requiem - Bugsmasher Edition.esp'
+      - 'Requiem - Legendary Bugsmasher Edition.esp'
       - 'KFR-Kryptopyr''sFixesReqtified.esp'
   - name: 'Bounty Gold.esp'
     after:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9583,6 +9583,8 @@ plugins:
   - name: 'Requiem - Improved Closefaced Helmets.esp'
     after:
       - 'Requiem_Minor_Arcana.esp'
+      - 'Requiem - Immersive Divine Blessings.esp'
+      - 'Requiem - IDB WAFR CCF patch.esp'
   - name: 'Requiem - ESF Companions.esp'
     after:
       - 'Requiem_Minor_Arcana.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9611,6 +9611,8 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrim/mods/95859' ]
     after:
       - 'Requiem - Legendary Bugsmasher Edition.esp'
+  - name: 'Sacrosanct Requiem Patch and Rebalance.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/95859' ]
   - name: 'Requiem - Alchemy Rebalance.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/86504' ]
     after:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9445,6 +9445,9 @@ plugins:
         udr: 10
   - name: 'Requiem - Hearthfire.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/61621' ]
+    after:
+      - 'Requiem - Bugsmasher Edition.esp'
+      - 'Requiem - Legendary Bugsmasher Edition.esp'
     msg:
       - <<: *alreadyInX
         condition: 'version("Requiem.esp", "2.0.0", >=)'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -28698,3 +28698,6 @@ plugins:
         condition: 'active("Requiem.esp") and not active("Requiem - Wintersun Patch.esp")'
   - name: 'Sacrosanct - Vampires of Skyrim.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/80159' ]
+    msg:
+      - <<: *patchRequiemSEG
+        condition: 'active("Requiem.esp") and not active("Sacrosanct Requiem Patch and Rebalance.esp")'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9551,6 +9551,9 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrim/mods/61621' ]
     after:
       - 'Requiem_Minor_Arcana.esp'
+  - name: 'Requiem - ESF Companions.esp'
+    after:
+      - 'Requiem - Immersive Weapons.esp'
   - name: 'Requiem - No Overencumbered Messages.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/19281' ]
     msg:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9486,6 +9486,8 @@ plugins:
       - 'KFR-Kryptopyr''sFixesReqtified.esp'
   - name: 'COR-CraftingOverhaulReqtified.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/61569' ]
+    after:
+      - 'Requiem - Legendary Bugsmasher Edition.esp'
     msg:
       - <<: *patchIncluded
         condition: 'active("Fozars_Dragonborn_-_Requiem_Patch.esp") and not active("COR-FZR.esp")'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9526,6 +9526,7 @@ plugins:
       - 'Fozars_Dragonborn_-_Requiem_Patch.esp'
       - 'NRM_Dragonborn_Reqtified.esp'
       - 'KFR-Kryptopyr''sFixesReqtified.esp'
+      - 'COR-CraftingOverhaulReqtified.esp'
   - name: 'Requiem - Immersive Horses( - SkyTEST)?\.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/61621' ]
     after:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9616,6 +9616,10 @@ plugins:
     after:
       - 'Requiem - Legendary Bugsmasher Edition.esp'
       - 'Requiem - Werewolf and Vampire Rebalance.esp'
+      - 'Requiem - Immersive Sounds Compendium.esp'
+      - 'ISC Requiem Patch.esp'
+      - 'Requiem - Audio Overhaul for Skyrim.esp'
+      - 'AOS2_Requiem Patch.esp'
   - name: 'Requiem - BDT Patch.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/95859' ]
     after:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9507,6 +9507,15 @@ plugins:
         subs: [ 'Crafting Overhaul Reqtified' ]
   - name: 'RSE-RequiemSurvivalExperience.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/56275' ]
+    after:
+      - 'Requiem - Legendary Bugsmasher Edition.esp'
+      - 'Requiem - Hearthfire.esp'
+      - 'Fozars_Dragonborn_-_Requiem_Patch.esp'
+      - 'NRM_Dragonborn_Reqtified.esp'
+      - 'KFR-Kryptopyr''sFixesReqtified.esp'
+      - 'KFR-FZR.esp'
+      - 'COR-CraftingOverhaulReqtified.esp'
+      - 'COR-FZR.esp'
   - name: 'Requiem_Minor_Arcana.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrim/mods/90983'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -28689,3 +28689,6 @@ plugins:
         condition: 'active("Requiem.esp") and not active("Requiem - Lucien.esp")'
   - name: 'Wintersun - Faiths of Skyrim.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/95545' ]
+    msg:
+      - <<: *patchRequiemSEG
+        condition: 'active("Requiem.esp") and not active("Requiem - Wintersun Patch.esp")'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9605,6 +9605,10 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrim/mods/87420' ]
     after:
       - 'Requiem - Legendary Bugsmasher Edition.esp'
+    msg:
+      - <<: *alreadyInX
+        condition: 'active("Requiem - Immersive Divine Blessings.esp")'
+        subs: [ 'Requiem - Immersive Divine Blessings' ]
   - name: 'Open Face Guard Helmets.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/52602' ]
     after:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -28706,3 +28706,5 @@ plugins:
     msg:
       - <<: *patchRequiemSEG
         condition: 'active("Requiem.esp") and not active("Sacrosanct Requiem Patch and Rebalance.esp")'
+  - name: 'BetterDeadThralls.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/58069' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -28712,6 +28712,8 @@ plugins:
       - <<: *patchRequiem3rdParty
         subs: [ '[Seg''s Requiem Patches](https://www.nexusmods.com/skyrim/mods/95859)' ]
         condition: 'active("Requiem.esp") and not active("Sacrosanct Requiem Patch and Rebalance.esp")'
+    after:
+      - 'Requiem.esp'
   - name: 'BetterDeadThralls.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/58069' ]
     msg:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9603,6 +9603,8 @@ plugins:
         subs: [ 'Requiem - No Messages.esp' ]
   - name: 'Requiem - Werewolf and Vampire Rebalance.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/87420' ]
+    after:
+      - 'Requiem - Legendary Bugsmasher Edition.esp'
   - name: 'Open Face Guard Helmets.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/52602' ]
     after:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9667,6 +9667,9 @@ plugins:
         subs: [ 'Requiem - Immersive Divine Blessings' ]
   - name: 'Requiem - Behind the Curtain.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/74330' ]
+    after:
+      - 'Requiem - Bugsmasher Edition.esp'
+      - 'Requiem - Legendary Bugsmasher Edition.esp'
   - name: 'AZ Tweaks.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/81785' ]
     after:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9524,6 +9524,8 @@ plugins:
       - 'NRM_Dragonborn_Reqtified.esp'
       - 'KFR-Kryptopyr''sFixesReqtified.esp'
       - 'KFR-FZR.esp'
+      - 'KFR-CircletsWithHoods.esp'
+      - 'KFR-NoHeavyStormcloaks.esp'
       - 'COR-CraftingOverhaulReqtified.esp'
       - 'COR-FZR.esp'
   - name: 'Requiem - Audio Overhaul for Skyrim.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -28683,3 +28683,5 @@ plugins:
     msg:
       - <<: *patchRequiemRPC
         condition: 'active("Requiem.esp") and not active("Requiem - Lucien.esp")'
+  - name: 'Wintersun - Faiths of Skyrim.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/95545' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9607,6 +9607,7 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrim/mods/95859' ]
     after:
       - 'Requiem - Legendary Bugsmasher Edition.esp'
+      - 'Requiem_Minor_Arcana.esp'
   - name: 'Sacrosanct Requiem Patch and Rebalance.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/95859' ]
     after:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9619,6 +9619,10 @@ plugins:
       - 'NRM_Dragonborn_Reqtified.esp'
       - 'KFR-Kryptopyr''sFixesReqtified.esp'
       - 'COR-CraftingOverhaulReqtified.esp'
+    msg:
+      - <<: *patchProvided
+        condition: 'active("Requiem_Minor_Arcana.esp") and not active("Requiem - Food and Drug Rebalance MA patch.esp")'
+        subs: [ 'Requiem - Minor Arcana Reborn' ]
   - name: 'Requiem - Werewolf and Vampire Rebalance.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/87420' ]
     after:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9625,6 +9625,12 @@ plugins:
         subs: [ 'Requiem - Minor Arcana Reborn' ]
   - name: 'Requiem - Immersive Divine Blessings.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/90691' ]
+    after:
+      - 'Requiem - Legendary Bugsmasher Edition.esp'
+      - 'KFR-Kryptopyr''sFixesReqtified.esp'
+      - 'COR-CraftingOverhaulReqtified.esp'
+      - 'Requiem_Minor_Arcana.esp'
+      - 'Requiem - Alchemy Rebalance.esp'
   - name: 'Requiem - Werewolf and Vampire Rebalance.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/87420' ]
     after:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9512,7 +9512,6 @@ plugins:
       - 'Requiem - Guard Dialogue & Open Helmets.esp'
       - 'Requiem - Immersive Spells.esp'
       - 'Requiem - Civil War Overhaul Patch.esp'
-      - 'Requiem - ESF Companions.esp'
       - 'Requiem - Immersive Armors.esp'
       - 'Requiem - Immersive Weapons.esp'
   - name: 'Requiem - (83Willows 101Bugs|Animallica|Arissa|Audio Overhaul for Skyrim|Black Mage Armor|Book Covers Skyrim|Campfire|Common Clothes and Armors|Craftable Horse Barding|Cutting Room Floor|Deadly Dragons( - AOS)?|Dragon Combat Overhaul|ESF Companions|Faction Crossbows|Frostfall|Heavy Armory|Hoth|Immersive Armors|Immersive College of Winterhold|Immersive Horses( - SkyTEST)?|Immersive Patrols|Immersive Sounds Compendium|Immersive Weapons|Improved Closefaced Helmets|Inconsequential NPCs|Inigo|Live Another Life|Lost Library|Lucien|RS Children Overhaul|Rustic Soulgems( - ISC)?|Scoped Bows|Skyrim Unlocked|SkyTEST|Timing is Everything|Trade and Barter|Unique Uniques( - AOS)?|Vilja|VioLens|Wild World|WM Flora Fixes)\.esp'
@@ -9564,6 +9563,7 @@ plugins:
       - 'Requiem_Minor_Arcana.esp'
   - name: 'Requiem - ESF Companions.esp'
     after:
+      - 'Requiem_Minor_Arcana.esp'
       - 'Requiem - Immersive Weapons.esp'
   - name: 'Requiem - No Overencumbered Messages.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/19281' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9603,6 +9603,13 @@ plugins:
         subs: [ 'Requiem - No Messages.esp' ]
   - name: 'Requiem - Alchemy Rebalance.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/86504' ]
+    after:
+      - 'Requiem - Legendary Bugsmasher Edition.esp'
+      - 'Requiem - Hearthfire.esp'
+      - 'Fozars_Dragonborn_-_Requiem_Patch.esp'
+      - 'NRM_Dragonborn_Reqtified.esp'
+      - 'KFR-Kryptopyr''sFixesReqtified.esp'
+      - 'COR-CraftingOverhaulReqtified.esp'
   - name: 'Requiem - Werewolf and Vampire Rebalance.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/87420' ]
     after:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9683,6 +9683,8 @@ plugins:
     inc:
       - 'KFR-Kryptopyr''sFixesReqtified.esp'
       - 'COR-CraftingOverhaulReqtified.esp'
+  - name: 'Requiem - Breaking Bad.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/88161' ]
   - name: 'Open Face Guard Helmets.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/52602' ]
     after:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9517,6 +9517,15 @@ plugins:
       - 'Requiem - Immersive Spells.esp'
       - 'Requiem - Civil War Overhaul Patch.esp'
       - 'Requiem - ESF Companions.esp'
+  - name: 'Requiem - (83Willows 101Bugs|Animallica|Arissa|Audio Overhaul for Skyrim|Black Mage Armor|Book Covers Skyrim|Campfire|Common Clothes and Armors|Craftable Horse Barding|Cutting Room Floor|Deadly Dragons( - AOS)?|Dragon Combat Overhaul|ESF Companions|Faction Crossbows|Frostfall|Heavy Armory|Hoth|Immersive Armors|Immersive College of Winterhold|Immersive Horses( - SkyTEST)?|Immersive Patrols|Immersive Sounds Compendium|Immersive Weapons|Improved Closefaced Helmets|Inconsequential NPCs|Inigo|Live Another Life|Lost Library|Lucien|RS Children Overhaul|Rustic Soulgems( - ISC)?|Scoped Bows|Skyrim Unlocked|SkyTEST|Timing is Everything|Trade and Barter|Unique Uniques( - AOS)?|Vilja|VioLens|Wild World|WM Flora Fixes)\.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/61621' ]
+    after:
+      - 'Requiem - Bugsmasher Edition.esp'
+      - 'Requiem - Legendary Bugsmasher Edition.esp'
+      - 'Requiem - Hearthfire.esp'
+      - 'Fozars_Dragonborn_-_Requiem_Patch.esp'
+      - 'NRM_Dragonborn_Reqtified.esp'
+      - 'KFR-Kryptopyr''sFixesReqtified.esp'
   - name: 'Requiem - Immersive Horses( - SkyTEST)?\.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/61621' ]
     after:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9667,6 +9667,10 @@ plugins:
         subs: [ 'Requiem - Immersive Divine Blessings' ]
   - name: 'AZ Tweaks.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/81785' ]
+    after:
+      - 'Requiem - Bugsmasher Edition.esp'
+      - 'Requiem - Legendary Bugsmasher Edition.esp'
+      - 'Requiem_Minor_Arcana.esp'
   - name: 'Open Face Guard Helmets.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/52602' ]
     after:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9454,6 +9454,9 @@ plugins:
         subs: [ 'Requiem 2.0.0 and higher' ]
   - name: 'NRM_Dragonborn_Reqtified.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/60508' ]
+    after:
+      - 'Requiem - Bugsmasher Edition.esp'
+      - 'Requiem - Legendary Bugsmasher Edition.esp'
     inc:
       - 'Fozars_Dragonborn_-_Requiem_Patch.esp'
   - name: 'Requiem - Vanilla Dragonborn DLC.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9528,6 +9528,7 @@ plugins:
       - 'KFR-NoHeavyStormcloaks.esp'
       - 'COR-CraftingOverhaulReqtified.esp'
       - 'COR-FZR.esp'
+      - 'COR-NoHeavyStormcloaks.esp'
   - name: 'Requiem - Audio Overhaul for Skyrim.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/61621' ]
     after:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9612,6 +9612,13 @@ plugins:
       - 'COR-CraftingOverhaulReqtified.esp'
   - name: 'Requiem - Food and Drug Rebalance.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/90714' ]
+    after:
+      - 'Requiem - Legendary Bugsmasher Edition.esp'
+      - 'Requiem - Hearthfire.esp'
+      - 'Fozars_Dragonborn_-_Requiem_Patch.esp'
+      - 'NRM_Dragonborn_Reqtified.esp'
+      - 'KFR-Kryptopyr''sFixesReqtified.esp'
+      - 'COR-CraftingOverhaulReqtified.esp'
   - name: 'Requiem - Werewolf and Vampire Rebalance.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/87420' ]
     after:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9613,6 +9613,7 @@ plugins:
     after:
       - 'Requiem - Legendary Bugsmasher Edition.esp'
       - 'Requiem - Werewolf and Vampire Rebalance.esp'
+      - 'Requiem - Immersive Divine Blessings.esp'
       - 'Requiem - Immersive Sounds Compendium.esp'
       - 'ISC Requiem Patch.esp'
       - 'Requiem - Audio Overhaul for Skyrim.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9616,6 +9616,8 @@ plugins:
     after:
       - 'Requiem - Legendary Bugsmasher Edition.esp'
       - 'Requiem - Werewolf and Vampire Rebalance.esp'
+  - name: 'Requiem - BDT Patch.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/95859' ]
   - name: 'Requiem - Alchemy Rebalance.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/86504' ]
     after:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9491,6 +9491,8 @@ plugins:
   - name: 'COR-(Campfire|CircletsWithHoods|Cloaks_LightGuardsOnly|FurCloaks_LightGuardsOnly|FZR|NoHeavyStormcloaks|WetAndCold|WoodenBows)\.esp'
     req:
       - 'COR-CraftingOverhaulReqtified.esp'
+  - name: 'CAR-ContentAddonReqtified.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/72562' ]
   - name: 'Requiem_Minor_Arcana.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrim/mods/90983'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9475,13 +9475,7 @@ plugins:
       - <<: *patchIncluded
         condition: 'active("Fozars_Dragonborn_-_Requiem_Patch.esp") and not active("KFR-FZR.esp")'
         subs: [ 'Fozar''s Dragonborn Patch' ]
-  - name: 'KFR-CircletsWithHoods.esp'
-    req:
-      - 'KFR-Kryptopyr''sFixesReqtified.esp'
-  - name: 'KFR-FZR.esp'
-    req:
-      - 'KFR-Kryptopyr''sFixesReqtified.esp'
-  - name: 'KFR-NoHeavyStormcloaks.esp'
+  - name: 'KFR-(CircletsWithHoods|FZR|NoHeavyStormcloaks)\.esp'
     req:
       - 'KFR-Kryptopyr''sFixesReqtified.esp'
   - name: 'COR-CraftingOverhaulReqtified.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9497,6 +9497,8 @@ plugins:
       - 'Requiem - Legendary Bugsmasher Edition.esp'
       - 'NRM_Dragonborn_Reqtified.esp'
       - 'KFR-Kryptopyr''sFixesReqtified.esp'
+  - name: 'CFR-CloaksForRequiem.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/61590' ]
   - name: 'Requiem_Minor_Arcana.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrim/mods/90983'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9671,6 +9671,9 @@ plugins:
       - 'Requiem - Bugsmasher Edition.esp'
       - 'Requiem - Legendary Bugsmasher Edition.esp'
       - 'Requiem_Minor_Arcana.esp'
+    inc:
+      - 'KFR-Kryptopyr''sFixesReqtified.esp'
+      - 'COR-CraftingOverhaulReqtified.esp'
   - name: 'Open Face Guard Helmets.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/52602' ]
     after:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9505,6 +9505,8 @@ plugins:
       - <<: *alreadyInX
         condition: 'active("COR-CraftingOverhaulReqtified.esp")'
         subs: [ 'Crafting Overhaul Reqtified' ]
+  - name: 'RSE-RequiemSurvivalExperience.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/56275' ]
   - name: 'Requiem_Minor_Arcana.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrim/mods/90983'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -28696,3 +28696,5 @@ plugins:
     msg:
       - <<: *patchRequiemSEG
         condition: 'active("Requiem.esp") and not active("Requiem - Wintersun Patch.esp")'
+  - name: 'Sacrosanct - Vampires of Skyrim.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/80159' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9496,7 +9496,7 @@ plugins:
     after:
       - 'Requiem - Legendary Bugsmasher Edition.esp'
       - 'NRM_Dragonborn_Reqtified.esp'
-      - 'KFR-Kryptopyr''sFixesReqtified.esp'
+      - 'Fozars_Dragonborn_-_Requiem_Patch.esp'
   - name: 'CFR-CloaksForRequiem.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/61590' ]
     after:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9613,6 +9613,9 @@ plugins:
       - 'Requiem - Legendary Bugsmasher Edition.esp'
   - name: 'Sacrosanct Requiem Patch and Rebalance.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/95859' ]
+    after:
+      - 'Requiem - Legendary Bugsmasher Edition.esp'
+      - 'Requiem - Werewolf and Vampire Rebalance.esp'
   - name: 'Requiem - Alchemy Rebalance.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/86504' ]
     after:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -260,10 +260,6 @@ common:
     <<: *patchRequiem3rdParty
     subs:
       - '[More Requiem Patches](https://www.nexusmods.com/skyrim/mods/58141)'
-  - &patchRequiemSEG
-    <<: *patchRequiem3rdParty
-    subs:
-      - '[Seg''s Requiem Patches](https://www.nexusmods.com/skyrim/mods/95859)'
   - &semiCompatible
     type: say
     content:
@@ -28707,15 +28703,18 @@ plugins:
   - name: 'Wintersun - Faiths of Skyrim.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/95545' ]
     msg:
-      - <<: *patchRequiemSEG
+      - <<: *patchRequiem3rdParty
+        subs: [ '[Seg''s Requiem Patches](https://www.nexusmods.com/skyrim/mods/95859)' ]
         condition: 'active("Requiem.esp") and not active("Requiem - Wintersun Patch.esp")'
   - name: 'Sacrosanct - Vampires of Skyrim.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/80159' ]
     msg:
-      - <<: *patchRequiemSEG
+      - <<: *patchRequiem3rdParty
+        subs: [ '[Seg''s Requiem Patches](https://www.nexusmods.com/skyrim/mods/95859)' ]
         condition: 'active("Requiem.esp") and not active("Sacrosanct Requiem Patch and Rebalance.esp")'
   - name: 'BetterDeadThralls.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/58069' ]
     msg:
-      - <<: *patchRequiemSEG
+      - <<: *patchRequiem3rdParty
+        subs: [ '[Seg''s Requiem Patches](https://www.nexusmods.com/skyrim/mods/95859)' ]
         condition: 'active("Requiem.esp") and not active("Requiem - BDT Patch.esp")'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9459,6 +9459,11 @@ plugins:
       - 'Requiem - Legendary Bugsmasher Edition.esp'
     inc:
       - 'Fozars_Dragonborn_-_Requiem_Patch.esp'
+  - name: 'Fozars_Dragonborn_-_Requiem_Patch.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/78139' ]
+    after:
+      - 'Requiem - Bugsmasher Edition.esp'
+      - 'Requiem - Legendary Bugsmasher Edition.esp'
   - name: 'Requiem - Vanilla Dragonborn DLC.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/19281' ]
     msg:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9623,6 +9623,8 @@ plugins:
       - <<: *patchProvided
         condition: 'active("Requiem_Minor_Arcana.esp") and not active("Requiem - Food and Drug Rebalance MA patch.esp")'
         subs: [ 'Requiem - Minor Arcana Reborn' ]
+  - name: 'Requiem - Immersive Divine Blessings.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/90691' ]
   - name: 'Requiem - Werewolf and Vampire Rebalance.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/87420' ]
     after:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9610,6 +9610,8 @@ plugins:
       - 'NRM_Dragonborn_Reqtified.esp'
       - 'KFR-Kryptopyr''sFixesReqtified.esp'
       - 'COR-CraftingOverhaulReqtified.esp'
+  - name: 'Requiem - Food and Drug Rebalance.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/90714' ]
   - name: 'Requiem - Werewolf and Vampire Rebalance.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/87420' ]
     after:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9601,6 +9601,8 @@ plugins:
       - <<: *alreadyInX
         condition: 'active("Requiem - No Messages.esp")'
         subs: [ 'Requiem - No Messages.esp' ]
+  - name: 'Requiem - Alchemy Rebalance.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/86504' ]
   - name: 'Requiem - Werewolf and Vampire Rebalance.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/87420' ]
     after:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -260,6 +260,10 @@ common:
     <<: *patchRequiem3rdParty
     subs:
       - '[More Requiem Patches](https://www.nexusmods.com/skyrim/mods/58141)'
+  - &patchRequiemSEG
+    <<: *patchRequiem3rdParty
+    subs:
+      - '[Seg''s Requiem Patches](https://www.nexusmods.com/skyrim/mods/95859)'
   - &semiCompatible
     type: say
     content:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -28708,3 +28708,6 @@ plugins:
         condition: 'active("Requiem.esp") and not active("Sacrosanct Requiem Patch and Rebalance.esp")'
   - name: 'BetterDeadThralls.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/58069' ]
+    msg:
+      - <<: *patchRequiemSEG
+        condition: 'active("Requiem.esp") and not active("Requiem - BDT Patch.esp")'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -28760,3 +28760,7 @@ plugins:
         condition: 'active("Requiem.esp") and not active("Requiem - BDT Patch.esp")'
   - name: 'Book of UUNP Iron And Steel.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/75861' ]
+    msg:
+      - <<: *patchRequiem3rdParty
+        subs: [ '[Requiem - The Book of UUNP Patch](https://www.nexusmods.com/skyrim/mods/90507)' ]
+        condition: 'active("Requiem.esp") and not active("Requiem - Book Of UUNP patch.esp")'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9564,6 +9564,7 @@ plugins:
       - 'Requiem - SkyTEST.esp'
       - 'Requiem - Wild World.esp'
       - 'Requiem - Mortal Enemies.esp'
+      - 'Requiem - Breaking Bad.esp'
   - name: 'Requiem - Immersive Horses - SkyTEST.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/61621' ]
     req:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9513,6 +9513,8 @@ plugins:
       - 'Requiem - Immersive Spells.esp'
       - 'Requiem - Civil War Overhaul Patch.esp'
       - 'Requiem - ESF Companions.esp'
+      - 'Requiem - Immersive Armors.esp'
+      - 'Requiem - Immersive Weapons.esp'
   - name: 'Requiem - (83Willows 101Bugs|Animallica|Arissa|Audio Overhaul for Skyrim|Black Mage Armor|Book Covers Skyrim|Campfire|Common Clothes and Armors|Craftable Horse Barding|Cutting Room Floor|Deadly Dragons( - AOS)?|Dragon Combat Overhaul|ESF Companions|Faction Crossbows|Frostfall|Heavy Armory|Hoth|Immersive Armors|Immersive College of Winterhold|Immersive Horses( - SkyTEST)?|Immersive Patrols|Immersive Sounds Compendium|Immersive Weapons|Improved Closefaced Helmets|Inconsequential NPCs|Inigo|Live Another Life|Lost Library|Lucien|RS Children Overhaul|Rustic Soulgems( - ISC)?|Scoped Bows|Skyrim Unlocked|SkyTEST|Timing is Everything|Trade and Barter|Unique Uniques( - AOS)?|Vilja|VioLens|Wild World|WM Flora Fixes)\.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/61621' ]
     after:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9446,7 +9446,6 @@ plugins:
   - name: 'Requiem - Hearthfire.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/61621' ]
     after:
-      - 'Requiem - Bugsmasher Edition.esp'
       - 'Requiem - Legendary Bugsmasher Edition.esp'
     msg:
       - <<: *alreadyInX
@@ -9455,14 +9454,12 @@ plugins:
   - name: 'NRM_Dragonborn_Reqtified.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/60508' ]
     after:
-      - 'Requiem - Bugsmasher Edition.esp'
       - 'Requiem - Legendary Bugsmasher Edition.esp'
     inc:
       - 'Fozars_Dragonborn_-_Requiem_Patch.esp'
   - name: 'Fozars_Dragonborn_-_Requiem_Patch.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/78139' ]
     after:
-      - 'Requiem - Bugsmasher Edition.esp'
       - 'Requiem - Legendary Bugsmasher Edition.esp'
   - name: 'Requiem - Vanilla Dragonborn DLC.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/19281' ]
@@ -9473,7 +9470,6 @@ plugins:
   - name: 'KFR-Kryptopyr''sFixesReqtified.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/61520' ]
     after:
-      - 'Requiem - Bugsmasher Edition.esp'
       - 'Requiem - Legendary Bugsmasher Edition.esp'
     msg:
       - <<: *patchIncluded


### PR DESCRIPTION
Groups in their current form are too unflexible to do what Requiem patches and addons really want. Thus I have now decided to go back to good old load after rules. All things considered they just work better.

The most popular Requiem patches and addons have the necessary rules to keep the order Bugsmasher < DLC patches < WAFR + CCF patches < Sound mod and other low priority patches < the remaining Requiem patches. The main advantage of load after rules compared to groups is that unrecognized plugins and non-Requiem mods that should load after Requiem are no longer forced between Requiem.esp and the Bugmasher plugin. Instead they usually end up somewhere lower which is where they belong.