### PR TITLE
Remove cleaning info

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3253,12 +3253,6 @@ plugins:
     msg:
       - <<: *corrupt
         condition: 'checksum("Faendal.esp",60930CE6) or checksum("Faendal.esp",C4A869DC)'
-    dirty:
-      # 12909 - v1.2
-      - <<: *quickClean
-        crc: 0x60930CE6
-        util: '[TES5Edit v4.0.2h](https://www.nexusmods.com/skyrim/mods/25859)'
-        itm: 4
   - name: 'Hirelingrevamp.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/22616' ]
     dirty:
@@ -24987,10 +24981,6 @@ plugins:
     msg:
       - <<: *corrupt
         condition: 'checksum("SlavePackRiekling.esp",9657019E)'
-    dirty:
-      - crc: 0x9657019e
-        <<: *dirtyPlugin
-        itm: 174
   - name: 'SloadCompanion.esp'
     dirty:
       - crc: 0xd249ade2
@@ -26031,10 +26021,6 @@ plugins:
     msg:
       - <<: *corrupt
         condition: 'checksum("Waves.esp",80C9D6A)'
-    dirty:
-      - crc: 0x80c9d6a
-        <<: *dirtyPlugin
-        itm: 189
   - name: 'kerplunk.esp'
     msg:
       - <<: *alreadyInX

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1223,9 +1223,6 @@ plugins:
         crc: 0x68AD6D32
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 1
-    clean:
-      - crc: 0xDF7362E3
-        util: 'TES5Edit v4.0.2f'
   - name: '28 Days and a Bit 5.esm'
     url: [ 'https://www.nexusmods.com/skyrim/mods/5604' ]
     msg: [ *obsolete ]
@@ -1240,10 +1237,6 @@ plugins:
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 73
         udr: 49
-    clean:
-      # v0.8.6 - after QAC
-      - crc: 0xAE091C12
-        util: 'TES5Edit v4.0.2f'
   - name: '3DNPC.esm'
     msg: [ *obsolete ]
   - name: '(83Willows_)?101BUGs.+\.esm'
@@ -1294,9 +1287,6 @@ plugins:
         crc: 0x319033CE
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 1
-    clean:
-      - crc: 0x075CE435
-        util: 'TES5Edit v4.0.2f'
   - name: 'AOM.esm'
     url: [ 'https://www.nexusmods.com/skyrim/mods/1040' ]
     clean:
@@ -1322,10 +1312,6 @@ plugins:
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 45
         udr: 20
-    clean:
-      # v1.3 - after QAC
-      - crc: 0x4CC58E5F
-        util: 'TES5Edit v4.0.2f'
   - name: 'archmageTrophyhall.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/11123' ]
     dirty:
@@ -1335,10 +1321,6 @@ plugins:
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 24
         udr: 564
-    clean:
-      # v1.3 - after QAC
-      - crc: 0x8A7BDBF3
-        util: 'TES5Edit v4.0.2f'
   - name: 'BBLuxurySuite.esm'
     url: [ 'https://www.nexusmods.com/skyrim/mods/11427' ]
     msg: [ *doNotClean ]
@@ -1362,10 +1344,6 @@ plugins:
         crc: 0xA1D94BDA
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 109
-    clean:
-      # v1.0 / v1.2 - after QAC
-      - crc: 0x47D8108A
-        util: 'TES5Edit v4.0.2f'
   - name: 'VFU_Home.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/12375' ]
     dirty:
@@ -1380,13 +1358,6 @@ plugins:
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 118
         udr: 28
-    clean:
-      # v1.0 - after QAC
-      - crc: 0x98166FA7
-        util: 'TES5Edit v4.0.2f'
-      # v1.2 - after QAC
-      - crc: 0x22EACC45
-        util: 'TES5Edit v4.0.2f'
   - name: 'breezehomebasement.esm'
     url: []
     msg:
@@ -1467,10 +1438,6 @@ plugins:
         crc: 0x7BF398F5
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 2
-    clean:
-      # v0.512 - after QAC
-      - crc: 0xCD3C6E62
-        util: 'TES5Edit v4.0.2f'
   - name: 'Castle Draco Riverwood Edition.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/30469' ]
     dirty:
@@ -1479,10 +1446,6 @@ plugins:
         crc: 0xC79A139B
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 29
-    clean:
-      # v5.5 - after QAC
-      - crc: 0x5EED3A77
-        util: 'TES5Edit v4.0.2f'
   - name: 'CastleDrakhur_masterfle.esm'
     url: [ 'https://www.nexusmods.com/skyrim/mods/20735' ]
     dirty:
@@ -1534,9 +1497,6 @@ plugins:
         crc: 0xDF772E21
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 8
-    clean:
-      - crc: 0xE8DC9BD9
-        util: 'TES5Edit v4.0.2f'
   - name: 'ClimatesOfTamriel-Dawnguard-Patch.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/17802' ]
     msg:
@@ -1589,9 +1549,6 @@ plugins:
         crc: 0x67CA961C
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 2
-    clean:
-      - crc: 0xAE6881C4
-        util: 'TES5Edit v4.0.2f'
   - name: 'ClimatesOfTamriel-Dungeons-Hazardous.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/17802' ]
     inc:
@@ -1671,9 +1628,6 @@ plugins:
         crc: 0xCE17BFE3
         util: '[TES5Edit v4.0.3](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 825
-    clean:
-      - crc: 0x0C11B865
-        util: 'TES5Edit v4.0.3'
   - name: 'ClimatesOfTamriel-WinterEdition.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/17802' ]
     msg:
@@ -1696,9 +1650,6 @@ plugins:
         crc: 0x2FEA325D
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 5
-    clean:
-      - crc: 0xF7D0C971
-        util: 'TES5Edit v4.0.2f'
   - name: 'CK''s Companions.esm'
     url: [ 'https://www.nexusmods.com/skyrim/mods/13228' ]
     dirty:
@@ -1706,9 +1657,6 @@ plugins:
         crc: 0xD5550E36
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 20
-    clean:
-      - crc: 0x3EBC2632
-        util: 'TES5Edit v4.0.2f'
   - name: 'CK''s Companions.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/13228' ]
     clean:
@@ -1725,9 +1673,6 @@ plugins:
         crc: 0x16E3C26D
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 19
-    clean:
-      - crc: 0xCC7A1963
-        util: 'TES5Edit v4.0.2f'
   - name: 'DBShreddedTriss.esm'
     msg: [ *obsolete ]
   - name: 'DeadlyDragons.esm'
@@ -1873,9 +1818,6 @@ plugins:
         crc: 0xB2831F34
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 6
-    clean:
-      - crc: 0x8A993DAA
-        util: 'TES5Edit v4.0.2f'
   - name: 'HjakhtraevarrTomb.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/16256' ]
     dirty:
@@ -1883,9 +1825,6 @@ plugins:
         crc: 0xE31F5E91
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 6
-    clean:
-      - crc: 0xBB8558BE
-        util: 'TES5Edit v4.0.2f'
   - name: 'Imp''s More Complex Needs.esm'
     msg: [ *obsolete ]
   - name: 'IsharasUniqueRaces.esm'
@@ -1991,9 +1930,6 @@ plugins:
         crc: 0x50A19275
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 1
-    clean:
-      - crc: 0x4C1B76C0
-        util: 'TES5Edit v4.0.2f'
   - name: 'moonpath_questdata.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/9782' ]
     dirty:
@@ -2001,9 +1937,6 @@ plugins:
         crc: 0x78CAE957
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 1
-    clean:
-      - crc: 0x40B15C70
-        util: 'TES5Edit v4.0.2f'
   - name: 'MTAutoStorage.esm'
     url: [ 'https://www.nexusmods.com/skyrim/mods/34241' ]
     dirty:
@@ -2011,9 +1944,6 @@ plugins:
         crc: 0xEDA019E7
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 22
-    clean:
-      - crc: 0x400AEEFB
-        util: 'TES5Edit v4.0.2f'
   - name: 'wingspread.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/34241' ]
     dirty:
@@ -2271,9 +2201,6 @@ plugins:
         crc: 0xE57E4EC6
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 944
-    clean:
-      - crc: 0x394BC4B8
-        util: 'TES5Edit v4.0.2f'
   - name: 'BecomeKingOfRiverHelm.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/16374' ]
     dirty:
@@ -2282,9 +2209,6 @@ plugins:
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 4
         udr: 1
-    clean:
-      - crc: 0x57B01C9B
-        util: 'TES5Edit v4.0.2f'
   - name: 'SC_Drow Race.esm'
     msg: [ *obsolete ]
   - name: 'SexiS.esm'
@@ -2385,13 +2309,6 @@ plugins:
         crc: 0x151A29D3
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 6
-    clean:
-      # V4 Main
-      - crc: 0xADC69596
-        util: 'TES5Edit v4.0.2f'
-      # V4 Main Lore
-      - crc: 0x7921FEDB
-        util: 'TES5Edit v4.0.2f'
   - name: 'SleepingTreeSanctuary.esm'
     url: [ 'https://www.nexusmods.com/skyrim/mods/17289' ]
     dirty:
@@ -2439,9 +2356,6 @@ plugins:
         crc: 0x09B9C494
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 11
-    clean:
-      - crc: 0x4B63E6E6
-        util: 'TES5Edit v4.0.2f'
   - name: 'Terramis_Dungeon_01.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/12935' ]
     inc:
@@ -2451,9 +2365,6 @@ plugins:
         crc: 0x0300A1D3
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 11
-    clean:
-      - crc: 0xAD2ED52A
-        util: 'TES5Edit v4.0.2f'
   - name: 'Terramis_DungeonChild.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/12935' ]
     msg: [ *obsolete ]
@@ -2501,10 +2412,6 @@ plugins:
         crc: 0x40169648
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 88
-    clean:
-      # v1.3 - after QAC
-      - crc: 0x4D2DCC06
-        util: 'TES5Edit v4.0.2f'
   - name: 'Vigilant of Stendarr Quests Master.esm'
     url: [ 'https://www.nexusmods.com/skyrim/mods/13725' ]
     dirty:
@@ -2513,10 +2420,6 @@ plugins:
         crc: 0x0B0207CF
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 3
-    clean:
-      # v1.5 - after QAC
-      - crc: 0x4654C82C
-        util: 'TES5Edit v4.0.2f'
   - name: 'Dawnguard - Vigilant of Stendarr Quests Patch.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/13725' ]
     msg:
@@ -2535,10 +2438,6 @@ plugins:
         crc: 0x9F4D4339
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 8
-    clean:
-      # v1.0 - after QAC
-      - crc: 0x7F0A7601
-        util: 'TES5Edit v4.0.2f'
   - name: 'Vigilant of Stendarr Quests.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/13725' ]
     dirty:
@@ -2587,10 +2486,6 @@ plugins:
         crc: 0x85A67A5A
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         nav: 1
-    clean:
-      # v2.25 - Normal - After QAC
-      - crc: 0xB662C637
-        util: 'TES5Edit v4.0.2f'
   - name: 'ExpandedWinterholdRuins.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/30554' ]
     dirty:
@@ -2599,10 +2494,6 @@ plugins:
         crc: 0xF462EFAE
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 8
-    clean:
-      # v2.25 - Normal - After QAC
-      - crc: 0xC9110449
-        util: 'TES5Edit v4.0.2f'
   - name: 'ExpandedWinterholdRuinsExterior.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/30554' ]
     dirty:
@@ -2610,9 +2501,6 @@ plugins:
         crc: 0xE76DACEB
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 10
-    clean:
-      - crc: 0xFE8D1903
-        util: 'TES5Edit v4.0.2f'
   - name: 'ExpandedWinterholdRuinsExterior - NoHouse.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/30554' ]
     dirty:
@@ -2620,9 +2508,6 @@ plugins:
         crc: 0x939075D0
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 10
-    clean:
-      - crc: 0x31898CAF
-        util: 'TES5Edit v4.0.2f'
   - name: 'XFLMain.esm'
     inc:
       - 'BDO.esp'
@@ -2737,9 +2622,6 @@ plugins:
         crc: 0xF0C49703
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 8
-    clean:
-      - crc: 0x6FE81988
-        util: 'TES5Edit v4.0.2f'
   - name: 'NPCEssential - .+\.esp'
     msg:
       - type: say
@@ -3165,9 +3047,6 @@ plugins:
         util: '[TES5Edit v4.0.2h](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 28
         udr: 7
-    clean:
-      - crc: 0xC07C3C88
-        util: 'TES5Edit v4.0.2h'
   - name: 'Thalmor Embassy Disguise Fix.esp'
     msg: [ *alreadyInOrFixedByUSLEEP ]
   - name: 'Thief armor fix.esp'
@@ -3233,9 +3112,6 @@ plugins:
         crc: 0x330AED25
         util: '[TES5Edit v4.0.2h](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 2
-    clean:
-      - crc: 0xA5683397
-        util: 'TES5Edit v4.0.2h'
   - name: 'Dawnguard Summons Fixed.esp'
     msg: [ *alreadyInOrFixedByUSLEEP ]
   - name: 'DawnguardDrainVitalityFix.esp'
@@ -3259,9 +3135,6 @@ plugins:
         crc: 0x7D544DFE
         util: '[TES5Edit v4.0.2h](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 48
-    clean:
-      - crc: 0xFA150E7D
-        util: 'TES5Edit v4.0.2h'
   - name: 'HighResTexturePackFix.esp'
     msg: [ *alreadyInOrFixedByUHRP ]
   - name: 'invisible_shield_fix.esp'
@@ -3280,10 +3153,6 @@ plugins:
         crc: 0x91AA4E51
         util: '[TES5Edit v4.0.2h](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 5
-    clean:
-      # v1 - after QAC
-      - crc: 0x397E80A8
-        util: 'TES5Edit v4.0.2h'
   - name: 'Skyrim - Director''s Cut - HD Pack Fix.esp'
     req:
       - name: 'HighResTexturePack01.esp'
@@ -3379,10 +3248,6 @@ plugins:
         crc: 0xAAC416C0
         util: '[TES5Edit v4.0.2h](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 5
-    clean:
-      # Main - after QAC
-      - crc: 0xE0EBF452
-        util: 'TES5Edit v4.0.2h'
   - name: 'Faendal.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/12909' ]
     msg:
@@ -3394,10 +3259,6 @@ plugins:
         crc: 0x60930CE6
         util: '[TES5Edit v4.0.2h](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 4
-    clean:
-      # 12909 - v1.2 - after QAC
-      - crc: 0xC4A869DC
-        util: 'TES5Edit v4.0.2h'
   - name: 'Hirelingrevamp.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/22616' ]
     dirty:
@@ -3406,10 +3267,6 @@ plugins:
         crc: 0x6F80462B
         util: '[TES5Edit v4.0.2h](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 4
-    clean:
-      # v1.2 - after QAC
-      - crc: 0x9920D75D
-        util: 'TES5Edit v4.0.2h'
   - name: 'Layla.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/24698' ]
     msg: [ *corrupt ]
@@ -3451,10 +3308,6 @@ plugins:
         crc: 0x1AEB51FC
         util: '[TES5Edit v4.0.2h](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 3
-    clean:
-      # v1.0 - after QAC
-      - crc: 0x914D89EB
-        util: 'TES5Edit v4.0.2h'
   - name: 'Vex.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/14040' ]
     msg:
@@ -3476,10 +3329,6 @@ plugins:
         crc: 0xFE2F1935
         util: '[TES5Edit v4.0.2h](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 3
-    clean:
-      # Final - after QAC
-      - crc: 0xB4CED9D1
-        util: 'TES5Edit v4.0.2h'
   - name: 'Chesko_Frostfall.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/11163' ]
     msg:
@@ -3515,10 +3364,6 @@ plugins:
         crc: 0x88CB9260
         util: '[TES5Edit v4.0.2h](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 7
-    clean:
-      # v1.0 - after QAC
-      - crc: 0x14164D28
-        util: 'TES5Edit v4.0.2h'
   - name: 'getSnowyV.+\.esp'
     inc:
       - 'Chesko_Frostfall.esp'
@@ -3532,10 +3377,6 @@ plugins:
         crc: 0xF26A6037
         util: '[TES5Edit v4.0.2h](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 2
-    clean:
-      # v1.1 - after QAC
-      - crc: 0x4F81151F
-        util: 'TES5Edit v4.0.2h'
   - name: 'MoreSnowWindy.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/8328' ]
     inc:
@@ -3546,10 +3387,6 @@ plugins:
         crc: 0xB1CC90A4
         util: '[TES5Edit v4.0.2h](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 2
-    clean:
-      # v1.1 - after QAC
-      - crc: 0x6BDD6671
-        util: 'TES5Edit v4.0.2h'
   - name: 'MoreSnow(Windy)?(and(75|150)percentLessView)?\.esp'
     msg:
       - <<: *useOnlyOneX
@@ -3562,9 +3399,6 @@ plugins:
         crc: 0x7ED853EE
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 2
-    clean:
-      - crc: 0xFC07A6A7
-        util: 'TES5Edit v4.0.2f'
   - name: 'MoreSnowWindyand75percentLessView.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/8328' ]
     dirty:
@@ -3572,9 +3406,6 @@ plugins:
         crc: 0x4A595497
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 2
-    clean:
-      - crc: 0x28F22A1E
-        util: 'TES5Edit v4.0.2f'
   - name: 'Better Dynamic Snow.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/11' ]
     clean:
@@ -3588,9 +3419,6 @@ plugins:
         crc: 0xB66B01E5
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 2
-    clean:
-      - crc: 0xFD17A22B
-        util: 'TES5Edit v4.0.2f'
   - name: 'PNENB.esp'
     msg:
       - <<: *useVersionNonDawnguard
@@ -3698,10 +3526,6 @@ plugins:
         crc: 0x34E8C367
         util: '[TES5Edit v4.0.1](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 1
-    clean:
-      # version: 2.3 Vanilla + Dawnguard + Dragonborn
-      - crc: 0xECA406F7
-        util: 'TES5Edit v4.0.1'
   - name: 'Prometheus_NSUTR BDS Patch.esp'
     clean:
       # version: 2.3
@@ -3720,10 +3544,6 @@ plugins:
         crc: 0x3F16767E
         util: '[TES5Edit v4.0.2i](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 12
-    clean:
-      # v1.2 - after QAC
-      - crc: 0xBD173777
-        util: 'TES5Edit v4.0.2i'
   - name: 'DFG''s Blade & Dagger Sheathe Sounds_Dawnguard.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/11465' ]
     dirty:
@@ -3732,10 +3552,6 @@ plugins:
         crc: 0x533F47EC
         util: '[TES5Edit v4.0.2i](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 13
-    clean:
-      # v1.2 - after QAC
-      - crc: 0x4273D36E
-        util: 'TES5Edit v4.0.2i'
   - name: 'Clanking Armor.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/24352' ]
     dirty:
@@ -3744,10 +3560,6 @@ plugins:
         crc: 0xDD039D67
         util: '[TES5Edit v4.0.2i](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 1
-    clean:
-      # v1.2 - after QAC
-      - crc: 0x1E4AB12E
-        util: 'TES5Edit v4.0.2i'
   - name: 'ClimatesOfTamriel-Sound.esp'
     msg:
       - type: warn
@@ -3779,10 +3591,6 @@ plugins:
         crc: 0x7252CC51
         util: '[TES5Edit v4.0.2i](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 2
-    clean:
-      # v2.0 - after QAC
-      - crc: 0x12188E5B
-        util: 'TES5Edit v4.0.2i'
   - name: 'LIAT - NPCs.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/19841' ]
     dirty:
@@ -3791,10 +3599,6 @@ plugins:
         crc: 0x8EFD5F95
         util: '[TES5Edit v4.0.2i](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 3
-    clean:
-      # v1.31 - after QAC
-      - crc: 0xB0C82860
-        util: 'TES5Edit v4.0.2i'
   - name: 'LIAT - Sounds.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/19841' ]
     dirty:
@@ -3803,10 +3607,6 @@ plugins:
         crc: 0x0068EB2F
         util: '[TES5Edit v4.0.2i](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 47
-    clean:
-      # v1.31 - after QAC
-      - crc: 0x726826BE
-        util: 'TES5Edit v4.0.2i'
   - name: 'LIAT - (AI Packages|Crowded|Less Visitors|Lively Inns and Taverns|More Visitors)?\.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/19841' ]
     msg: [ *obsolete ]
@@ -3853,10 +3653,6 @@ plugins:
         util: '[TES5Edit v4.0.2i](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 7
         udr: 106
-    clean:
-      # v2.0 - after QAC
-      - crc: 0x52C1F8CD
-        util: 'TES5Edit v4.0.2i'
   - name: 'Blackout_Skyrim.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/27960' ]
     msg:
@@ -3878,10 +3674,6 @@ plugins:
         crc: 0x3A1DA448
         util: '[TES5Edit v4.0.2i](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 8
-    clean:
-      # v2.0 - after QAC
-      - crc: 0x58BF8CE5
-        util: 'TES5Edit v4.0.2i'
   - name: 'Blackout_Dawnguard.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/27960' ]
     msg:
@@ -3908,9 +3700,6 @@ plugins:
         crc: 0xFFAAF7FF
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 8
-    clean:
-      - crc: 0x01217166
-        util: 'TES5Edit v4.0.2f'
   - name: 'CLARALUX - More and Brighter Lights.esm'
     url: [ 'https://www.nexusmods.com/skyrim/mods/17605' ]
     msg: [ *obsolete ]
@@ -3940,10 +3729,6 @@ plugins:
         util: '[TES5Edit v4.0.2i](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 12
         udr: 302
-    clean:
-      # v0.a.3 - after QAC
-      - crc: 0x0E8FABEF
-        util: 'TES5Edit v4.0.2i'
   - name: 'realrain.esp'
     inc:
       - 'realrainextended.esp'
@@ -3988,10 +3773,6 @@ plugins:
         crc: 0x2014AA8E
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 9
-    clean:
-      # v1.3 - after QAC
-      - crc: 0x78E23FB2
-        util: 'TES5Edit v4.0.2j'
   - name: 'Remove Interior Fog V2 - Skyrim.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/29253' ]
     inc:
@@ -4033,10 +3814,6 @@ plugins:
         crc: 0x4FD63CD3
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 3
-    clean:
-      # v1.3 - after QAC
-      - crc: 0x0DAEEE55
-        util: 'TES5Edit v4.0.2j'
   - name: 'Warmer Magic Lights v2.esp'
     msg:
       - <<: *fixedPluginPreCKSharlikran
@@ -4089,10 +3866,6 @@ plugins:
         crc: 0xA64545AF
         util: '[TES5Edit v4.0.2h](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 5
-    clean:
-      # v1.08 - after QAC
-      - crc: 0x0C8D5264
-        util: 'TES5Edit v4.0.2h'
   - name: 'AdditionalMusicBundleI.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/25625' ]
     dirty:
@@ -4101,10 +3874,6 @@ plugins:
         crc: 0x010E2879
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 1
-    clean:
-      # v1.1 - after QAC
-      - crc: 0xA1664BDA
-        util: 'TES5Edit v4.0.2j'
   - name: 'Ambience Music Overhaul - Addon.esp'
     msg: [ *obsolete ]
   - name: 'Ambience Music Overhaul - Addon - with vanilla music -.esp'
@@ -4150,10 +3919,6 @@ plugins:
         crc: 0x06FA5890
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 1
-    clean:
-      # v1.0 - after QAC
-      - crc: 0xE3297A17
-        util: 'TES5Edit v4.0.2j'
   - name: 'calientevanillaarmor - banditpack curvy.esp'
     msg:
       - *requiresCBBE
@@ -4188,10 +3953,6 @@ plugins:
         crc: 0xDCFE8BC1
         util: '[TES5Edit v4.0.1](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 24
-    clean:
-      # v2.0.9
-      - crc: 0x5B6DC391
-        util: 'TES5Edit v4.0.2f'
   - name: 'BeastModels.esp'
     msg: [ *obsolete ]
   - name: 'BorderRegionsDisabled(EV)?\.esp'
@@ -4334,10 +4095,6 @@ plugins:
         crc: 0x63FA5A9F
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 11
-    clean:
-      # v5.0 - after QAC
-      - crc: 0x4CC395ED
-        util: 'TES5Edit v4.0.2j'
   - name: 'anon_soullevelsrevealed.esp'
     dirty:
       - crc: 0xd513587f
@@ -4352,10 +4109,6 @@ plugins:
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 12
         udr: 1
-    clean:
-      # v1 - after QAC
-      - crc: 0x4069547B
-        util: 'TES5Edit v4.0.2j'
   - name: 'KhajiitfemGuild.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/22198' ]
     dirty:
@@ -4365,10 +4118,6 @@ plugins:
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 11
         udr: 1
-    clean:
-      # v1 - after QAC
-      - crc: 0xCFAB88C6
-        util: 'TES5Edit v4.0.2j'
   - name: 'Armor and Clothing Diversity.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/21605' ]
     dirty:
@@ -4377,10 +4126,6 @@ plugins:
         crc: 0x8550B53D
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 1
-    clean:
-      # v2.0 - after QAC
-      - crc: 0x937B8A9A
-        util: 'TES5Edit v4.0.2j'
   - name: 'Armored Skeleton.esp'
     msg: [ *alreadyInSkyrimImmersiveCreatures ]
     tag: [ Relev ]
@@ -4425,10 +4170,6 @@ plugins:
         crc: 0x449C7BDC
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 8
-    clean:
-      # v1.6 - after QAC
-      - crc: 0x1AEA3B69
-        util: 'TES5Edit v4.0.2j'
   - name: 'Arrows of Magicka.*\.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/9799' ]
     msg:
@@ -4464,10 +4205,6 @@ plugins:
         crc: 0x0803FA31
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 1
-    clean:
-      # v1.0b - after QAC
-      - crc: 0x02ADEEB2
-        util: 'TES5Edit v4.0.2j'
   - name: 'AvengersBosses.esp'
     msg:
       - <<: *corrupt
@@ -4530,10 +4267,6 @@ plugins:
         crc: 0x93F7FE15
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 75
-    clean:
-      # v1.41 - after QAC
-      - crc: 0x3D85BFF0
-        util: 'TES5Edit v4.0.2j'
   - name: 'Back off, [Subject Name Here]!.esp'
     inc:
       - 'Back off, Barbas!.esp'
@@ -4562,10 +4295,6 @@ plugins:
         crc: 0x38F04200
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 6
-    clean:
-      # 2Point0h - after QAC
-      - crc: 0x86511E90
-        util: 'TES5Edit v4.0.2j'
   - name: 'BecomeAVampire.esp'
     req:
       - *SKSE
@@ -4601,10 +4330,6 @@ plugins:
         crc: 0x3E08AD8B
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 3
-    clean:
-      # v1.8 - after QAC
-      - crc: 0x87C34448
-        util: 'TES5Edit v4.0.2j'
   - name: 'BetterFurnitureClutter_CratesVanillaLoot.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/19545' ]
     dirty:
@@ -4613,10 +4338,6 @@ plugins:
         crc: 0x099C1A15
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 3
-    clean:
-      # v1.8 - after QAC
-      - crc: 0x2D0D04B6
-        util: 'TES5Edit v4.0.2j'
   - name: 'bbLager.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/11329' ]
     tag:
@@ -4642,10 +4363,6 @@ plugins:
         crc: 0x7AEA5A0A
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 3
-    clean:
-      # v1.1.1 - after QAC
-      - crc: 0xEAB8FD16
-        util: 'TES5Edit v4.0.2j'
   - name: 'BellyachesNewDragonSpecies_FactionlessDragons.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/20889' ]
     dirty:
@@ -4655,10 +4372,6 @@ plugins:
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 120
         udr: 3
-    clean:
-      # v1.5 - after QAC
-      - crc: 0xF7F080E8
-        util: 'TES5Edit v4.0.2j'
   - name: 'BellyachesNewDragonSpecies.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/20889' ]
     dirty:
@@ -4668,10 +4381,6 @@ plugins:
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 120
         udr: 3
-    clean:
-      # v1.5 - after QAC
-      - crc: 0x17A028B7
-        util: 'TES5Edit v4.0.2j'
   - name: 'Birds.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/11555' ]
     inc:
@@ -4683,10 +4392,6 @@ plugins:
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 423
         udr: 2
-    clean:
-      # v2.4 - after QAC
-      - crc: 0x2667DB4C
-        util: 'TES5Edit v4.0.2j'
   - name: 'Birdsclean.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/11555' ]
     inc:
@@ -4697,10 +4402,6 @@ plugins:
         crc: 0xDCF07465
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 47
-    clean:
-      # after QAC
-      - crc: 0x4DFD4015
-        util: 'TES5Edit v4.0.2j'
   - name: 'BirdsHF.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/11555' ]
     inc:
@@ -4713,10 +4414,6 @@ plugins:
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 417
         udr: 2
-    clean:
-      # v1.0 - after QAC
-      - crc: 0x96D1D815
-        util: 'TES5Edit v4.0.2j'
   - name: 'BirdsHFclean.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/11555' ]
     inc:
@@ -4726,10 +4423,6 @@ plugins:
         crc: 0xB5314156
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 50
-    clean:
-      # after QAC
-      - crc: 0xBD947B8D
-        util: 'TES5Edit v4.0.2j'
   - name: 'Birdsofskyrim.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/17723' ]
     dirty:
@@ -4738,10 +4431,6 @@ plugins:
         crc: 0xCF25ED24
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 32
-    clean:
-      # v0.6.5 - after QAC
-      - crc: 0xA5A9D2CE
-        util: 'TES5Edit v4.0.2j'
   - name: 'bladesfactionfix.esp'
     dirty:
       - crc: 0xb487451d
@@ -4776,12 +4465,6 @@ plugins:
     clean:
       # v0.10b
       - crc: 0x75D6B87E
-        util: 'TES5Edit v4.0.2j'
-      # v0.11BETA - after QAC
-      - crc: 0xCE29177A
-        util: 'TES5Edit v4.0.2j'
-      # v0.11BETA - No Dawnguard - after QAC
-      - crc: 0x4FB6BB16
         util: 'TES5Edit v4.0.2j'
   - name: 'Bob The Merchant.esp'
     dirty:
@@ -4849,10 +4532,6 @@ plugins:
         crc: 0x8A3C392A
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 1
-    clean:
-      # v1.7 - after QAC
-      - crc: 0xCBC4C456
-        util: 'TES5Edit v4.0.2j'
   - name: 'Carriage1.esp'
     dirty:
       - crc: 0xdd48cc7
@@ -4886,16 +4565,6 @@ plugins:
         crc: 0x3DE83B91
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 10
-    clean:
-      # 14379 - v1.31 - after QAC
-      - crc: 0x48EE7E23
-        util: 'TES5Edit v4.0.2j'
-      # 17424 - v0.3.1 - Main - after QAC
-      - crc: 0x8C0D1AE2
-        util: 'TES5Edit v4.0.2j'
-      # 17424 - v0.3.1 - Essential animals - after QAC
-      - crc: 0xBF38444F
-        util: 'TES5Edit v4.0.2j'
   - name: 'Dogsofskyrim.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/17424' ]
     dirty:
@@ -4911,13 +4580,6 @@ plugins:
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 4
         udr: 2
-    clean:
-      # v0.3.1 - Main - after QAC
-      - crc: 0x438CDA45
-        util: 'TES5Edit v4.0.2j'
-      # v0.3.1 - Essential animals - after QAC
-      - crc: 0x4973E083
-        util: 'TES5Edit v4.0.2j'
   - name: 'Char Your Own Skeevers.esp'
     req: [ *SKSE ]
   - name: 'Chesko_WearableLantern.esp'
@@ -4950,10 +4612,6 @@ plugins:
         crc: 0xDF949B70
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 11
-    clean:
-      # v2.5 - after QAC
-      - crc: 0x4EC2BC6F
-        util: 'TES5Edit v4.0.2j'
   - name: 'CopyArmor.esp'
     req:
       - *SKSE
@@ -4967,10 +4625,6 @@ plugins:
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 2
         udr: 1
-    clean:
-      # v1.3a - after QAC
-      - crc: 0xD8E11D05
-        util: 'TES5Edit v4.0.2j'
   - name: 'CRAFT - Salvage Material.esp'
     msg:
       - *alreadyInCraftTemperSmelt
@@ -5010,10 +4664,6 @@ plugins:
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 95
         udr: 2479
-    clean:
-      # v1.0 - after QAC
-      - crc: 0xC8277359
-        util: 'TES5Edit v4.0.2j'
   - name: 'CrossbowsRevamped.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/21666' ]
     tag:
@@ -5025,10 +4675,6 @@ plugins:
         crc: 0xFB9BC01A
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 2
-    clean:
-      # v2.1 - after QAC
-      - crc: 0x1594C16D
-        util: 'TES5Edit v4.0.2j'
   - name: 'CrossbowsRevamped70pctnospawn.esp'
     tag:
       - Delev
@@ -5072,10 +4718,6 @@ plugins:
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 9
         udr: 3
-    clean:
-      # v1.1 - after QAC
-      - crc: 0x6B0402E4
-        util: 'TES5Edit v4.0.2j'
   - name: 'DeadThrall.esp'
     msg: [ *obsolete ]
   - name: 'Decorator Assistant.+\.esp'
@@ -5121,10 +4763,6 @@ plugins:
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 38
         udr: 92
-    clean:
-      # Final - after QAC
-      - crc: 0xA03527F0
-        util: 'TES5Edit v4.0.2j'
   - name: 'DIM-playeridlingmod.esp'
     req: [ *SKSE ]
   - name: 'DineWithFollowers.esp'
@@ -5144,10 +4782,6 @@ plugins:
         crc: 0x6DB847E0
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 2
-    clean:
-      # v1.1.5 - after QAC
-      - crc: 0xF646494B
-        util: 'TES5Edit v4.0.2j'
   - name: 'Dragonlings 1.0 - A dragon sub-species.esp'
     tag: [ Delev ]
   - name: 'dragonmanstandalone.esp'
@@ -5202,10 +4836,6 @@ plugins:
         crc: 0xC4A5BE33
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 7
-    clean:
-      # v1.2 - after QAC
-      - crc: 0xCCB92B34
-        util: 'TES5Edit v4.0.2j'
   - name: 'Enchanters Merchant.esp'
     msg: [ *obsolete ]
   - name: 'EQUIPMENT - Unarmed Spiked Gauntlets.esp'
@@ -5227,10 +4857,6 @@ plugins:
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 21
         udr: 1
-    clean:
-      # 0.5 - after QAC
-      - crc: 0xD5151454
-        util: 'TES5Edit v4.0.2j'
   - name: 'Expensive Transports 5x.esp'
     inc:
       - 'Expensive Transports 10x.esp'
@@ -5297,10 +4923,6 @@ plugins:
         crc: 0x597DC92B
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 4
-    clean:
-      # v1.0 - after QAC
-      - crc: 0xF4C5DD03
-        util: 'TES5Edit v4.0.2j'
   - name: 'FollowerHuntingBow(_20|_40|_60|_80|_100)?\.esp'
     msg:
       - <<: *useOnlyOneX
@@ -5315,10 +4937,6 @@ plugins:
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 10
         udr: 70
-    clean:
-      # v1.0 - after QAC
-      - crc: 0x510DDB28
-        util: 'TES5Edit v4.0.2j'
   - name: 'Four New Dragons.esp'
     dirty:
       - crc: 0x7673f01d
@@ -5343,13 +4961,6 @@ plugins:
         crc: 0xE02CC68B
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 25
-    clean:
-      # v2.1 - after QAC
-      - crc: 0x4D1B5AFD
-        util: 'TES5Edit v4.0.2j'
-      # v2.1a - after QAC
-      - crc: 0xC6C04DDB
-        util: 'TES5Edit v4.0.2j'
   - name: 'GenebrisTreasureChests.esp'
     tag:
       - Delev
@@ -5370,10 +4981,6 @@ plugins:
         crc: 0x7DFCB25D
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 3
-    clean:
-      # v1.0 - after QAC
-      - crc: 0x3AA6A412
-        util: 'TES5Edit v4.0.2j'
   - name: 'GeneralStoresVlindrelHall.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/25316' ]
     dirty:
@@ -5382,10 +4989,6 @@ plugins:
         crc: 0xC3C58F71
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 1
-    clean:
-      # v1.1 - after QAC
-      - crc: 0x25139EDF
-        util: 'TES5Edit v4.0.2j'
   - name: 'Get More Ingots 3 ingots.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/4578' ]
     dirty:
@@ -5394,10 +4997,6 @@ plugins:
         crc: 0xCB4C5908
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 4
-    clean:
-      # v1.00 - after QAC
-      - crc: 0xBCF6A9DA
-        util: 'TES5Edit v4.0.2j'
   - name: 'GlaiceLootMod.esp'
     tag:
       - Delev
@@ -5433,10 +5032,6 @@ plugins:
         crc: 0x374C0A09
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 13
-    clean:
-      # v1.5 - after QAC
-      - crc: 0x47820E24
-        util: 'TES5Edit v4.0.2j'
   - name: 'GuardedBorders.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/18106' ]
     dirty:
@@ -5467,10 +5062,6 @@ plugins:
         crc: 0xCC07C650
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 2
-    clean:
-      # v1.0 - after QAC
-      - crc: 0x0A14C68F
-        util: 'TES5Edit v4.0.2j'
   - name: 'AMatterOfTime.esp'
     after:
       - name: 'FISS.esp'
@@ -5489,10 +5080,6 @@ plugins:
         crc: 0xBC1E72EF
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 2
-    clean:
-      # v1.0 - after QAC
-      - crc: 0xCBE518A1
-        util: 'TES5Edit v4.0.2j'
   - name: 'High Level Enemies.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/27866' ]
     tag: [ Relev ]
@@ -5534,13 +5121,6 @@ plugins:
         crc: 0xD656F01A
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 1
-    clean:
-      # DG
-      - crc: 0xF1C7394D
-        util: 'TES5Edit v4.0.2f'
-      # DG Scaled
-      - crc: 0x8367D5DD
-        util: 'TES5Edit v4.0.2f'
   - name: 'High Level Enemies - Dragonborn.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/27866' ]
     tag: [ Relev ]
@@ -5563,10 +5143,6 @@ plugins:
         crc: 0x88158E41
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 25
-    clean:
-      # v1.9 - after QAC
-      - crc: 0x55AC8A3A
-        util: 'TES5Edit v4.0.2j'
   - name: 'HM Marry All.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/8779' ]
     dirty:
@@ -5599,13 +5175,6 @@ plugins:
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 1
         udr: 243
-    clean:
-      # v1.0 - after QAC
-      - crc: 0x20DF2008
-        util: 'TES5Edit v4.0.2j'
-      # v1.1 - after QAC
-      - crc: 0xE50A86A2
-        util: 'TES5Edit v4.0.2j'
   - name: 'HoodlessArchmageWithFixedStats.esp'
     msg:
       - <<: *corrupt
@@ -5636,10 +5205,6 @@ plugins:
         crc: 0x8BC60484
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 8
-    clean:
-      # v1.6 - after QAC
-      - crc: 0x1409598E
-        util: 'TES5Edit v4.0.2j'
   - name: 'Immersive Battles.esp'
     dirty:
       - crc: 0x6cecb1b1
@@ -5660,10 +5225,6 @@ plugins:
         crc: 0xFB7A1973
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 4
-    clean:
-      # v1.7.7.1 - after QAC
-      - crc: 0x7B2D10B8
-        util: 'TES5Edit v4.0.2j'
   - name: 'Immersive Factions.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/50389' ]
     clean:
@@ -5678,10 +5239,6 @@ plugins:
         crc: 0x336739C0
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 1
-    clean:
-      # v1.7.7.1 - after QAC
-      - crc: 0x1BE4F987
-        util: 'TES5Edit v4.0.2j'
   - name: 'Immersive Travelers.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/50389' ]
     clean:
@@ -5703,10 +5260,6 @@ plugins:
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 17
         udr: 1
-    clean:
-      # v1.6Beta - after QAC
-      - crc: 0xFF32F68F
-        util: 'TES5Edit v4.0.2j'
   - name: 'ImmersiveBountyHunting.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/29448' ]
     dirty:
@@ -5855,10 +5408,6 @@ plugins:
         crc: 0xB48249E6
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 7
-    clean:
-      # v0.03 - after QAC
-      - crc: 0xB5E525BA
-        util: 'TES5Edit v4.0.2j'
   - name: 'Lady Body.esp'
     msg:
       - type: warn
@@ -5940,10 +5489,6 @@ plugins:
         crc: 0xA5296315
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 12
-    clean:
-      # v1.9 - after QAC
-      - crc: 0xC6D76F4A
-        util: 'TES5Edit v4.0.2j'
   - name: 'Loot_Overhaul_Rebalanced_v.04.esp'
     tag:
       - Delev
@@ -6011,9 +5556,6 @@ plugins:
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 11
     clean:
-      # v1.6 - after QAC
-      - crc: 0x7E92D357
-        util: 'TES5Edit v4.0.2j'
       # v1.7
       - crc: 0x46396C20
         util: 'TES5Edit v4.0.2j'
@@ -6045,10 +5587,6 @@ plugins:
         crc: 0x8A2881F2
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 8
-    clean:
-      # v1.04 - after QAC
-      - crc: 0x1EA4711F
-        util: 'TES5Edit v4.0.2j'
   - name: 'Modern Day Calendar Names_Learn Names.esp'
     inc:
       - 'ModernDayCalendarNames.esp'
@@ -6079,13 +5617,6 @@ plugins:
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 2
         udr: 1
-    clean:
-      # v1.4.1 - after QAC
-      - crc: 0xA2A1BA52
-        util: 'TES5Edit v4.0.2j'
-      # v1.5.1 - after QAC
-      - crc: 0xAB602ECE
-        util: 'TES5Edit v4.0.2j'
   - name: 'More Craftables.esp'
     tag: [ Relev ]
   - name: 'More Craftables - Crafting 300 compatibility.esp'
@@ -6114,10 +5645,6 @@ plugins:
         crc: 0xD0B6794D
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 5
-    clean:
-      # v1.1 - after QAC
-      - crc: 0x06140626
-        util: 'TES5Edit v4.0.2j'
   - name: 'MoreVillageAnimals.esp'
     msg: [ *obsolete ]
   - name: 'Moss Rocks_DB.esp'
@@ -6145,10 +5672,6 @@ plugins:
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 70
         udr: 1
-    clean:
-      # v3.0 - after QAC
-      - crc: 0xEFC24D9D
-        util: 'TES5Edit v4.0.2j'
   - name: 'NewBeveragesAndMiscItems.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/10826' ]
     dirty:
@@ -6189,10 +5712,6 @@ plugins:
         crc: 0xB79D2CCD
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 5
-    clean:
-      # v2.0 - after QAC
-      - crc: 0x6226093F
-        util: 'TES5Edit v4.0.2j'
   - name: 'Nocturnal Craftable Armors.esp'
     inc:
       - 'Vampirelordroyal.esp'
@@ -6320,10 +5839,6 @@ plugins:
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 8
         udr: 14
-    clean:
-      # v1.0 - after QAC
-      - crc: 0xF4EDC1A9
-        util: 'TES5Edit v4.0.2j'
   - name: 'Portable Campsite.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/9935' ]
     dirty:
@@ -6332,10 +5847,6 @@ plugins:
         crc: 0xC70BE4C6
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 26
-    clean:
-      # v3.0 - after QAC
-      - crc: 0x63D180F9
-        util: 'TES5Edit v4.0.2j'
   - name: 'poshmudcrabs.esp'
     dirty:
       - crc: 0x7b384084
@@ -6350,10 +5861,6 @@ plugins:
         crc: 0x7F5EA37E
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 26
-    clean:
-      # v1.2 - after QAC
-      - crc: 0x5A591FD6
-        util: 'TES5Edit v4.0.2j'
   - name: 'Project-Legacy.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/12968' ]
     dirty:
@@ -6433,10 +5940,6 @@ plugins:
         crc: 0x8E25C2AD
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 2
-    clean:
-      # v2.0 - after QAC
-      - crc: 0xFB123018
-        util: 'TES5Edit v4.0.2j'
   - name: 'real glaciers.esp'
     msg: [ *obsolete ]
   - name: 'realistic dragons.esp'
@@ -6485,10 +5988,6 @@ plugins:
         crc: 0xBFFF72CE
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 11
-    clean:
-      # v1.343 - after QAC
-      - crc: 0x26001CC2
-        util: 'TES5Edit v4.0.2j'
   - name: 'Real Wildlife Skyrim 0.1 No Food.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/9778' ]
     inc:
@@ -6500,10 +5999,6 @@ plugins:
         crc: 0x52DD73E8
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 383
-    clean:
-      # v1.341 - after QAC
-      - crc: 0x89C88E08
-        util: 'TES5Edit v4.0.2j'
   - name: 'Real Wildlife.esp'
     tag: [ Relev ]
   - name: 'wildlife_overhaul.esp'
@@ -6515,10 +6010,6 @@ plugins:
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 19
         udr: 16
-    clean:
-      # v1.3 - after QAC
-      - crc: 0x6971B05A
-        util: 'TES5Edit v4.0.2j'
   - name: 'SIRWPat?ch\.esp'
     tag:
       - Delev
@@ -6534,10 +6025,6 @@ plugins:
         crc: 0x629B83B6
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 6
-    clean:
-      # v7 - after QAC
-      - crc: 0x2EB4DE21
-        util: 'TES5Edit v4.0.2j'
   - name: 'RecyclingMod.esp'
     msg:
       - type: say
@@ -6594,10 +6081,6 @@ plugins:
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 242
         udr: 34
-    clean:
-      # Final - after QAC
-      - crc: 0xA1D31C1A
-        util: 'TES5Edit v4.0.2j'
   - name: 'Roasted Meat - RWL + RND.esp'
     msg:
       - type: say
@@ -6619,10 +6102,6 @@ plugins:
         crc: 0xFD51136D
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 1
-    clean:
-      # v1.1 - after QAC
-      - crc: 0x6CD18D5B
-        util: 'TES5Edit v4.0.2j'
   - name: 'rt_Animal - Processing.esp'
     inc:
       - 'rt_AutoHarvest.esp'
@@ -6639,10 +6118,6 @@ plugins:
         crc: 0x652FD3F8
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 6
-    clean:
-      # v1.1 - after QAC
-      - crc: 0xDAF5D363
-        util: 'TES5Edit v4.0.2j'
   - name: 'SaltSacks.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/23948' ]
     clean:
@@ -6663,10 +6138,6 @@ plugins:
         crc: 0x4CB0A7CC
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 12
-    clean:
-      # v1.0 - after QAC
-      - crc: 0xB1BD0CA6
-        util: 'TES5Edit v4.0.2j'
   - name: 'SDO Full-LOD - The Morthal Swamp Complete.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/19446' ]
     dirty:
@@ -6675,10 +6146,6 @@ plugins:
         crc: 0x43A4FD69
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 129
-    clean:
-      # v1.0 - after QAC
-      - crc: 0x54600053
-        util: 'TES5Edit v4.0.2j'
   - name: 'SDO Full-LOD - The Morthal Swamp Light.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/19446' ]
     dirty:
@@ -6687,10 +6154,6 @@ plugins:
         crc: 0xF7F16C14
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 117
-    clean:
-      # v1.0 - after QAC
-      - crc: 0x30DD813A
-        util: 'TES5Edit v4.0.2j'
   - name: 'SDO Full-LOD - Waterfall Effects.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/19446' ]
     dirty:
@@ -6699,10 +6162,6 @@ plugins:
         crc: 0x03DE3F58
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 36
-    clean:
-      # v1.0 - after QAC
-      - crc: 0xB1293726
-        util: 'TES5Edit v4.0.2j'
   - name: 'SDO Full-LOD - Whiterun Trundra Creeks.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/19446' ]
     dirty:
@@ -6711,10 +6170,6 @@ plugins:
         crc: 0xBF8F3890
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 39
-    clean:
-      # v1.0 - after QAC
-      - crc: 0xAACFD505
-        util: 'TES5Edit v4.0.2j'
   - name: 'See Your Neighbor.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/24513' ]
     dirty:
@@ -6724,10 +6179,6 @@ plugins:
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 18
         udr: 5
-    clean:
-      # v4.0 - after QAC
-      - crc: 0x4DF9126C
-        util: 'TES5Edit v4.0.2j'
   - name: 'SexiSWorkingGirl.esp'
     req:
       - *SKSE
@@ -6800,15 +6251,6 @@ plugins:
       # USLEEP
       - crc: 0xF3206010
         util: 'TES5Edit v4.0.1'
-      # USLEEP - No Barrels
-      - crc: 0xA3A1CA0A
-        util: 'TES5Edit v4.0.1'
-      # USLEEP - No Bugs101
-      - crc: 0x8B8241B5
-        util: 'TES5Edit v4.0.1'
-      # USLEEP - No Bugs101 - No Barrels
-      - crc: 0x3D231807
-        util: 'TES5Edit v4.0.1'
   - name: 'SkyEx.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/37554' ]
     dirty:
@@ -6824,13 +6266,6 @@ plugins:
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 31
         udr: 31
-    clean:
-      # v1.0Hearth - after QAC
-      - crc: 0x9AAECEC3
-        util: 'TES5Edit v4.0.2j'
-      # v1.0 - after QAC
-      - crc: 0x4ED251FF
-        util: 'TES5Edit v4.0.2j'
   - name: 'Skyforge Smelter.esp'
     dirty:
       - crc: 0x86b4d1d2
@@ -6849,10 +6284,6 @@ plugins:
         crc: 0x96CC9821
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 17
-    clean:
-      # v2.5 - after QAC
-      - crc: 0x0391624C
-        util: 'TES5Edit v4.0.2j'
   - name: 'SkyMoMod.esp'
     msg: [ *obsolete ]
     tag:
@@ -7058,9 +6489,6 @@ plugins:
         crc: 0x067CB652
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 3
-    clean:
-      - crc: 0xCA006C17
-        util: 'TES5Edit v4.0.2f'
   - name: 'StormcloakArmorVariety(OPTION\d)?\.esp'
     msg:
       - <<: *useOnlyOneX
@@ -7090,10 +6518,6 @@ plugins:
         crc: 0x58433592
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 1
-    clean:
-      # v1 - Main - after QAC
-      - crc: 0x3C7C8C39
-        util: 'TES5Edit v4.0.2j'
   - name: 'Tailoring.esp'
     dirty:
       - crc: 0x9fabd6ad
@@ -7131,10 +6555,6 @@ plugins:
         crc: 0x2DED0382
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 5
-    clean:
-      # v1.2 - after QAC
-      - crc: 0x457015C5
-        util: 'TES5Edit v4.0.2j'
   - name: 'Training Dummies XP.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/26491' ]
     dirty:
@@ -7142,9 +6562,6 @@ plugins:
         crc: 0x03DA8870
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 16
-    clean:
-      - crc: 0xE737AD8F
-        util: 'TES5Edit v4.0.2f'
   - name: 'Training Dummies XP Dawnguard.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/26491' ]
     dirty:
@@ -7152,9 +6569,6 @@ plugins:
         crc: 0xE82810D0
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 5
-    clean:
-      - crc: 0xB57DC136
-        util: 'TES5Edit v4.0.2f'
   - name: 'TravellersOfSkyrim.esp'
     msg: [ *obsolete ]
   - name: 'TravellersOfSkyrim - Light.esp'
@@ -7184,10 +6598,6 @@ plugins:
         crc: 0x5871D2FC
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 5
-    clean:
-      # Main - after QAC
-      - crc: 0x7CD582E4
-        util: 'TES5Edit v4.0.2j'
   - name: 'Tytanis_v052_SPANISH.esp'
     msg: [ *obsolete ]
   - name: 'Tytanis\w{0,2}(GER)?\.esp'
@@ -7213,10 +6623,6 @@ plugins:
         crc: 0x69A349B1
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 6
-    clean:
-      # v2.2 - after QAC
-      - crc: 0x2804BA2F
-        util: 'TES5Edit v4.0.2j'
   - name: 'UniqueGear.esp'
     dirty:
       - crc: 0xf1dac5d6
@@ -7230,10 +6636,6 @@ plugins:
         crc: 0x9AB1ACCF
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 8
-    clean:
-      # v2.0 - after QAC
-      - crc: 0x1DA3FD5F
-        util: 'TES5Edit v4.0.2j'
   - name: 'Unleveled_Skyrim_Items.esp'
     tag:
       - Delev
@@ -7292,10 +6694,6 @@ plugins:
         crc: 0xD23B4D2A
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 11
-    clean:
-      # v1.3 - after QAC
-      - crc: 0xEB980F36
-        util: 'TES5Edit v4.0.2j'
   - name: 'WiS IV - Heroes & Villains( insane| Easy| Hard)?\.esp'
     msg:
       - <<: *useOnlyOneX
@@ -7352,9 +6750,6 @@ plugins:
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 64
         udr: 47
-    clean:
-      - crc: 0xA648C624
-        util: 'TES5Edit v4.0.2f'
   - name: 'Zira''s Skyrim Horse Base( - (Armored|Bareback Riding|No Tack))?\.esp'
     msg:
       - <<: *useOnlyOneX
@@ -7368,9 +6763,6 @@ plugins:
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 64
         udr: 47
-    clean:
-      - crc: 0x6058CC23
-        util: 'TES5Edit v4.0.2f'
   - name: 'Zira''s Skyrim Horse Base - Bareback Riding.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/19710' ]
     dirty:
@@ -7379,9 +6771,6 @@ plugins:
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 64
         udr: 47
-    clean:
-      - crc: 0x2DC2E37C
-        util: 'TES5Edit v4.0.2f'
   - name: 'Zira''s Skyrim Horse Base - No Tack.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/19710' ]
     dirty:
@@ -7390,9 +6779,6 @@ plugins:
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 64
         udr: 47
-    clean:
-      - crc: 0x769F83D2
-        util: 'TES5Edit v4.0.2f'
   - name: 'KoS_Outcast(_Lite)?\.esp'
     msg:
       - <<: *useOnlyOneX
@@ -7463,9 +6849,6 @@ plugins:
         crc: 0x658A6A4E
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 5
-    clean:
-      - crc: 0xA4DEC088
-        util: 'TES5Edit v4.0.2f'
   - name: 'Item Sorting DG by Saige.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/87514' ]
     dirty:
@@ -7473,9 +6856,6 @@ plugins:
         crc: 0x03E12EE2
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 3
-    clean:
-      - crc: 0x86811CFD
-        util: 'TES5Edit v4.0.2f'
   - name: 'more_Travelers.esm'
     url: [ 'https://www.nexusmods.com/skyrim/mods/9759' ]
     dirty:
@@ -7483,9 +6863,6 @@ plugins:
         crc: 0x7E530819
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 87
-    clean:
-      - crc: 0xC5EEBF2D
-        util: 'TES5Edit v4.0.2f'
   - name: 'more_Travelers(_light)?\.esp'
     msg:
       - <<: *useOnlyOneX
@@ -7512,9 +6889,6 @@ plugins:
         crc: 0x28CCA4F1
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 51
-    clean:
-      - crc: 0xFB58D762
-        util: 'TES5Edit v4.0.2f'
   - name: 'CAS.esp'
     msg:
       - type: warn
@@ -7538,9 +6912,6 @@ plugins:
         crc: 0xCBF09128
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 3
-    clean:
-      - crc: 0x86C86AB2
-        util: 'TES5Edit v4.0.2f'
   - name: 'DEAsprint&jump.esp'
     req:
       - *SKSE
@@ -7564,9 +6935,6 @@ plugins:
         crc: 0xE270AD1E
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 1
-    clean:
-      - crc: 0x0861BEA2
-        util: 'TES5Edit v4.0.2f'
   - name: 'Duke Patricks - Savvy Save .esp'
     # the empty space before the .esp is intended
     url: [ 'https://www.nexusmods.com/skyrim/mods/35429' ]
@@ -7618,10 +6986,6 @@ plugins:
         crc: 0xFB3A2B27
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 5
-    clean:
-      # v2 - after QAC
-      - crc: 0xABE7186E
-        util: 'TES5Edit v4.0.2j'
   - name: 'kuerteeActorDetails.esp'
     req: [ *SKSE ]
   - name: 'kuerteeAutoFirstThirdPersonView.esp'
@@ -7833,10 +7197,6 @@ plugins:
         crc: 0x86BEC75A
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 9
-    clean:
-      # v1.01 - after QAC
-      - crc: 0x08703862
-        util: 'TES5Edit v4.0.2j'
   - name: 'ACB Harley.esp'
     dirty:
       - crc: 0x1fd524b8
@@ -7871,13 +7231,6 @@ plugins:
         crc: 0x35A0984B
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 7
-    clean:
-      # v2.40 - Main - after QAC
-      - crc: 0xA2DC5E2D
-        util: 'TES5Edit v4.0.2j'
-      # v2.40 - Tonw Down - after QAC
-      - crc: 0x935E25F4
-        util: 'TES5Edit v4.0.2j'
   - name: 'AgedRoundShield.esp'
     tag: [ Relev ]
   - name: 'akavirisharpkatana.esp'
@@ -7914,13 +7267,6 @@ plugins:
         crc: 0x1A0A3341
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 6
-    clean:
-      # v1.1 - after QAC
-      - crc: 0x00829DD8
-        util: 'TES5Edit v4.0.2j'
-      # v1.1a - after QAC
-      - crc: 0x241D6705
-        util: 'TES5Edit v4.0.2j'
   - name: 'Alchemic Tomes.esp'
     dirty:
       - crc: 0xeda60d92
@@ -7940,10 +7286,6 @@ plugins:
         crc: 0xDEC01F16
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 1
-    clean:
-      # v1.7 - after QAC
-      - crc: 0x10EB7A0F
-        util: 'TES5Edit v4.0.2j'
   - name: 'Althirs Camping Tools German.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/10824' ]
     inc:
@@ -7954,10 +7296,6 @@ plugins:
         crc: 0x87EEDB7A
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 1
-    clean:
-      # v1.7 - after QAC
-      - crc: 0xCABC5DE1
-        util: 'TES5Edit v4.0.2j'
   - name: 'AMB Glass Variants Lore.esp'
     msg:
       - <<: *alreadyInAmidianBornContentAddon
@@ -7989,10 +7327,6 @@ plugins:
         crc: 0x3BB808E1
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 2
-    clean:
-      # v0.05a - after QAC
-      - crc: 0x466DEFDB
-        util: 'TES5Edit v4.0.2j'
   - name: 'archdemonplushighdragon.esp'
     dirty:
       - crc: 0x84f7cb68
@@ -8019,10 +7353,6 @@ plugins:
         crc: 0x267783D2
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 14
-    clean:
-      # v1 - after QAC
-      - crc: 0xB5E73B1E
-        util: 'TES5Edit v4.0.2j'
   - name: 'AronsMechaDragons.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/24587' ]
     msg: [ *alreadyInSkyrimImmersiveCreatures ]
@@ -8032,10 +7362,6 @@ plugins:
         crc: 0x77A605C4
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 15
-    clean:
-      # v1 - after QAC
-      - crc: 0xC31DD6D6
-        util: 'TES5Edit v4.0.2j'
   - name: 'ArrowsOfMight1.1.esp'
     msg: [ *obsolete ]
   - name: 'Avatar of Baltazar.esp'
@@ -8049,10 +7375,6 @@ plugins:
         crc: 0x1233BBAF
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 6
-    clean:
-      # v1.1 - after QAC
-      - crc: 0xC50F293F
-        util: 'TES5Edit v4.0.2j'
   - name: 'Backpack OE.esp'
     msg: [ *requiresUNP ]
   - name: 'BadGremlinsJarHunt.esp'
@@ -8073,10 +7395,6 @@ plugins:
         crc: 0x0012EDE5
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 4
-    clean:
-      # v4.0 - after QAC
-      - crc: 0x805120C1
-        util: 'TES5Edit v4.0.2j'
   - name: 'BaratheonArmor.esp'
     tag:
       - name: Deactivate
@@ -8142,10 +7460,6 @@ plugins:
         crc: 0xBFF2E35C
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 15
-    clean:
-      # v2.3 - after QAC
-      - crc: 0xA8CA2716
-        util: 'TES5Edit v4.0.2j'
   - name: 'Black Scaled Armor MOD.esp'
     msg:
       - <<: *obsolete
@@ -8175,10 +7489,6 @@ plugins:
         crc: 0x3E021F5D
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 7
-    clean:
-      # v1.3 - after QAC
-      - crc: 0x5DA0B0E4
-        util: 'TES5Edit v4.0.2j'
   - name: 'bouncy_bodices.*\.esp'
     msg:
       - <<: *useOnlyOneX
@@ -8226,9 +7536,6 @@ plugins:
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 1
         udr: 4
-    clean:
-      - crc: 0x2B4AE61A
-        util: 'TES5Edit v4.0.2f'
   - name: 'True Bound Armors.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/30462' ]
     msg: [ *obsolete ]
@@ -8325,10 +7632,6 @@ plugins:
         crc: 0xD8F94C02
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 2
-    clean:
-      # v1.2 - after QAC
-      - crc: 0x2D16EDED
-        util: 'TES5Edit v4.0.2j'
   - name: 'Cloaks - No Imperial.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/12092' ]
     dirty:
@@ -8337,10 +7640,6 @@ plugins:
         crc: 0x1C6298CE
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 2
-    clean:
-      # v1.2 - after QAC
-      - crc: 0x646C341F
-        util: 'TES5Edit v4.0.2j'
   - name: 'Cloaks - Player Only.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/12092' ]
     dirty:
@@ -8349,10 +7648,6 @@ plugins:
         crc: 0x2453C2E4
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 2
-    clean:
-      # v1.2 - after QAC
-      - crc: 0xA691B584
-        util: 'TES5Edit v4.0.2j'
   - name: 'Cloaks( - (No Imperial|Player Only))? - Dawnguard\.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/12092' ]
     msg:
@@ -8448,10 +7743,6 @@ plugins:
         crc: 0x187F75AB
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 2
-    clean:
-      # v1.1.2 - after QAC
-      - crc: 0x3C8AB5DB
-        util: 'TES5Edit v4.0.2j'
   - name: 'Crossbows_Basic_Collection_DE_LL.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/23876' ]
     dirty:
@@ -8461,10 +7752,6 @@ plugins:
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 2
         udr: 2
-    clean:
-      # v1.1.2 - after QAC
-      - crc: 0xAF3328CC
-        util: 'TES5Edit v4.0.2j'
   - name: 'Crossbows_Basic_Collection_EN.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/23876' ]
     inc:
@@ -8475,10 +7762,6 @@ plugins:
         crc: 0x01148789
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 2
-    clean:
-      # v1.1.2 - after QAC
-      - crc: 0x8DD86F96
-        util: 'TES5Edit v4.0.2j'
   - name: 'Crossbows_Basic_Collection_EN_LL.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/23876' ]
     dirty:
@@ -8487,10 +7770,6 @@ plugins:
         crc: 0x44ED3622
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 2
-    clean:
-      # v1.1.2 - after QAC
-      - crc: 0x60B863F2
-        util: 'TES5Edit v4.0.2j'
   - name: 'Crossbows by Scot.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/22207' ]
     dirty:
@@ -8519,10 +7798,6 @@ plugins:
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 2
         udr: 2
-    clean:
-      # v1.3 - after QAC
-      - crc: 0x837A5184
-        util: 'TES5Edit v4.0.2j'
   - name: 'DaggerCraft.esp'
     tag:
       - name: Deactivate
@@ -8553,10 +7828,6 @@ plugins:
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 3
         udr: 1
-    clean:
-      # v1.0 - after QAC
-      - crc: 0x5539763B
-        util: 'TES5Edit v4.0.2j'
   - name: 'Dawnguard Fraktionen Extended.esp'
     dirty:
       - crc: 0x9c5504fc
@@ -8575,10 +7846,6 @@ plugins:
         crc: 0xE367811F
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 3
-    clean:
-      # v1.0 - after QAC
-      - crc: 0xB38EBD6B
-        util: 'TES5Edit v4.0.2j'
   - name: 'DDD-BardsLute.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/23216' ]
     dirty:
@@ -8587,10 +7854,6 @@ plugins:
         crc: 0x583FC67E
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 4
-    clean:
-      # v1.0 - after QAC
-      - crc: 0x80579990
-        util: 'TES5Edit v4.0.2j'
   - name: 'deadly bow spell.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/25848' ]
     dirty:
@@ -8599,10 +7862,6 @@ plugins:
         crc: 0xB162020E
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 16
-    clean:
-      # v2.0 - after QAC
-      - crc: 0x3F489D37
-        util: 'TES5Edit v4.0.2j'
   - name: 'DEATH-DEALER.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/18077' ]
     dirty:
@@ -8612,10 +7871,6 @@ plugins:
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 5
         udr: 5
-    clean:
-      # v2.0 - after QAC
-      - crc: 0xC9B423BC
-        util: 'TES5Edit v4.0.2j'
   - name: 'DEATH-DEALER-PKR.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/18077' ]
     dirty:
@@ -8624,10 +7879,6 @@ plugins:
         crc: 0x13C7E048
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 4
-    clean:
-      # v1.2 - after QAC
-      - crc: 0xF5D6FF60
-        util: 'TES5Edit v4.0.2j'
   - name: 'DemonHunterArmor.esp'
     msg:
       - type: say
@@ -8692,10 +7943,6 @@ plugins:
         crc: 0x294218C5
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 1
-    clean:
-      # v1.2 - after QAC
-      - crc: 0x9235783A
-        util: 'TES5Edit v4.0.2j'
   - name: 'dragonblood mod.esp'
     dirty:
       - crc: 0x83115133
@@ -8717,10 +7964,6 @@ plugins:
         crc: 0x5596EEF2
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 16
-    clean:
-      # v1 - after QAC
-      - crc: 0x9B178DD2
-        util: 'TES5Edit v4.0.2j'
   - name: 'DragonfireCrossbow02.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/22233' ]
     dirty:
@@ -8729,10 +7972,6 @@ plugins:
         crc: 0xA8EDDE9D
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 1
-    clean:
-      # v2 - after QAC
-      - crc: 0x4F55623E
-        util: 'TES5Edit v4.0.2j'
   - name: 'DragonIron.esp'
     msg:
       - <<: *corrupt
@@ -8756,10 +7995,6 @@ plugins:
         crc: 0xE0C93BA1
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 7
-    clean:
-      # v1.1 - after QAC
-      - crc: 0xCFAB8B0B
-        util: 'TES5Edit v4.0.2j'
   - name: 'DragonsoulWeapons.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/13866' ]
     clean:
@@ -8784,10 +8019,6 @@ plugins:
         crc: 0xD792FFF8
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 4
-    clean:
-      # v1.1 - after QAC
-      - crc: 0x09D31F06
-        util: 'TES5Edit v4.0.2j'
   - name: 'Divine Aegis.esp'
     tag:
       - name: Deactivate
@@ -8800,10 +8031,6 @@ plugins:
         crc: 0x5F8B8BBC
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 7
-    clean:
-      # v3.31 - after QAC
-      - crc: 0x1119C940
-        util: 'TES5Edit v4.0.2j'
   - name: 'DwarvenArmorUpgrade.esp'
     tag: [ Relev ]
   - name: 'Dwarven War Cross Bow.esp'
@@ -8828,10 +8055,6 @@ plugins:
         crc: 0x350C9568
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 6
-    clean:
-      # v0.2.1 - after QAC
-      - crc: 0xFB5FBA24
-        util: 'TES5Edit v4.0.2j'
   - name: 'Dwemer Artificer.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/8389' ]
     dirty:
@@ -8862,10 +8085,6 @@ plugins:
         crc: 0xD7BB72C4
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 10
-    clean:
-      # Main - after QAC
-      - crc: 0xACAEA2EA
-        util: 'TES5Edit v4.0.2j'
   - name: 'DwemerBombsNoPerkTree.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/12754' ]
     inc:
@@ -8884,10 +8103,6 @@ plugins:
         crc: 0x5D8A9FDB
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 1
-    clean:
-      # v1.5 - after QAC
-      - crc: 0x60C1135E
-        util: 'TES5Edit v4.0.2j'
   - name: 'HN66s_Earrings_1.5_DV.esp'
     req:
       - 'Earrings Set1.esp'
@@ -8907,10 +8122,6 @@ plugins:
         crc: 0x653D7CB4
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         udr: 1
-    clean:
-      # v2 - after QAC
-      - crc: 0x4AE01987
-        util: 'TES5Edit v4.0.2j'
   - name: 'EK_RingLimiter.esp'
     req:
       - *SKSE
@@ -8923,10 +8134,6 @@ plugins:
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 2
         udr: 1
-    clean:
-      # v1.1 - after QAC
-      - crc: 0x3D090243
-        util: 'TES5Edit v4.0.2j'
   - name: 'Elgars Silver Emporium -Weapon Set-.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/28961' ]
     dirty:
@@ -8935,10 +8142,6 @@ plugins:
         crc: 0xD060543F
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 2
-    clean:
-      # v0.8 - after QAC
-      - crc: 0xEF528F89
-        util: 'TES5Edit v4.0.2j'
   - name: 'EliteRogueArmour.esp'
     url:
       - 'https://www.nexusmods.com/skyrim/mods/30189'
@@ -8960,16 +8163,6 @@ plugins:
         crc: 0x4358CFD8
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 1
-    clean:
-      # 30189 - v1.11 && 37111 - v1.0 & v1.1 - after QAC
-      - crc: 0xAD12AA47
-        util: 'TES5Edit v4.0.2j'
-      # 35682 - v1.2 - after QAC
-      - crc: 0xE5C27125
-        util: 'TES5Edit v4.0.2j'
-      # 35682 - v1.1 - after QAC
-      - crc: 0xF957F939
-        util: 'TES5Edit v4.0.2j'
   - name: 'Empowered Archmage Robes.esp'
     tag: [ Relev ]
   - name: 'EnchantableDPMask.esp'
@@ -8998,13 +8191,6 @@ plugins:
         crc: 0x42E067F8
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 9
-    clean:
-      # v3.13 - after QAC
-      - crc: 0x052D4BE2
-        util: 'TES5Edit v4.0.2j'
-      # 4.25 - after QAC
-      - crc: 0xDF5214F4
-        util: 'TES5Edit v4.0.2j'
   - name: 'EternalShineArmorAndWeapons.esp'
     msg:
       - <<: *fixedPluginOutSub
@@ -9044,10 +8230,6 @@ plugins:
         crc: 0xCF7AD7C4
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 14
-    clean:
-      # v1.01 - after QAC
-      - crc: 0x35124F02
-        util: 'TES5Edit v4.0.2j'
   - name: 'Faleria.esp'
     dirty:
       - crc: 0xd624babc
@@ -9062,10 +8244,6 @@ plugins:
         crc: 0x109F7C23
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 2
-    clean:
-      # v2.3 - after QAC
-      - crc: 0x836BC1D8
-        util: 'TES5Edit v4.0.2j'
   - name: 'FlameAtronachArmor.esp'
     msg:
       - *requiresCBBE
@@ -9084,10 +8262,6 @@ plugins:
         crc: 0xB2669E47
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 1
-    clean:
-      # v1.0 - after QAC
-      - crc: 0x04F499E2
-        util: 'TES5Edit v4.0.2j'
   - name: 'Footwear OE.esp'
     msg: [ *requiresUNP ]
   - name: 'fox(\d\d?)[^51-56] Armor\.esp' #up to fox50 for FoxMergedv2.6(checksumofesp,2E996104)
@@ -9126,13 +8300,6 @@ plugins:
         crc: 0x3D18C33F
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 16
-    clean:
-      # v1.3 - Main - after QAC
-      - crc: 0x1435A0C0
-        util: 'TES5Edit v4.0.2j'
-      # v1.3 Cleaned
-      - crc: 0x2A1483ED
-        util: 'TES5Edit v4.0.2j'
   - name: 'Glass Variants.esp'
     msg:
       - <<: *alreadyInAmidianBornContentAddon
@@ -9164,10 +8331,6 @@ plugins:
         crc: 0x0E05797B
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 9
-    clean:
-      # v1 - after QAC
-      - crc: 0xE2FA24ED
-        util: 'TES5Edit v4.0.2j'
   - name: 'Hana.esp'
     msg:
       - <<: *fixedPluginPreCKSharlikran
@@ -9185,10 +8348,6 @@ plugins:
         crc: 0xD1207154
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 1
-    clean:
-      # v1.3 - after QAC
-      - crc: 0xB654AF0E
-        util: 'TES5Edit v4.0.2j'
   - name: 'HBetterBows.esp'
     tag:
       - name: Deactivate
@@ -9201,10 +8360,6 @@ plugins:
         crc: 0x31A503EB
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 9
-    clean:
-      # v12 - after QAC
-      - crc: 0xDD222A32
-        util: 'TES5Edit v4.0.2j'
   - name: 'HeavyBows.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/19396' ]
     dirty:
@@ -9213,10 +8368,6 @@ plugins:
         crc: 0x03D45749
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 1
-    clean:
-      # v1.1 - after QAC
-      - crc: 0x1403C50E
-        util: 'TES5Edit v4.0.2j'
   - name: 'HedgeKnight.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/13961' ]
     tag:
@@ -9228,10 +8379,6 @@ plugins:
         crc: 0xA7A55AB3
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 2
-    clean:
-      # v4 - after QAC
-      - crc: 0x7603E511
-        util: 'TES5Edit v4.0.2j'
   - name: 'HellionArrows_v1.2.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/12293' ]
     dirty:
@@ -9241,10 +8388,6 @@ plugins:
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 5
         udr: 7
-    clean:
-      # v1.2 - after QAC
-      - crc: 0x2C3E218F
-        util: 'TES5Edit v4.0.2j'
   - name: 'Henrys Ring of Light v1-0.esp'
     msg: [ *obsolete ]
   - name: 'HeroicDwarven.esp'
@@ -9263,13 +8406,6 @@ plugins:
         crc: 0xBCC4742A
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 1
-    clean:
-      # v1.0 - after QAC
-      - crc: 0x034B8534
-        util: 'TES5Edit v4.0.2j'
-      # v1.1 - after QAC
-      - crc: 0xBBED6E01
-        util: 'TES5Edit v4.0.2j'
   - name: 'HmmWhatToWear.esp'
     msg: [ *requiresUNP ]
   - name: 'HmmWhatToWearMerged.esp'
@@ -9284,10 +8420,6 @@ plugins:
         crc: 0xD5E4880B
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         udr: 1
-    clean:
-      # v2.0 - after QAC
-      - crc: 0x4C069A1E
-        util: 'TES5Edit v4.0.2j'
   - name: 'Hothtrooper44_Armor_Ecksstra.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/19733' ]
     clean:
@@ -9338,9 +8470,6 @@ plugins:
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 1
     clean:
-      # v1.0 - after QAC
-      - crc: 0x863459C4
-        util: 'TES5Edit v4.0.2j'
       # v1.6
       - crc: 0xEB5A871E
         util: 'TES5Edit v4.0.2j'
@@ -9354,16 +8483,6 @@ plugins:
       # v1.58
       - <<: *corrupt
         condition: 'checksum("HunEbonyWeaponsStandalone.esp",F7132DAC)'
-    dirty:
-      # v1.3
-      - <<: *quickClean
-        crc: 0x49FA902D
-        util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
-        itm: 11
-    clean:
-      # v1.3 - after QAC
-      - crc: 0x0972EEC6
-        util: 'TES5Edit v4.0.2j'
   - name: 'hunnicarmors.esp'
     msg:
       - <<: *corrupt
@@ -9420,9 +8539,6 @@ plugins:
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 22
         udr: 14
-    clean:
-      - crc: 0xCCC93DD2
-        util: 'TES5Edit v4.0.2f'
   - name: 'Immersive Weapons.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/27644' ]
     after:
@@ -9455,10 +8571,6 @@ plugins:
         crc: 0x19E2D968
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 5
-    clean:
-      # v1.5 - after QAC
-      - crc: 0xCE4D9445
-        util: 'TES5Edit v4.0.2f'
   - name: 'WeaponsArmorFixes_ClosefacedHelmets_Patch.esp'
     req:
       - name: 'Weapons & Armor Fixes_Remade.esp'
@@ -9474,9 +8586,6 @@ plugins:
         crc: 0x519A4055
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 2
-    clean:
-      - crc: 0x630327E7
-        util: 'TES5Edit v4.0.2f'
   - name: 'InigoPerkPointGiver.esp'
     req: [ *SKSE ]
   - name: 'InsanitysCelticKatana.esp'
@@ -9513,9 +8622,6 @@ plugins:
         crc: 0xD8894064
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 3
-    clean:
-      - crc: 0x3B4027F3
-        util: 'TES5Edit v4.0.2f'
   - name: 'Invisible_Helm.esp'
     msg:
       - <<: *corrupt
@@ -9537,9 +8643,6 @@ plugins:
         crc: 0xA43571C0
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 17
-    clean:
-      - crc: 0x5E438845
-        util: 'TES5Edit v4.0.2f'
   - name: 'Ivory Armor.esp'
     dirty:
       - crc: 0xe7cea340
@@ -9557,10 +8660,6 @@ plugins:
         crc: 0x8DD4B708
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 5
-    clean:
-      # v1.1 - after QAC
-      - crc: 0x8592F8FA
-        util: 'TES5Edit v4.0.2j'
   - name: 'Jacksh.+\.esp'
     msg:
       - <<: *alreadyInX
@@ -9581,13 +8680,6 @@ plugins:
         crc: 0x4CE34157
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 13
-    clean:
-      # v1.1 - after QAC
-      - crc: 0x63E96310
-        util: 'TES5Edit v4.0.2j'
-      # v1.1a - after QAC
-      - crc: 0x5EE36115
-        util: 'TES5Edit v4.0.2j'
   - name: 'JSwords.esp'
     msg: [ *obsolete ]
   - name: 'JSwordsDistributionBalancePlugin.esp'
@@ -9625,10 +8717,6 @@ plugins:
         crc: 0xA48AB749
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 5
-    clean:
-      # Main - after QAC
-      - crc: 0xD3164A71
-        util: 'TES5Edit v4.0.2j'
   - name: 'Ket_WEAPONIZER.esp'
     tag:
       - Delev
@@ -9687,9 +8775,6 @@ plugins:
         crc: 0x530E2E4A
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 1
-    clean:
-      - crc: 0x2ACA1D5E
-        util: 'TES5Edit v4.0.2f'
   - name: 'LB Necromance Robe.esp'
     msg: [ *requiresLadyBody ]
   - name: 'LB Pantie & Boots.esp'
@@ -9721,10 +8806,6 @@ plugins:
         crc: 0x9A81FB2E
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 12
-    clean:
-      # v1.1 - after QAC
-      - crc: 0x8084FB46
-        util: 'TES5Edit v4.0.2j'
   - name: 'LC_AssassinOfShadownArmor.esp'
     msg: [ *requiresLadyBody ]
   - name: 'LeatherBackpackBlack.*\.esp'
@@ -9785,10 +8866,6 @@ plugins:
         crc: 0x747ED3F4
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 1
-    clean:
-      # v3.0 - after QAC
-      - crc: 0xA0565DAC
-        util: 'TES5Edit v4.0.2j'
   - name: 'lilithssickle_axe_1.esp'
     msg: [ *obsolete ]
   - name: 'lilithssickle_2_0.esp'
@@ -9803,10 +8880,6 @@ plugins:
         crc: 0xFF8890BC
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 1
-    clean:
-      # v3.0 - after QAC
-      - crc: 0xF0A557CD
-        util: 'TES5Edit v4.0.2j'
   - name: 'lilithsslayer.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/24079' ]
     clean:
@@ -9829,10 +8902,6 @@ plugins:
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 25
         udr: 22
-    clean:
-      # v5.2 - after QAC
-      - crc: 0x5A5B15C0
-        util: 'TES5Edit v4.0.2j'
   - name: 'LongbowsDG.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/29950' ]
     dirty:
@@ -9842,10 +8911,6 @@ plugins:
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 10
         udr: 11
-    clean:
-      # v5.2 - after QAC
-      - crc: 0x4649CA88
-        util: 'TES5Edit v4.0.2j'
   - name: 'LongbowsDB.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/29950' ]
     dirty:
@@ -9854,10 +8919,6 @@ plugins:
         crc: 0xE7C37B02
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 6
-    clean:
-      # v5.2 - after QAC
-      - crc: 0x84580FCC
-        util: 'TES5Edit v4.0.2j'
   - name: 'LongbowsPerks.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/29950' ]
     dirty:
@@ -9866,10 +8927,6 @@ plugins:
         crc: 0xE9F64015
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 1
-    clean:
-      # v5.2 - after QAC
-      - crc: 0x9F72C8EF
-        util: 'TES5Edit v4.0.2j'
   - name: 'Longbows&Crossbows.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/29950' ]
     clean:
@@ -9910,10 +8967,6 @@ plugins:
         crc: 0xF8E960CF
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 3
-    clean:
-      # v2.3a - after QAC
-      - crc: 0x31BBA90F
-        util: 'TES5Edit v4.0.2j'
   - name: 'LSB_BattleHammersV6.esp'
     tag: [ Delev ]
   - name: 'Magicka Sabers.esp'
@@ -9940,13 +8993,6 @@ plugins:
         crc: 0x7E9E0DAF
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 3
-    clean:
-      # v3.0 - after QAC
-      - crc: 0xE11B9012
-        util: 'TES5Edit v4.0.2j'
-      # v5.5 - after QAC
-      - crc: 0x076C6DAF
-        util: 'TES5Edit v4.0.2j'
   - name: 'magna carta armor.esp'
     dirty:
       - crc: 0x7c8f5058
@@ -10044,10 +9090,6 @@ plugins:
         crc: 0xA8A0C107
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 1
-    clean:
-      # v1.2 - after QAC
-      - crc: 0x25ECD084
-        util: 'TES5Edit v4.0.2j'
   - name: 'Monys Portable Crafting Equipment.esp'
     msg:
       - <<: *corrupt
@@ -10101,9 +9143,6 @@ plugins:
         crc: 0xB37F55E7
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         udr: 6
-    clean:
-      - crc: 0xCFDA2303
-        util: 'TES5Edit v4.0.2f'
   - name: 'NobleArtifacts_RUS.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/47052' ]
     dirty:
@@ -10111,9 +9150,6 @@ plugins:
         crc: 0x038E142C
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         udr: 6
-    clean:
-      - crc: 0xFA30358F
-        util: 'TES5Edit v4.0.2f'
   - name: 'NewBladesArmor.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/15735' ]
     dirty:
@@ -10128,13 +9164,6 @@ plugins:
         crc: 0x56666897
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 5
-    clean:
-      # v1.2 - Sky Haven Temple - after QAC
-      - crc: 0x32431842
-        util: 'TES5Edit v4.0.2j'
-      # v1.2 - Skyforge - after QAC
-      - crc: 0xC0B6FAB1
-        util: 'TES5Edit v4.0.2j'
   - name: 'NewmillerCasualBikiniUNP2.esp'
     msg:
       - type: say
@@ -10204,10 +9233,6 @@ plugins:
         crc: 0x62B77116
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 1
-    clean:
-      # Final - after QAC
-      - crc: 0x3283DCB9
-        util: 'TES5Edit v4.0.2j'
   - name: 'nightingalevoidarmor.esp'
     dirty:
       - crc: 0x143a972
@@ -10255,10 +9280,6 @@ plugins:
         crc: 0x2DFEBD42
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 3
-    clean:
-      # v1.0 - after QAC
-      - crc: 0x9B1F6BE8
-        util: 'TES5Edit v4.0.2j'
   - name: 'NordLederruestung.esp'
     inc:
       - 'NordLeatherArmor.esp'
@@ -10276,10 +9297,6 @@ plugins:
         crc: 0x02A48FCF
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 4
-    clean:
-      # v1.1 - after QAC
-      - crc: 0x1284E460
-        util: 'TES5Edit v4.0.2j'
   - name: 'OldKnightShield.esp'
     tag: [ Relev ]
   - name: 'Omegared99-Compilation.esp'
@@ -10323,10 +9340,6 @@ plugins:
         crc: 0x0781B36E
         util: '[TES5Edit v4.0.2k](https://www.nexusmods.com/skyrim/mods/25859)'
         udr: 2
-    clean:
-      # v1.3 - after QAC
-      - crc: 0x9A6BC47A
-        util: 'TES5Edit v4.0.2k'
   - name: 'PBGearRings.esp'
     req:
       - *SKSE
@@ -10351,10 +9364,6 @@ plugins:
         crc: 0x2559F5C8
         util: '[TES5Edit v4.0.2k](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 3
-    clean:
-      # v1.02 - after QAC
-      - crc: 0x7A7F6BD8
-        util: 'TES5Edit v4.0.2k'
   - name: 'PrvtI_HeavyArmory.esp'
     msg:
       - <<: *alreadyInSkyRe
@@ -10381,10 +9390,6 @@ plugins:
         crc: 0xBAF5E2E4
         util: '[TES5Edit v4.0.2k](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 1
-    clean:
-      # v1.0 - after QAC
-      - crc: 0x07A3E01F
-        util: 'TES5Edit v4.0.2k'
   - name: 'RagnvaldBookFarengar+Ragnvald.esp'
     inc:
       - 'RagnvaldBook.esp'
@@ -10404,10 +9409,6 @@ plugins:
         util: '[TES5Edit v4.0.2k](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 5
         udr: 3
-    clean:
-      # v1 - after QAC
-      - crc: 0xBCF3C4BF
-        util: 'TES5Edit v4.0.2k'
   - name: 'Redguard Shield.esp'
     msg:
       - <<: *fixedPluginPreCKSharlikran
@@ -10423,10 +9424,6 @@ plugins:
         crc: 0x8D48F1C3
         util: '[TES5Edit v4.0.2k](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 3
-    clean:
-      # v6 - after QAC
-      - crc: 0x15C7EDBA
-        util: 'TES5Edit v4.0.2k'
   - name: 'RegentSword.esp'
     tag:
       - name: Deactivate
@@ -10456,10 +9453,6 @@ plugins:
         crc: 0xB28A5287
         util: '[TES5Edit v4.0.2k](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 7
-    clean:
-      # v1.0 - after QAC
-      - crc: 0x02FF3946
-        util: 'TES5Edit v4.0.2k'
   - name: 'RingOfTalos.esp'
     msg: [ *corrupt ]
   - name: 'RIP88_Pool_Furniture_Sample.esp'
@@ -10475,10 +9468,6 @@ plugins:
         crc: 0xC6BCA82F
         util: '[TES5Edit v4.0.2k](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 4
-    clean:
-      # v4.24 - after QAC
-      - crc: 0x2653E9ED
-        util: 'TES5Edit v4.0.2k'
   - name: 'RobedSteelPlateArmor.esp'
     inc:
       - 'RobedEbonyArmor.esp'
@@ -10518,10 +9507,6 @@ plugins:
         crc: 0x3CF22AAE
         util: '[TES5Edit v4.0.2k](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 9
-    clean:
-      # v1.9 - after QAC
-      - crc: 0x25309237
-        util: 'TES5Edit v4.0.2k'
   - name: 'Sauron Armor.esp'
     msg: [ *corrupt ]
   - name: 'ScarabSilentArchery.esp'
@@ -10537,10 +9522,6 @@ plugins:
         crc: 0x7AA5E3BB
         util: '[TES5Edit v4.0.2k](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 1
-    clean:
-      # v2.2 - after QAC
-      - crc: 0xCF62E72E
-        util: 'TES5Edit v4.0.2k'
   - name: 'seducesets.esp'
     msg:
       - *requiresCBBE
@@ -10604,16 +9585,6 @@ plugins:
         crc: 0xE83A3490
         util: '[TES5Edit v4.0.2k](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 4
-    clean:
-      # 18231 - Main - after QAC
-      - crc: 0x6AAFE5F0
-        util: 'TES5Edit v4.0.2k'
-      # 35188 - v1.10 - Main - after QAC
-      - crc: 0x29666388
-        util: 'TES5Edit v4.0.2k'
-      # 35188 - v1.10 - Optional - after QAC
-      - crc: 0x24A4B7CC
-        util: 'TES5Edit v4.0.2k'
   - name: 'ShieldsofSkyrimLists.esp'
     inc:
       - 'ShieldsofSkyrim.esp'
@@ -10664,10 +9635,6 @@ plugins:
         crc: 0xBED6E7D8
         util: '[TES5Edit v4.0.2k](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 8
-    clean:
-      # v2.0.3 - after QAC
-      - crc: 0x372FBEDD
-        util: 'TES5Edit v4.0.2k'
   - name: 'SnowyNightingale.esp'
     msg:
       - <<: *fixedPluginOutSub
@@ -10695,13 +9662,6 @@ plugins:
         crc: 0x4D1F46FA
         util: '[TES5Edit v4.0.2k](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 4
-    clean:
-      # v5.0 - Skyrim - after QAC
-      - crc: 0x26A57A6F
-        util: 'TES5Edit v4.0.2k'
-      # v5.0 - Dawnguard - after QAC
-      - crc: 0x2570AD1E
-        util: 'TES5Edit v4.0.2k'
   - name: 'Space Wiking''s The Elementals.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/18072' ]
     clean:
@@ -10721,10 +9681,6 @@ plugins:
         crc: 0x847D0495
         util: '[TES5Edit v4.0.2k](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 3
-    clean:
-      # v0.9.2 - after QAC
-      - crc: 0x7383C905
-        util: 'TES5Edit v4.0.2k'
   - name: 'SpellbreakersLOREFRIENDLY.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/22090' ]
     inc:
@@ -10745,10 +9701,6 @@ plugins:
         crc: 0xC5E7B65B
         util: '[TES5Edit v4.0.2k](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 2
-    clean:
-      # v1.42 - after QAC
-      - crc: 0x17F43297
-        util: 'TES5Edit v4.0.2k'
   - name: 'spyduckWands.esp'
     req:
       - *SKSE
@@ -11034,9 +9986,6 @@ plugins:
         crc: 0xF758F3FA
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 2
-    clean:
-      - crc: 0x8588F9FE
-        util: 'TES5Edit v4.0.2f'
   - name: 'WeaponsOf3E - No Leveled Lists.esp'
     msg:
       - <<: *fixedPluginOutSub
@@ -11487,13 +10436,6 @@ plugins:
         crc: 0x2A697C7B
         util: '[TES5Edit v4.0.1](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 1
-    clean:
-      # version: 1.7
-      - crc: 0x6F49DA49
-        util: 'TES5Edit v4.0.1'
-      # version: 1.2 Replacer esp from Bandolier - Bags and Pouches Patch (https://www.nexusmods.com/skyrim/mods/92550)
-      - crc: 0xB4AE003E
-        util: 'TES5Edit v4.0.1'
   - name: 'CCO_Frostfall_Patch.esp'
     dirty:
       - crc: 0x7b3ce75d
@@ -12009,9 +10951,6 @@ plugins:
         crc: 0xDAE7CFE2
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 5
-    clean:
-      - crc: 0x719D07F2
-        util: 'TES5Edit v4.0.2f'
   - name: 'Skyrim_New Balance.esp'
     tag:
       - Delev
@@ -12023,9 +10962,6 @@ plugins:
         crc: 0x2D7F88D5
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 3
-    clean:
-      - crc: 0xA3D1E816
-        util: 'TES5Edit v4.0.2f'
   - name: 'Tropical Skyrim.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/33017' ]
     after:
@@ -13421,9 +12357,6 @@ plugins:
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 16
         udr: 4
-    clean:
-      - crc: 0x4210E3F2
-        util: 'TES5Edit v4.0.2f'
   - name: 'AAIRiverwood.esp'
     dirty:
       - crc: 0x4eab6a6f
@@ -13462,9 +12395,6 @@ plugins:
         crc: 0x4A8E173E
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 13
-    clean:
-      - crc: 0x6043E1D0
-        util: 'TES5Edit v4.0.2f'
   - name: 'AdventCalendar.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/27638' ]
     dirty:
@@ -13488,9 +12418,6 @@ plugins:
         crc: 0x8DF1944C
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 3
-    clean:
-      - crc: 0xC9B86DB0
-        util: 'TES5Edit v4.0.2f'
   - name: 'afewrandomnpcs.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/21031' ]
     dirty:
@@ -13498,9 +12425,6 @@ plugins:
         crc: 0xAEF1C6E3
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 5
-    clean:
-      - crc: 0x9C30DB3C
-        util: 'TES5Edit v4.0.2f'
   - name: 'AGameOfThrones.esp'
     dirty:
       - crc: 0xda07a741
@@ -13780,10 +12704,6 @@ plugins:
         crc: 0x7CB5C5EA
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 26
-    clean:
-      # v2.0 - after QAC
-      - crc: 0xAA686CBE
-        util: 'TES5Edit v4.0.2f'
   - name: 'SummerWearBBLS.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/25237' ]
     dirty:
@@ -13792,10 +12712,6 @@ plugins:
         crc: 0xE9CA2DDC
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 5
-    clean:
-      # v2.0 - after QAC
-      - crc: 0xE7354444
-        util: 'TES5Edit v4.0.2f'
   - name: 'SummerWearUBH.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/25237' ]
     dirty:
@@ -13804,10 +12720,6 @@ plugins:
         crc: 0x759E6860
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 5
-    clean:
-      # v2.1 - after QAC
-      - crc: 0x4B6EE849
-        util: 'TES5Edit v4.0.2f'
   - name: 'BBLS_PatioFurniture.esp'
     dirty:
       - crc: 0x90c691
@@ -13902,9 +12814,6 @@ plugins:
         crc: 0xF08D2BC8
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 43
-    clean:
-      - crc: 0x6C58DE0D
-        util: 'TES5Edit v4.0.2f'
   - name: 'BertsBreezehomeRemodel.3(Exterior).esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/8922' ]
     dirty:
@@ -13912,9 +12821,6 @@ plugins:
         crc: 0x193713D4
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 34
-    clean:
-      - crc: 0x2D580A74
-        util: 'TES5Edit v4.0.2f'
   - name: 'PutBreezehomeBack.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/8922' ]
     dirty:
@@ -13922,9 +12828,6 @@ plugins:
         crc: 0xB0E441FF
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 3
-    clean:
-      - crc: 0x558A6FF3
-        util: 'TES5Edit v4.0.2f'
   - name: 'BertsBreezeCellar.v.1.0(esm).esm'
     url: [ 'https://www.nexusmods.com/skyrim/mods/15801' ]
     dirty:
@@ -13982,9 +12885,6 @@ plugins:
         crc: 0x9A695A1C
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 26
-    clean:
-      - crc: 0x7A78F5FD
-        util: 'TES5Edit v4.0.2f'
   - name: 'BertsBreezehomeGarden(Cheat).esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/15806' ]
     clean:
@@ -13997,9 +12897,6 @@ plugins:
         crc: 0x78807A6A
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 3
-    clean:
-      - crc: 0xBD6B7972
-        util: 'TES5Edit v4.0.2f'
   - name: 'BertsBreezehomeGardeConnector(VanillaESP).esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/15806' ]
     dirty:
@@ -14007,9 +12904,6 @@ plugins:
         crc: 0x5EDF2908
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         udr: 7
-    clean:
-      - crc: 0xBBD3ED89
-        util: 'TES5Edit v4.0.2f'
   - name: 'BertsBreezehomeGreenhouse.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/29942' ]
     dirty:
@@ -14017,9 +12911,6 @@ plugins:
         crc: 0x5066DA46
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         udr: 2
-    clean:
-      - crc: 0x4B378944
-        util: 'TES5Edit v4.0.2f'
   - name: 'BetterBreezehome.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/10811' ]
     after:
@@ -14076,10 +12967,6 @@ plugins:
         crc: 0x53EC5DE6
         util: '[TES5Edit v4.0.2h](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 28
-    clean:
-      # v1.0 - after QAC
-      - crc: 0x3BCF9616
-        util: 'TES5Edit v4.0.2h'
   - name: 'BetterDwemerExteriors.esp'
     dirty:
       - crc: 0xc96424e
@@ -14224,9 +13111,6 @@ plugins:
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 16
         udr: 1
-    clean:
-      - crc: 0x51EAB7DC
-        util: 'TES5Edit v4.0.2f'
   - name: 'Breezehome_FullyUpgradable.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/11158' ]
     inc:
@@ -14282,9 +13166,6 @@ plugins:
         crc: 0x35506A64
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 34
-    clean:
-      - crc: 0x6F1AE4E6
-        util: 'TES5Edit v4.0.2f'
   - name: 'Breezehome Mannequin.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/14641' ]
     dirty:
@@ -14669,10 +13550,6 @@ plugins:
       - crc: 0xE2194448
         util: 'TES5Edit v4.0.2h'
   - name: 'CWIELnFXPatch.esp'
-    dirty:
-      - crc: 0x350cacf3
-        <<: *dirtyPlugin
-        itm: 10
     clean:
       # version: 5.2
       - crc: 0xCE70123B
@@ -14908,9 +13785,6 @@ plugins:
         crc: 0x2CFC0E15
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 241
-    clean:
-      - crc: 0x796E85F0
-        util: 'TES5Edit v4.0.2f'
   - name: 'Dovaheim4.0.esp'
     dirty:
       - crc: 0x4c8ae31d
@@ -14941,9 +13815,6 @@ plugins:
         crc: 0x27656479
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 8
-    clean:
-      - crc: 0xB23123F1
-        util: 'TES5Edit v4.0.2f'
   - name: 'DovahkiinSpeech - HigherReq.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/9548' ]
     msg: [ *obsolete ]
@@ -15007,9 +13878,6 @@ plugins:
         crc: 0xD167169B
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 46
-    clean:
-      - crc: 0x6A1C2B6B
-        util: 'TES5Edit v4.0.2f'
   - name: 'dragonpeaks.esp'
     dirty:
       - crc: 0xc11aeb0a
@@ -15049,9 +13917,6 @@ plugins:
         crc: 0x4DC5D6E5
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 54
-    clean:
-      - crc: 0xE98F85D1
-        util: 'TES5Edit v4.0.2f'
   - name: 'dremorathrall.esp'
     dirty:
       - crc: 0x752f259a
@@ -15104,9 +13969,6 @@ plugins:
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 3
         udr: 4
-    clean:
-      - crc: 0x10F99865
-        util: 'TES5Edit v4.0.2f'
   - name: 'DwarvenFalls.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/21115' ]
     dirty:
@@ -15115,9 +13977,6 @@ plugins:
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 22
         udr: 26
-    clean:
-      - crc: 0xB975B64E
-        util: 'TES5Edit v4.0.2f'
   - name: 'DwemerAquarium.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/14122' ]
     dirty:
@@ -15168,9 +14027,6 @@ plugins:
         crc: 0x8CFA5A84
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 17
-    clean:
-      - crc: 0xD5D85B60
-        util: 'TES5Edit v4.0.2f'
   - name: 'Ebonvale.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/41391' ]
     dirty:
@@ -15190,10 +14046,6 @@ plugins:
         crc: 0x981B275F
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 2
-    clean:
-      # v5.0.3 - after QAC
-      - crc: 0x8FDEBE9E
-        util: 'TES5Edit v4.0.2f'
   - name: 'enhancedhighhrothgarbymat.esp'
     url: [ 'https://steamcommunity.com/sharedfiles/filedetails/?id=131196527' ]
     dirty:
@@ -15201,9 +14053,6 @@ plugins:
         crc: 0x63B82993
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 2
-    clean:
-      - crc: 0x662B1648
-        util: 'TES5Edit v4.0.2f'
   - name: 'EnlargedDwemerStoreRoom.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/9664' ]
     dirty:
@@ -15275,10 +14124,6 @@ plugins:
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 59
         udr: 10
-    clean:
-      # esm / esp combo
-      - crc: 0xD11774FF
-        util: 'TES5Edit v4.0.2f'
   - name: 'Falconroost.esp'
     inc:
       - 'WhiteFallsHouse.esp'
@@ -15294,12 +14139,6 @@ plugins:
         itm: 12
         udr: 1
   - name: 'fallentreebridges.esp'
-    dirty:
-      - crc: 0xf7d47176
-        <<: *dirtyPlugin
-        itm: 15
-        udr: 0
-        nav: 16
     clean:
       # version: 2.0.2
       - crc: 0x0FFF5BB1
@@ -15373,9 +14212,6 @@ plugins:
         crc: 0x6D3A13D9
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 78
-    clean:
-      - crc: 0x0EC2EA98
-        util: 'TES5Edit v4.0.2f'
   - name: 'FM - UNP Merchants.esp'
     msg:
       - type: warn
@@ -15728,9 +14564,6 @@ plugins:
         crc: 0x61DCB4E0
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 20
-    clean:
-      - crc: 0xAC9EF379
-        util: 'TES5Edit v4.0.2f'
   - name: 'hellaylegacydungeon02.esp'
     msg:
       - <<: *obsolete
@@ -15931,9 +14764,6 @@ plugins:
         crc: 0x310AEBA9
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 55
-    clean:
-      - crc: 0x6DA61604
-        util: 'TES5Edit v4.0.2f'
   - name: 'Hunter.esp'
     req:
       - name: 'SkyMoMod.esm'
@@ -15987,9 +14817,6 @@ plugins:
         crc: 0x7F5941A8
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 16
-    clean:
-      - crc: 0xBAA71649
-        util: 'TES5Edit v4.0.2f'
   - name: 'Immersive Dawnstar.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/33162' ]
     dirty:
@@ -15997,9 +14824,6 @@ plugins:
         crc: 0x77B50484
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 30
-    clean:
-      - crc: 0x7816252E
-        util: 'TES5Edit v4.0.2f'
   - name: 'Immersive Dragon Bridge.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/33162' ]
     dirty:
@@ -16007,9 +14831,6 @@ plugins:
         crc: 0xDEF331B5
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 24
-    clean:
-      - crc: 0xB05CACCD
-        util: 'TES5Edit v4.0.2f'
   - name: 'Immersive Falkreath.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/33162' ]
     dirty:
@@ -16017,9 +14838,6 @@ plugins:
         crc: 0x10B7DDA3
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 33
-    clean:
-      - crc: 0x17F60265
-        util: 'TES5Edit v4.0.2f'
   - name: 'Immersive Ivarstead.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/33162' ]
     dirty:
@@ -16027,9 +14845,6 @@ plugins:
         crc: 0x5527B81C
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 18
-    clean:
-      - crc: 0x185ACE9E
-        util: 'TES5Edit v4.0.2f'
   - name: 'Immersive Karthwasten.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/33162' ]
     dirty:
@@ -16037,9 +14852,6 @@ plugins:
         crc: 0x1086444D
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 24
-    clean:
-      - crc: 0x30B69805
-        util: 'TES5Edit v4.0.2f'
   - name: 'Immersive Kynesgrove.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/33162' ]
     dirty:
@@ -16047,9 +14859,6 @@ plugins:
         crc: 0x3AA3F3FC
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 13
-    clean:
-      - crc: 0x9B5E36B4
-        util: 'TES5Edit v4.0.2f'
   - name: 'Immersive Morthal.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/33162' ]
     dirty:
@@ -16057,9 +14866,6 @@ plugins:
         crc: 0x96038A8A
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 34
-    clean:
-      - crc: 0x4FFD73EA
-        util: 'TES5Edit v4.0.2f'
   - name: 'Immersive Orc Strongholds.esp'
     url:
       - 'https://www.nexusmods.com/skyrim/mods/13608'
@@ -16075,13 +14881,6 @@ plugins:
         crc: 0x3C4BB3AC
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 70
-    clean:
-      # v14.3.1 - after QAC - 13608
-      - crc: 0x81562542
-        util: 'TES5Edit v4.0.2f'
-      # v0.55 - after QAC - 33162
-      - crc: 0x79530C21
-        util: 'TES5Edit v4.0.2f'
   - name: 'Immersive Riverwood.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/33162' ]
     dirty:
@@ -16089,9 +14888,6 @@ plugins:
         crc: 0x8FE246C6
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 39
-    clean:
-      - crc: 0x7F266054
-        util: 'TES5Edit v4.0.2f'
   - name: 'Immersive Rorikstead.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/33162' ]
     dirty:
@@ -16099,9 +14895,6 @@ plugins:
         crc: 0xF4530E86
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 34
-    clean:
-      - crc: 0xCBA5B313
-        util: 'TES5Edit v4.0.2f'
   - name: 'Immersive Shors stone.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/33162' ]
     dirty:
@@ -16109,9 +14902,6 @@ plugins:
         crc: 0x816648DF
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 18
-    clean:
-      - crc: 0xB6A0FDF1
-        util: 'TES5Edit v4.0.2f'
   - name: 'Immersive Stonehills.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/33162' ]
     dirty:
@@ -16119,9 +14909,6 @@ plugins:
         crc: 0x59A75B27
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 5
-    clean:
-      - crc: 0xBDD9AED7
-        util: 'TES5Edit v4.0.2f'
   - name: 'Immersive Whiterun.esp'
     url:
       - 'https://www.nexusmods.com/skyrim/mods/13608'
@@ -16137,13 +14924,6 @@ plugins:
         crc: 0x24FA0727
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 50
-    clean:
-      # v14.3.1 - after QAC - 13608
-      - crc: 0x82D68512
-        util: 'TES5Edit v4.0.2f'
-      # v0.55 - after QAC - 33162
-      - crc: 0x0E9C0A6E
-        util: 'TES5Edit v4.0.2f'
   - name: 'Immersive Solstheim.esp'
     url:
       - 'https://www.nexusmods.com/skyrim/mods/13608'
@@ -16159,13 +14939,6 @@ plugins:
         crc: 0x983FC6E8
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 12
-    clean:
-      # v14.3.1 - after QAC - 13608
-      - crc: 0x57ED7123
-        util: 'TES5Edit v4.0.2f'
-      # v0.55 - after QAC - 33162
-      - crc: 0x604F6DB6
-        util: 'TES5Edit v4.0.2f'
   - name: 'JKs Towns.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/61035' ]
     dirty:
@@ -16173,9 +14946,6 @@ plugins:
         crc: 0x177DC7AB
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 203
-    clean:
-      - crc: 0x8DC6FE10
-        util: 'TES5Edit v4.0.2f'
   - name: 'Improved Hjerimv1.esp'
     msg: [ *obsolete ]
   - name: 'Improved Hjerimv V2.esp'
@@ -16187,9 +14957,6 @@ plugins:
         crc: 0x86BF900A
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 41
-    clean:
-      - crc: 0x339A4BC3
-        util: 'TES5Edit v4.0.2f'
   - name: 'ImprovedSkyforge.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/24067' ]
     dirty:
@@ -16220,13 +14987,6 @@ plugins:
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 30
         udr: 6
-    clean:
-      # Normal - after QAC
-      - crc: 0x25F1372A
-        util: 'TES5Edit v4.0.2f'
-      # No Mannequins - after QAC
-      - crc: 0xFE287D69
-        util: 'TES5Edit v4.0.2f'
   - name: 'Inns and Taverns.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/28283' ]
     dirty:
@@ -16235,10 +14995,6 @@ plugins:
         crc: 0x72880D3B
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 154
-    clean:
-      # v2.6 - after QAC
-      - crc: 0x13C51343
-        util: 'TES5Edit v4.0.2f'
   - name: 'Inns and Taverns - Heartwood Inn.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/28283' ]
     inc:
@@ -16249,10 +15005,6 @@ plugins:
         crc: 0x0EC85387
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 14
-    clean:
-      # v1.1 - after QAC
-      - crc: 0x95BD2A73
-        util: 'TES5Edit v4.0.2f'
   - name: 'Inns and Taverns - Lighthouse Tavern.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/28283' ]
     inc:
@@ -16263,10 +15015,6 @@ plugins:
         crc: 0xF0F457DF
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 5
-    clean:
-      # v1 - after QAC
-      - crc: 0x3682F9C7
-        util: 'TES5Edit v4.0.2f'
   - name: 'Inns and Taverns - Mixwater Tavern.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/28283' ]
     inc:
@@ -16277,10 +15025,6 @@ plugins:
         crc: 0xFCB8411B
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 15
-    clean:
-      # v1.1 - after QAC
-      - crc: 0xC5D221B2
-        util: 'TES5Edit v4.0.2f'
   - name: 'Inns and Taverns - Old Windmill Inn.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/28283' ]
     inc:
@@ -16291,10 +15035,6 @@ plugins:
         crc: 0x0272F30A
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 5
-    clean:
-      # v1.1 - after QAC
-      - crc: 0x4A65AF5A
-        util: 'TES5Edit v4.0.2f'
   - name: 'Inns and Taverns - The Frosty Tankard.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/28283' ]
     inc:
@@ -16305,10 +15045,6 @@ plugins:
         crc: 0xCEE0468C
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 9
-    clean:
-      # v1 - after QAC
-      - crc: 0x3F1591F0
-        util: 'TES5Edit v4.0.2f'
   - name: 'Inns and Taverns - The Ghostly View.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/28283' ]
     inc:
@@ -16319,10 +15055,6 @@ plugins:
         crc: 0x4DFF2B8C
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 16
-    clean:
-      # v1.1 - after QAC
-      - crc: 0xB75ACE93
-        util: 'TES5Edit v4.0.2f'
   - name: 'InfiniteShouts.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/20997' ]
     dirty:
@@ -16331,9 +15063,6 @@ plugins:
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 3
         udr: 4
-    clean:
-      - crc: 0x4790E6A5
-        util: 'TES5Edit v4.0.2f'
   - name: 'JNL - Lots More Followers.esp'
     dirty:
       - crc: 0x17a0601a
@@ -16591,9 +15320,6 @@ plugins:
         crc: 0x57223ADC
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 85
-    clean:
-      - crc: 0xCB0B8C53
-        util: 'TES5Edit v4.0.2f'
   - name: 'Lyberanthuin Restored.esp'
     dirty:
       - crc: 0x41f211fe
@@ -17095,9 +15821,6 @@ plugins:
         crc: 0x444FA0BC
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 8
-    clean:
-      - crc: 0x887D54FC
-        util: 'TES5Edit v4.0.2f'
   - name: 'Reapers.esp'
     msg: [ *obsolete ]
   - name: 'Reaper''s The Dark Tower.esp'
@@ -17107,9 +15830,6 @@ plugins:
         crc: 0x2E445146
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 2
-    clean:
-      - crc: 0x9E26BE0D
-        util: 'TES5Edit v4.0.2f'
   - name: 'Reaper''s Landscape - The Dead Forest.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/30522' ]
     dirty:
@@ -17145,9 +15865,6 @@ plugins:
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 26
         udr: 3
-    clean:
-      - crc: 0xEA171B1D
-        util: 'TES5Edit v4.0.2f'
   - name: 'Resource Bonanza.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/13975' ]
     dirty:
@@ -17156,9 +15873,6 @@ plugins:
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 17
         udr: 1
-    clean:
-      - crc: 0x1D08115B
-        util: 'TES5Edit v4.0.2f'
   - name: 'Ridgeview House BETA.esp'
     msg: [ *obsolete ]
   - name: 'Ridgeview House.esp'
@@ -17210,10 +15924,6 @@ plugins:
         crc: 0x0A35ADC2
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 16
-    clean:
-      # v2.1 - after QAC
-      - crc: 0xDAE78C8F
-        util: 'TES5Edit v4.0.2f'
   - name: 'RiverwoodHuntingCabin.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/15878' ]
     msg: [ *obsolete ]
@@ -17225,10 +15935,6 @@ plugins:
         crc: 0xDE7F9603
         util: '[TES5Edit v4.0.2h](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 11
-    clean:
-      # v1.8 - after QAC
-      - crc: 0x3783C8CA
-        util: 'TES5Edit v4.0.2h'
   - name: 'RiverwoodRepose.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/11944' ]
     dirty:
@@ -17253,10 +15959,6 @@ plugins:
         util: '[TES5Edit v4.0.2h](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 10
         udr: 17
-    clean:
-      # v0.3 - after QAC
-      - crc: 0x48CA1DF7
-        util: 'TES5Edit v4.0.2h'
   - name: 'rooq_bathing_twocell.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/9227' ]
     msg:
@@ -17269,10 +15971,6 @@ plugins:
         util: '[TES5Edit v4.0.2h](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 9
         udr: 17
-    clean:
-      # v0.3 - after QAC
-      - crc: 0xB6690AAB
-        util: 'TES5Edit v4.0.2h'
   - name: 'Rooq_Bathing_TwoCell_HearthFires.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/9227' ]
     clean:
@@ -17288,10 +15986,6 @@ plugins:
         util: '[TES5Edit v4.0.2h](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 35
         udr: 1
-    clean:
-      # v3.0 - after QAC
-      - crc: 0xFDCB0990
-        util: 'TES5Edit v4.0.2h'
   - name: 'RPQuestAssist_2dot0.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/35785' ]
     dirty:
@@ -17309,10 +16003,6 @@ plugins:
         util: '[TES5Edit v4.0.2h](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 7
         udr: 40
-    clean:
-      # v1.0 - after QAC
-      - crc: 0x9186EE50
-        util: 'TES5Edit v4.0.2h'
   - name: 'RTSforSkyrim.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/12683' ]
     msg:
@@ -17341,10 +16031,6 @@ plugins:
         util: '[TES5Edit v4.0.2h](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 147
         udr: 59
-    clean:
-      # v1.2 - after QAC
-      - crc: 0xF65AEFCB
-        util: 'TES5Edit v4.0.2h'
   - name: 'Run For Your Lives.esp'
     inc:
       - 'EveryoneGetInside.esp'
@@ -17935,9 +16621,6 @@ plugins:
         crc: 0x2726C0BF
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 76
-    clean:
-      - crc: 0xA8F3FD0B
-        util: 'TES5Edit v4.0.2f'
   - name: 'Die fünf Pforten- Deutsch.esp'
     dirty:
       - crc: 0x69e4e164
@@ -17956,9 +16639,6 @@ plugins:
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 30
         udr: 1
-    clean:
-      - crc: 0x7C087D3A
-        util: 'TES5Edit v4.0.2f'
   - name: 'The McMiller Chronicles.esp'
     dirty:
       - crc: 0xe2214b30
@@ -17986,10 +16666,6 @@ plugins:
         util: '[TES5Edit v4.0.2h](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 10
         udr: 1
-    clean:
-      # v1.2 - after QAC
-      - crc: 0xF4533AAD
-        util: 'TES5Edit v4.0.2h'
   - name: 'The Secret Room of Breezehome.esp'
     inc:
       - 'secretroom-bh-en.esp'
@@ -18006,10 +16682,6 @@ plugins:
         util: '[TES5Edit v4.0.2h](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 73
         udr: 4
-    clean:
-      # v10072012 - after QAC
-      - crc: 0x7F6D8FE3
-        util: 'TES5Edit v4.0.2h'
   - name: 'The Warden Stone.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/22412' ]
     dirty:
@@ -18019,10 +16691,6 @@ plugins:
         util: '[TES5Edit v4.0.2h](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 19
         udr: 1
-    clean:
-      # v1.0 - after QAC
-      - crc: 0x2ECA571E
-        util: 'TES5Edit v4.0.2h'
   - name: 'thievesguildexit.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/16638' ]
     dirty:
@@ -18031,10 +16699,6 @@ plugins:
         crc: 0x4F253B98
         util: '[TES5Edit v4.0.2h](https://www.nexusmods.com/skyrim/mods/25859)'
         udr: 18
-    clean:
-      # v3.0 - after QAC
-      - crc: 0x927955B9
-        util: 'TES5Edit v4.0.2h'
   - name: 'ThiefSecretEntrances.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/17604' ]
     dirty:
@@ -18044,10 +16708,6 @@ plugins:
         util: '[TES5Edit v4.0.2h](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 34
         udr: 2
-    clean:
-      # v1.0 - after QAC
-      - crc: 0x07AB8F6C
-        util: 'TES5Edit v4.0.2h'
   - name: 'ThievesGuildTrapDoor.esp'
     url: [ 'http://www.nexusmods.com/skyrim/mods/8513' ]
     clean:
@@ -19693,9 +18353,6 @@ plugins:
         crc: 0x41A04451
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 37
-    clean:
-      - crc: 0x01D063C6
-        util: 'TES5Edit v4.0.2f'
   - name: 'ImprovedMonsterLoot.esp'
     tag: [ Relev ]
     dirty:
@@ -20431,9 +19088,6 @@ plugins:
         crc: 0xBD40ECF4
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 1
-    clean:
-      - crc: 0x5D6ABC17
-        util: 'TES5Edit v4.0.2f'
   - name: 'SkyTEST-RealisticAnimals&Predators.esm'
     url: [ 'https://www.nexusmods.com/skyrim/mods/10175' ]
     inc:
@@ -20443,9 +19097,6 @@ plugins:
         crc: 0x598C3077
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 1
-    clean:
-      - crc: 0xD7DBBD9A
-        util: 'TES5Edit v4.0.2f'
   - name: 'SkyTEST-RealisticAnimals&Predators-Dragonborn.esp'
     dirty:
       - crc: 0x23f00d9a
@@ -20573,13 +19224,6 @@ plugins:
     after:
       - 'BetterQuestObjectives.esp'
     tag: [ Names ]
-    dirty:
-      - crc: 0xdd345cc
-        <<: *dirtyPlugin
-        itm: 4
-      - crc: 0x6cf96c54
-        <<: *dirtyPlugin
-        itm: 8
     clean:
       # version: 2.0
       - crc: 0x3A570202
@@ -20602,10 +19246,6 @@ plugins:
     msg:
       - <<: *patchRequiemRPC
         condition: 'active("Requiem.esp") and not active("Requiem - Timing Is Everything.esp")'
-    dirty:
-      - crc: 0x99c43ba5
-        <<: *dirtyPlugin
-        itm: 4
     clean:
       # version: 2.02
       - crc: 0x70ACDD02
@@ -21024,16 +19664,6 @@ plugins:
         crc: 0x1CB40901
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 220
-    clean:
-      # v14.3.1 Complete
-      - crc: 0xF4C41918
-        util: 'TES5Edit v4.0.2f'
-      # v14.3.1 Complete - No Inns
-      - crc: 0x73686028
-        util: 'TES5Edit v4.0.2f'
-      # v0.4.4 Complete
-      - crc: 0xA3E49812
-        util: 'TES5Edit v4.0.2f'
   - name: 'ETaC - Dragon Bridge South.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/13608' ]
     dirty:
@@ -21042,10 +19672,6 @@ plugins:
         crc: 0x6BFE713C
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 12
-    clean:
-      # v14.3.1
-      - crc: 0xFC68DD41
-        util: 'TES5Edit v4.0.2f'
   - name: 'ETaC - Complete No Snow Patch.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/13608' ]
     clean:
@@ -21677,9 +20303,6 @@ plugins:
         crc: 0x5FC72375
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 60
-    clean:
-      - crc: 0x948B6761
-        util: 'TES5Edit v4.0.2f'
   - name: 'BFT Ships and Carriages.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/15508' ]
     dirty:
@@ -21756,10 +20379,6 @@ plugins:
         crc: 0x255F7577
         util: '[TES5Edit v4.0.1](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 14
-    clean:
-      # version: 4.12
-      - crc: 0x3C15CEAB
-        util: 'TES5Edit v4.0.1'
   - name: 'Open Cities Skyrim.esp'
     group: *ocsGroup
     after:
@@ -21999,10 +20618,6 @@ plugins:
         crc: 0x99AAB3DC
         util: '[TES5Edit v4.0.2i](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 4
-    clean:
-      # v5.0.3 - after QAC
-      - crc: 0xB214FC3F
-        util: 'TES5Edit v4.0.2i'
   - name: 'RLO - Interiors.esp'
     url: [ 'http://www.nexusmods.com/skyrim/mods/30450' ]
     clean:
@@ -22191,10 +20806,6 @@ plugins:
         crc: 0x8B0C212F
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 1
-    clean:
-      ## v1.0.3 RealisticNeedsandDiseasesUSLEEP - ENG
-      - crc: 0xCEDB343F
-        util: 'TES5Edit v4.0.2f'
   - name: 'RND_Dawnguard-Patch.esp'
     after:
       - '3DNPC.esp'
@@ -22868,9 +21479,6 @@ plugins:
         crc: 0xB30C1BB1
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 4
-    clean:
-      - crc: 0x1F9E3C1D
-        util: 'TES5Edit v4.0.2f'
   - name: 'elemental fury.esp'
     dirty:
       - crc: 0x6b3370e8
@@ -23127,9 +21735,6 @@ plugins:
         crc: 0x31CCE33F
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 32
-    clean:
-      - crc: 0xC4FED628
-        util: 'TES5Edit v4.0.2f'
   - name: 'sprigganandwispmother.esp'
     dirty:
       - crc: 0xfcc956db
@@ -23783,9 +22388,6 @@ plugins:
         crc: 0x6F07D98B
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 1
-    clean:
-      - crc: 0xDEA447A3
-        util: 'TES5Edit v4.0.2f'
   - name: 'ACE BYOG Carry Weight ([Dd]+\d{1,3})\.esp'
     msg:
       - <<: *useOnlyOneX
@@ -24253,11 +22855,6 @@ plugins:
       - 'Perk_Heavy_Armor_Tree_Redone.esp'
   - name: 'PerkUP-Alchemy.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/9359' ]
-    dirty:
-      - <<: *quickClean
-        crc: 0x78B29460
-        util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
-        itm: 8
     msg:
       - <<: *corrupt
         condition: 'checksum("PerkUP-Alchemy.esp",78B29460)'
@@ -24270,11 +22867,6 @@ plugins:
         itm: 4
   - name: 'PerkUP-Archery.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/9359' ]
-    dirty:
-      - <<: *quickClean
-        crc: 0x7DE1869B
-        util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
-        itm: 8
     msg:
       - <<: *corrupt
         condition: 'checksum("PerkUP-Archery.esp",7DE1869B)'
@@ -24299,11 +22891,6 @@ plugins:
         itm: 9
   - name: 'PerkUP-Enchanting.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/9359' ]
-    dirty:
-      - <<: *quickClean
-        crc: 0x44A1D95B
-        util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
-        itm: 12
     msg:
       - <<: *corrupt
         condition: 'checksum("PerkUP-Enchanting.esp",44A1D95B)'
@@ -24327,31 +22914,16 @@ plugins:
         condition: 'checksum("PerkUP-LightArmor.esp",B06368FC)'
   - name: 'PerkUP-Lockpicking.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/9359' ]
-    dirty:
-      - <<: *quickClean
-        crc: 0x84E156CF
-        util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
-        itm: 1
     msg:
       - <<: *corrupt
         condition: 'checksum("PerkUP-Lockpicking.esp",84E156CF)'
   - name: 'PerkUP-OneHanded.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/9359' ]
-    dirty:
-      - <<: *quickClean
-        crc: 0x537E45D7
-        util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
-        itm: 14
     msg:
       - <<: *corrupt
         condition: 'checksum("PerkUP-OneHanded.esp",537E45D7)'
   - name: 'PerkUP-Pickpocket.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/9359' ]
-    dirty:
-      - <<: *quickClean
-        crc: 0xC499715D
-        util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
-        itm: 8
     msg:
       - <<: *corrupt
         condition: 'checksum("PerkUP-Pickpocket.esp",C499715D)'
@@ -24364,41 +22936,21 @@ plugins:
         itm: 5
   - name: 'PerkUP-Smithing.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/9359' ]
-    dirty:
-      - <<: *quickClean
-        crc: 0xF607DBD3
-        util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
-        itm: 11
     msg:
       - <<: *corrupt
         condition: 'checksum("PerkUP-Smithing.esp",F607DBD3)'
   - name: 'PerkUP-Sneak.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/9359' ]
-    dirty:
-      - <<: *quickClean
-        crc: 0x5B3B0E3A
-        util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
-        itm: 9
     msg:
       - <<: *corrupt
         condition: 'checksum("PerkUP-Sneak.esp",5B3B0E3A)'
   - name: 'PerkUP-Speech.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/9359' ]
-    dirty:
-      - <<: *quickClean
-        crc: 0x8E72AE48
-        util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
-        itm: 9
     msg:
       - <<: *corrupt
         condition: 'checksum("PerkUP-Speech.esp",8E72AE48)'
   - name: 'PerkUP-TwoHanded.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/9359' ]
-    dirty:
-      - <<: *quickClean
-        crc: 0x2EC31219
-        util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
-        itm: 11
     msg:
       - <<: *corrupt
         condition: 'checksum("PerkUP-TwoHanded.esp",2EC31219)'
@@ -24680,9 +23232,6 @@ plugins:
         crc: 0xC7233FED
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 10
-    clean:
-      - crc: 0xC9FCC766
-        util: 'TES5Edit v4.0.2f'
   - name: 'weaponperkadjustments.esp'
     dirty:
       - crc: 0xe830cbbe
@@ -25147,9 +23696,6 @@ plugins:
         crc: 0xE91FCA2F
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 336
-    clean:
-      - crc: 0xA26C90FD
-        util: 'TES5Edit v4.0.2f'
   - name: 'AlmostEveryoneIsAnAdventurer.esp'
     req: [ *SKSE ]
   - name: 'kuerteeSimpleMultipleFollowers MCM.esp'
@@ -25233,10 +23779,6 @@ plugins:
         crc: 0x6371E737
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 36
-    clean:
-      # version: 2.3
-      - crc: 0xAAB7BD04
-        util: 'TES5Edit v4.0.2f'
   - name: 'tos_laintardale_hf.esp'
     dirty:
       - crc: 0xe536de07
@@ -25257,10 +23799,6 @@ plugins:
         crc: 0x043A5D8F
         util: '[TES5Edit v4.0.1](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 52
-    clean:
-      # version: 1.3
-      - crc: 0xAEDD0511
-        util: 'TES5Edit v4.0.1'
   - name: 'SeaPointSettlement.esp'
     dirty:
       # version: 1.01
@@ -25268,10 +23806,6 @@ plugins:
         crc: 0x0CA559AA
         util: '[TES5Edit v4.0.1](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 69
-    clean:
-      # version: 1.01
-      - crc: 0xE397FFA6
-        util: 'TES5Edit v4.0.1'
   - name: 'SerenitySeapointPatch.esp'
     dirty:
       - crc: 0x74F86411
@@ -26757,9 +25291,6 @@ plugins:
         crc: 0xD6C72A3C
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 7
-    clean:
-      - crc: 0x24727083
-        util: 'TES5Edit v4.0.2f'
   - name: 'Guardian HeadQuarters.esp'
     dirty:
       - crc: 0x5ba9ace4
@@ -26805,16 +25336,6 @@ plugins:
         crc: 0x87AFFB0D
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 71
-    clean:
-      # v5e - aysigago - 41087
-      - crc: 0x90DE5BE8
-        util: 'TES5Edit v4.0.2f'
-      # v7 - Harkon121599 - 64018
-      - crc: 0x3A185CCE
-        util: 'TES5Edit v4.0.2f'
-      # v1.7 - DJAretin0 - 79490
-      - crc: 0xA1C8EB23
-        util: 'TES5Edit v4.0.2f'
   - name: 'RemoveEssentialPatch.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/41087' ]
     clean:
@@ -27113,9 +25634,6 @@ plugins:
         crc: 0x1841112C
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 6
-    clean:
-      - crc: 0xE87FD1CE
-        util: 'TES5Edit v4.0.2f'
   - name: 'Chesko_LevelUp.esp'
     req:
       - *SKSE
@@ -27351,10 +25869,6 @@ plugins:
         crc: 0xA505BEA9
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 6
-    clean:
-      # version: 1.11
-      - crc: 0xE3A55142
-        util: 'TES5Edit v4.0.2f'
   - name: 'RealisticWaterTwo - Legendary.esp'
     after:
       - 'SkyFalls + SkyMills.esp'
@@ -27387,10 +25901,6 @@ plugins:
         crc: 0xA0056AE4
         util: '[TES5Edit v4.0.1](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 4
-    clean:
-      # version: 1.11
-      - crc: 0xC86D935E
-        util: 'TES5Edit v4.0.1'
   - name: 'RealisticWaterTwo - Waves.esp'
     dirty:
       # version: 1.11
@@ -27398,10 +25908,6 @@ plugins:
         crc: 0x3B4FFDF9
         util: '[TES5Edit v4.0.1](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 8
-    clean:
-      # version: 1.11
-      - crc: 0xD15BB352
-        util: 'TES5Edit v4.0.1'
   - name: 'RealisticWaterTwo - Waves - Dawnguard.esp'
     clean:
       # version: 1.11
@@ -27414,10 +25920,6 @@ plugins:
         crc: 0xB1462A53
         util: '[TES5Edit v4.0.1](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 1
-    clean:
-      # version: 1.11
-      - crc: 0x81BF5C3C
-        util: 'TES5Edit v4.0.1'
   - name: 'RealisticWaterTwo - Waves - Wyrmstooth.esp'
     dirty:
       # version: 1.11
@@ -27425,10 +25927,6 @@ plugins:
         crc: 0x3B3FFCEC
         util: '[TES5Edit v4.0.1](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 1
-    clean:
-      # version: 1.11
-      - crc: 0x7FDA566C
-        util: 'TES5Edit v4.0.1'
   - name: 'RealisticWaterTwo - (Dawnguard|Dragonborn|Waves( - Dawnguard)?)\.esp'
     msg:
       - <<: *alreadyInX
@@ -27578,9 +26076,6 @@ plugins:
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 4
     clean:
-      # v1.7 - kronixx - 14976
-      - crc: 0x5F2E1E45
-        util: 'TES5Edit v4.0.2f'
       # v2.0 - kryptopyr - 74045
       - crc: 0xDA3B193D
         util: 'TES5Edit v4.0.2f'
@@ -27606,9 +26101,6 @@ plugins:
         crc: 0x9A0D454B
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 5
-    clean:
-      - crc: 0x1F0A44F6
-        util: 'TES5Edit v4.0.2f'
   - name: 'Atlas Blackreach.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/14976' ]
     clean:
@@ -27626,9 +26118,6 @@ plugins:
         crc: 0x23EBE51C
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 5
-    clean:
-      - crc: 0xA63D08DF
-        util: 'TES5Edit v4.0.2f'
   - name: 'Atlas Map Markers.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/14976' ]
     clean:
@@ -28294,9 +26783,6 @@ plugins:
         crc: 0x13173CB1
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 48
-    clean:
-      - crc: 0xE5E76148
-        util: 'TES5Edit v4.0.2f'
   - name: 'Verdant - A Skyrim Grass Plugin.esp'
     after:
       - 'Skyrim Flora Overhaul.esp'
@@ -28306,10 +26792,6 @@ plugins:
         crc: 0xE28C36AB
         util: '[TES5Edit v4.0.1](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 594
-    clean:
-      # version: 2.2
-      - crc: 0xA5525828
-        util: 'TES5Edit v4.0.1'
   - name: 'Immersive detection of NPC.esp'
     after:
       - 'Combat Evolved.esp'
@@ -28354,10 +26836,6 @@ plugins:
         crc: 0x756D2124
         util: '[TES5Edit v4.0.2h](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 4
-    clean:
-      # v2.92 - after QAC
-      - crc: 0x2FF1388B
-        util: 'TES5Edit v4.0.2h'
   - name: 'TrueStorms.esp'
     dirty:
       # version: 1.5 Vanilla
@@ -28365,10 +26843,6 @@ plugins:
         crc: 0xA04BFEF0
         util: '[TES5Edit v4.0.1](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 1
-    clean:
-      # version: 1.5 Vanilla
-      - crc: 0xB69368F3
-        util: 'TES5Edit v4.0.1'
   - name: 'ETaC - Complete ELFX Patch.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/13608' ]
     clean:
@@ -28392,12 +26866,6 @@ plugins:
       # v1.0 - Main
       - crc: 0x8BC46C80
         util: 'TES5Edit v4.0.2h'
-      # v1.0 - No Guards - after QAC
-      - crc: 0x7126413C
-        util: 'TES5Edit v4.0.2h'
-      # v0.5 - Craftable only - after QAC
-      - crc: 0xFE044E64
-        util: 'TES5Edit v4.0.2h'
   - name: 'OCS - ICOW Patch.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/59937' ]
     dirty:
@@ -28406,10 +26874,6 @@ plugins:
         crc: 0xDAAF398F
         util: '[TES5Edit v4.0.2h](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 11
-    clean:
-      # v1.0 - after QAC
-      - crc: 0xED45A970
-        util: 'TES5Edit v4.0.2h'
   - name: 'OCS - SkyTEST Patch.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/59937' ]
     dirty:
@@ -28426,10 +26890,6 @@ plugins:
         crc: 0x7FB536C4
         util: '[TES5Edit v4.0.2h](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 2
-    clean:
-      # v1.9.5 - after QAC
-      - crc: 0x2FE3F9E9
-        util: 'TES5Edit v4.0.2h'
   - name: 'CornerofTheSkyrim.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/29824' ]
     dirty:
@@ -28461,10 +26921,6 @@ plugins:
         crc: 0xC2653B1F
         util: '[TES5Edit v4.0.2h](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 1
-    clean:
-      # v2.1 - after QAC
-      - crc: 0x1F7AF473
-        util: 'TES5Edit v4.0.2h'
   - name: 'hearthfireextended.esp'
     dirty:
       # version: 1.0.3
@@ -28472,15 +26928,7 @@ plugins:
         crc: 0xCDADF5BC
         util: '[TES5Edit v4.0.2](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 1
-    clean:
-      # version: 1.0.3
-      - crc: 0x237B1FAF
-        util: 'TES5Edit v4.0.2'
   - name: 'Purity.esp'
-    dirty:
-      - crc: 0xA466C02D
-        <<: *dirtyPlugin
-        itm: 2
     clean:
       - crc: 0xAC8EE7AD
         util: TES5Edit v3.1.3
@@ -28555,10 +27003,6 @@ plugins:
         crc: 0x1C59B53A
         util: '[TES5Edit v4.0.1](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 17
-    clean:
-      # version: 0.6
-      - crc: 0x2AC72F3F
-        util: 'TES5Edit v4.0.1'
     url: [ 'http://www.nexusmods.com/skyrim/mods/62886' ]
   - name: 'MoreBanditCamps(Explorer''sEdition).esp'
     dirty:
@@ -28599,10 +27043,6 @@ plugins:
         crc: 0x06253825
         util: '[TES5Edit v4.0.2h](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 47
-    clean:
-      # 1.9.32.0.8 - after QAC
-      - crc: 0xF8FDA4E8
-        util: 'TES5Edit v4.0.2h'
   - name: 'Complete Alchemy & Cooking Overhaul.esp'
     url: [ 'http://www.nexusmods.com/skyrim/mods/69306' ]
     after:
@@ -28615,9 +27055,6 @@ plugins:
         crc: 0x185A6E55
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 7
-    clean:
-      - crc: 0x6166F91F
-        util: 'TES5Edit v4.0.2f'
   - name: 'Elisdriel.esp'
     after:
       - 'WhiterunHoldForest.esp'
@@ -28715,10 +27152,6 @@ plugins:
         crc: 0xC4AE95C0
         util: '[TES5Edit v4.0.1](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 10
-    clean:
-      # version: 2.2.2
-      - crc: 0xE7736ABE
-        util: 'TES5Edit v4.0.1'
   - name: 'Gray Fox Cowl.esm'
     dirty:
       # version: 2.0DC
@@ -28726,10 +27159,6 @@ plugins:
         crc: 0x80B017F9
         util: '[TES5Edit v4.0.1](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 21
-    clean:
-      # version: 2.0DC
-      - crc: 0x088AE1EE
-        util: 'TES5Edit v4.0.1'
   - name: 'HeljarchenFarm.esp'
     dirty:
       # version: 1.47
@@ -28737,10 +27166,6 @@ plugins:
         crc: 0xFB523A92
         util: '[TES5Edit v4.0.1](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 13
-    clean:
-      # version: 1.47
-      - crc: 0x4DFB66D4
-        util: 'TES5Edit v4.0.1'
   - name: 'garm_white.esp'
     clean:
       - crc: 0x0AC6F994
@@ -28936,10 +27361,6 @@ plugins:
         crc: 0x7781895E
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 10
-    clean:
-      # version 0.4.1a Legendary
-      - crc: 0xCDB6F1FC
-        util: 'TES5Edit v4.0.2f'
   - name: 'Provincial Courier Service.esp'
     after:
       - 'Immersive Citizens - AI Overhaul.esp'
@@ -29022,9 +27443,6 @@ plugins:
         crc: 0xE19B3101
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 28
-    clean:
-      - crc: 0x0D6CA609
-        util: 'TES5Edit v4.0.2f'
   - name: 'No Vendor or Loot Spells.esp'
     group: *reproccerGroup
   - name: 'Skyrim Unlocked.esp'
@@ -29115,10 +27533,6 @@ plugins:
         crc: 0xA96903E0
         util: '[TES5Edit v4.0.2](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 7
-    clean:
-      # version: 3.0
-      - crc: 0xFE550B76
-        util: 'TES5Edit v4.0.2'
   - name: 'Hypothermia.esp'
     msg:
       - <<: *patchRequiem3rdParty
@@ -29164,10 +27578,6 @@ plugins:
         crc: 0x773D467E
         util: '[TES5Edit v4.0.1](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 2
-    clean:
-      # version: 1.9e
-      - crc: 0x25AA5381
-        util: 'TES5Edit v4.0.1'
   - name: 'Inconsequential NPCs - Enhancement.esp'
     msg:
       - <<: *patchRequiemRPC
@@ -29377,10 +27787,6 @@ plugins:
         crc: 0xDCD3E352
         util: '[TES5Edit v4.0.1](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 123
-    clean:
-      # version: 1.1
-      - crc: 0xF1B0F29B
-        util: 'TES5Edit v4.0.1'
   - name: 'Arthmoor''s Skyrim Villages - All In One.esp'
     after:
       - 'Immersive Citizens - AI Overhaul.esp'
@@ -29390,10 +27796,6 @@ plugins:
         crc: 0x5E034168
         util: '[TES5Edit v4.0.1](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 21
-    clean:
-      # version: 1.0.1
-      - crc: 0xF692C397
-        util: 'TES5Edit v4.0.1'
   - name: 'SMIM-Merged-All.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/8655' ]
     dirty:
@@ -29401,16 +27803,8 @@ plugins:
       - <<: *quickClean
         crc: 0x26FC8290
         util: '[TES5Edit v4.0.1](https://www.nexusmods.com/skyrim/mods/25859)'
-        udr: 1
-      # version: 2.08 before 2nd pass of Quick Clean
-      - <<: *quickClean
-        crc: 0xE5FD8BD1
-        util: '[TES5Edit v4.0.1](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 3
-    clean:
-      # version: 2.08
-      - crc: 0x56EC1A21
-        util: 'TES5Edit v4.0.1'
+        udr: 1
   - name: 'SkyrimUnhinged.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/93144' ]
     dirty:
@@ -29433,10 +27827,6 @@ plugins:
         util: '[TES5Edit v4.0.2h](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 26
         udr: 17
-    clean:
-      # v1.1 - after QAC
-      - crc: 0xE318D109
-        util: 'TES5Edit v4.0.2h'
   - name: 'Vaults of Skyrim 1.0 NEXUS.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/84599' ]
     dirty:
@@ -29446,10 +27836,6 @@ plugins:
         util: '[TES5Edit v4.0.2h](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 20
         udr: 24
-    clean:
-      # v1.1 - after QAC
-      - crc: 0x9C413DD0
-        util: 'TES5Edit v4.0.2h'
   - name: 'Ducks and Swans.esp'
     dirty:
       # version: 1.1
@@ -29457,10 +27843,6 @@ plugins:
         crc: 0x98F444CA
         util: '[TES5Edit v4.0.1](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 9
-    clean:
-      # version: 1.1
-      - crc: 0x33AE6156
-        util: 'TES5Edit v4.0.1'
   - name: 'skycity3.esp'
     msg:
       # version: 3.2 after Quick Clean
@@ -29473,19 +27855,12 @@ plugins:
         crc: 0xD31A8590
         util: '[TES5Edit v4.0.1](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 20
-    clean:
-      # version: 3.2 Fully cleaned
-      - crc: 0xFB1682E7
-        util: 'TES5Edit v4.0.1'
   - name: 'NB-Scars.esp'
     dirty:
       - <<: *quickClean
         crc: 0x8A54FBB8
         util: '[TES5Edit v4.0.1](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 1
-    clean:
-      - crc: 0x1622F4F3
-        util: 'TES5Edit v4.0.1'
   - name: 'Unique Flowers & Plants.esm'
     msg:
       - <<: *wildEdits
@@ -29506,17 +27881,8 @@ plugins:
       - <<: *quickClean
         crc: 0xBDE2DA1A
         util: '[TES5Edit v4.0.1](https://www.nexusmods.com/skyrim/mods/25859)'
-        itm: 13
+        itm: 14
         udr: 38
-      # Main file before 2nd pass of Quick Clean
-      - <<: *quickClean
-        crc: 0x80664EF3
-        util: '[TES5Edit v4.0.1](https://www.nexusmods.com/skyrim/mods/25859)'
-        itm: 1
-    clean:
-      # Main file
-      - crc: 0x43707301
-        util: 'TES5Edit v4.0.1'
   - name: 'CollegeApplication.esp'
     msg:
       - <<: *obsolete
@@ -29532,10 +27898,6 @@ plugins:
         crc: 0xC761C6D2
         util: '[TES5Edit v4.0.1](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 21
-    clean:
-      # version: 2.0
-      - crc: 0x3039DE16
-        util: 'TES5Edit v4.0.1'
   - name: 'Farmers Sell Produce - Skyrim.esp'
     dirty:
       # version: 1.0
@@ -29543,10 +27905,6 @@ plugins:
         crc: 0x3B13F994
         util: '[TES5Edit v4.0.1](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 38
-    clean:
-      # version: 1.0
-      - crc: 0xF911A725
-        util: 'TES5Edit v4.0.1'
   - name: 'Old Dusty travels again.esp'
     dirty:
       # version: 1.0
@@ -29554,10 +27912,6 @@ plugins:
         crc: 0x0104C73C
         util: '[TES5Edit v4.0.1](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 36
-    clean:
-      # version: 1.0
-      - crc: 0x113510F1
-        util: 'TES5Edit v4.0.1'
   - name: 'Covered in Bees.esp'
     dirty:
       # version: 1.0
@@ -29571,10 +27925,6 @@ plugins:
         crc: 0x5B3D1C8B
         util: '[TES5Edit v4.0.1](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 1
-    clean:
-      # version: 1.0
-      - crc: 0x7B9F49A2
-        util: 'TES5Edit v4.0.1'
   - name: 'RoleplayNotes.esp'
     dirty:
       # version: 1.0
@@ -29582,10 +27932,6 @@ plugins:
         crc: 0x9440F010
         util: '[TES5Edit v4.0.1](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 8
-    clean:
-      # version: 1.0 Fully cleaned
-      - crc: 0xF1A775A7
-        util: 'TES5Edit v4.0.1'
   - name: 'DoorAnswersSolvable.esp'
     dirty:
       # version: 1.0
@@ -29593,10 +27939,6 @@ plugins:
         crc: 0x8F8299D3
         util: '[TES5Edit v4.0.1](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 1
-    clean:
-      # version: 1.0
-      - crc: 0x7C0AF83C
-        util: 'TES5Edit v4.0.1'
   - name: 'more idle markers.esp'
     after:
       - 'Immersive Citizens - AI Overhaul.esp'
@@ -29615,10 +27957,6 @@ plugins:
         crc: 0x058841E0
         util: '[TES5Edit v4.0.1](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 3
-    clean:
-      # version: 1 Fully cleaned
-      - crc: 0x46192AFE
-        util: 'TES5Edit v4.0.1'
   - name: 'Book Covers Skyrim - Lost Library.esp'
     msg:
       - <<: *patchRequiemRPC
@@ -29730,10 +28068,6 @@ plugins:
         crc: 0xEB33640C
         util: '[TES5Edit v4.0.1](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 27
-    clean:
-      # version: 1.0
-      - crc: 0xDB9393D8
-        util: 'TES5Edit v4.0.1'
   - name: 'Populated Skyrim Legendary.esp'
     clean:
       # version: 2.4
@@ -29769,10 +28103,6 @@ plugins:
         crc: 0xFFD6E99E
         util: '[TES5Edit v4.0.1](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 31
-    clean:
-      # version: 1.1
-      - crc: 0x93D3D2BB
-        util: 'TES5Edit v4.0.1'
   - name: 'Point The Way.esp'
     clean:
       # version: 1.0.9
@@ -29795,10 +28125,6 @@ plugins:
         crc: 0xA17306F7
         util: '[TES5Edit v4.0.1](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 1
-    clean:
-      # version: 2.0.1
-      - crc: 0x50622EB8
-        util: 'TES5Edit v4.0.1'
   - name: 'UniqueBorderGates-All.esp'
     dirty:
       # version: 2.2
@@ -29806,10 +28132,6 @@ plugins:
         crc: 0x7E6B19CA
         util: '[TES5Edit v4.0.1](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 17
-    clean:
-      # version: 2.2
-      - crc: 0x88F5BC0B
-        util: 'TES5Edit v4.0.1'
   - name: 'UniqueBorderGates-All-BetterDGEntrance.esp'
     clean:
       # version: 2.11
@@ -29857,10 +28179,6 @@ plugins:
         crc: 0x0991A6A6
         util: '[TES5Edit v4.0.1](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 14
-    clean:
-      # version: 3.2
-      - crc: 0xCC26E8EB
-        util: 'TES5Edit v4.0.1'
   - name: 'manny Lantern Caretakers.esp'
     dirty:
       # version: 1.0
@@ -29868,10 +28186,6 @@ plugins:
         crc: 0x4EB77E00
         util: '[TES5Edit v4.0.1](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 2
-    clean:
-      # version: 1.0
-      - crc: 0x8C36427D
-        util: 'TES5Edit v4.0.1'
   - name: 'EasierRidersDungeonPack.esp'
     clean:
       # version: 1.3
@@ -29894,10 +28208,6 @@ plugins:
         crc: 0xDE8C3380
         util: '[TES5Edit v4.0.1](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 3
-    clean:
-      # version: 1.2
-      - crc: 0x1422B5BB
-        util: 'TES5Edit v4.0.1'
   - name: 'Windhelm''s Ancient Lighthouse.esp'
     dirty:
       # version: 1.0
@@ -29905,10 +28215,6 @@ plugins:
         crc: 0x9BC1D211
         util: '[TES5Edit v4.0.1](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 16
-    clean:
-      # version: 1.0
-      - crc: 0xC75FC1DD
-        util: 'TES5Edit v4.0.1'
   - name: 'high hrothgar overhaul.esp'
     clean:
       # version: 1.0
@@ -29921,10 +28227,6 @@ plugins:
         crc: 0xEBCD3A30
         util: '[TES5Edit v4.0.1](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 1
-    clean:
-      # version: 2.01
-      - crc: 0xA0E195E8
-        util: 'TES5Edit v4.0.1'
   - name: 'iNeed.esp'
     clean:
       # version: 1.602
@@ -30085,10 +28387,6 @@ plugins:
         crc: 0xD41D7D35
         util: '[TES5Edit v4.0.1](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 1
-    clean:
-      # version: 1.0d
-      - crc: 0x07431BCC
-        util: 'TES5Edit v4.0.1'
   - name: 'goldpilesyum.esp'
     clean:
       # version: 1.0
@@ -30196,10 +28494,6 @@ plugins:
         crc: 0x39D0E506
         util: '[TES5Edit v4.0.1](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 31
-    clean:
-      # version: 2.0 All In One
-      - crc: 0xA9601237
-        util: 'TES5Edit v4.0.1'
   - name: 'Beards.esp'
     clean:
       # version: 4.1
@@ -30232,10 +28526,6 @@ plugins:
         crc: 0x6BF5ED10
         util: '[TES5Edit v4.0.2](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 21
-    clean:
-      # version: 2.2
-      - crc: 0x2FB6593E
-        util: 'TES5Edit v4.0.2'
   - name: 'Artful Dodger - Dynamic Pickpocket Cap.esp'
     clean:
       # version: 1.11
@@ -30306,10 +28596,6 @@ plugins:
         crc: 0xF5522805
         util: '[TES5Edit v4.0.1](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 1
-    clean:
-      # version: 1.0
-      - crc: 0x59E379FF
-        util: 'TES5Edit v4.0.1'
   - name: 'WSCO - OcciBetterMale.esp'
     clean:
       # version: 1.0
@@ -30332,10 +28618,6 @@ plugins:
         crc: 0x6F5FD398
         util: '[TES5Edit v4.0.1](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 13
-    clean:
-      # version: 1.8.1
-      - crc: 0xAB30482A
-        util: 'TES5Edit v4.0.1'
   - name: 'Whistling Mine - No Snow Under the Roof.esp'
     clean:
       # version: 1.0
@@ -30353,10 +28635,6 @@ plugins:
         crc: 0xC68AD9B0
         util: '[TES5Edit v4.0.1](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 5
-    clean:
-      # version: 1.56
-      - crc: 0xC805D0BC
-        util: 'TES5Edit v4.0.1'
   - name: 'Vivid Weathers - AOS patch.esp'
     clean:
       # version: 1.56
@@ -30369,10 +28647,6 @@ plugins:
         crc: 0xAB1CB7A0
         util: '[TES5Edit v4.0.1](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 10
-    clean:
-      # version: 1.56
-      - crc: 0x7BE42D05
-        util: 'TES5Edit v4.0.1'
   - name: 'Vivid Weathers - Extended Snow.esp'
     dirty:
       # version: 1.56
@@ -30380,10 +28654,6 @@ plugins:
         crc: 0xB4B80067
         util: '[TES5Edit v4.0.1](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 5
-    clean:
-      # version: 1.56
-      - crc: 0x68C7F388
-        util: 'TES5Edit v4.0.1'
   - name: 'Hunters Not Bandits.esp'
     clean:
       # version: 3.1
@@ -30419,10 +28689,6 @@ plugins:
         crc: 0x1A99235E
         util: '[TES5Edit v4.0.1](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 12
-    clean:
-      # version: 1.1
-      - crc: 0x3F0D9343
-        util: 'TES5Edit v4.0.1'
   - name: 'Calves.esp'
     clean:
       # version: 1.0
@@ -30445,10 +28711,6 @@ plugins:
         crc: 0xB5D410B2
         util: '[TES5Edit v4.0.1](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 2
-    clean:
-      # version: 1.0
-      - crc: 0x20FDC598
-        util: 'TES5Edit v4.0.1'
   - name: 'Common Clothes and Armors.esp'
     msg:
       - <<: *patchRequiemRPC
@@ -30481,10 +28743,6 @@ plugins:
         crc: 0x769CAF73
         util: '[TES5Edit v4.0.1](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 35
-    clean:
-      # version: 4.01
-      - crc: 0xAB1254B3
-        util: 'TES5Edit v4.0.1'
   - name: 'dunmerplacesmod.esp'
     dirty:
       - <<: *reqManualFix
@@ -30513,10 +28771,6 @@ plugins:
         crc: 0x72A54CD3
         util: '[TES5Edit v4.0.1](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 38
-    clean:
-      # version: 1.5
-      - crc: 0xFB8256E5
-        util: 'TES5Edit v4.0.1'
   - name: 'Nordic Ruins of Skyrim.esp'
     clean:
       # version: 1.0.1
@@ -30534,10 +28788,6 @@ plugins:
         crc: 0xE212753A
         util: '[TES5Edit v4.0.2](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 7
-    clean:
-      # version: 1.0
-      - crc: 0x8A31D7EE
-        util: 'TES5Edit v4.0.2'
   - name: 'The Great City of Winterhold.esp'
     clean:
       # version: 3.02
@@ -30550,10 +28800,6 @@ plugins:
         crc: 0x6B06FCC3
         util: '[TES5Edit v4.0.1](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 9
-    clean:
-      # version: 1.12
-      - crc: 0x08BCCA62
-        util: 'TES5Edit v4.0.1'
   - name: 'The Great City of Morthal - CFTO Patch.esp'
     dirty:
       # version: 1.0
@@ -30562,10 +28808,6 @@ plugins:
         util: '[TES5Edit v4.0.2](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 17
         udr: 2
-    clean:
-      # version: 1.0
-      - crc: 0xCF83BB2E
-        util: 'TES5Edit v4.0.2'
   - name: 'The Great City of Solitude.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/95401' ]
     clean:
@@ -30579,10 +28821,6 @@ plugins:
         crc: 0xD3951CBC
         util: '[TES5Edit v4.0.1](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 1
-    clean:
-      # version: 1.0.3
-      - crc: 0x4FA126DF
-        util: 'TES5Edit v4.0.1'
   - name: 'Ivarstead.esp'
     clean:
         # version: 1.1
@@ -30595,10 +28833,6 @@ plugins:
         crc: 0xDEC6DD37
         util: '[TES5Edit v4.0.1](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 3
-    clean:
-      # version: 1.1.6
-      - crc: 0x742CE31F
-        util: 'TES5Edit v4.0.1'
   - name: 'Soljund''s Sinkhole.esp'
     clean:
       # version: 1.0.1
@@ -30626,10 +28860,6 @@ plugins:
         crc: 0x326B8D63
         util: '[TES5Edit v4.0.1](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 2
-    clean:
-      # version: 2.0
-      - crc: 0xD7BC96D7
-        util: 'TES5Edit v4.0.1'
   - name: 'Sovngarde Particle Fix.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/95361' ]
     clean:
@@ -30701,10 +28931,6 @@ plugins:
         crc: 0x17C4919C
         util: '[TES5Edit v4.0.2](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 25
-    clean:
-      # version: 1.1
-      - crc: 0x91923485
-        util: 'TES5Edit v4.0.2'
   - name: 'Ulags Legacy.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/94177' ]
     msg:
@@ -30728,10 +28954,6 @@ plugins:
         crc: 0xDEEE4B61
         util: '[TES5Edit v4.0.2](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 6
-    clean:
-      # version: 1.final
-      - crc: 0x35043422
-        util: 'TES5Edit v4.0.2'
   - name: 'El_WayfarersCoat.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/73040' ]
     clean:
@@ -30758,10 +28980,6 @@ plugins:
         crc: 0x5425F279
         util: '[TES5Edit v4.0.2](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 1
-    clean:
-      # version: 1.5
-      - crc: 0xEBB7CC0A
-        util: 'TES5Edit v4.0.2'
   - name: 'Cloaks&Capes.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/86219' ]
     clean:
@@ -30802,9 +29020,6 @@ plugins:
         crc: 0xF1419DC5
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 7
-    clean:
-      - crc: 0xC97AAEF8
-        util: 'TES5Edit v4.0.2f'
   - name: 'PATCHDragon Break.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/50882' ]
     clean:
@@ -30817,9 +29032,6 @@ plugins:
         crc: 0xA2C3A201
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 8
-    clean:
-      - crc: 0xA64931DC
-        util: 'TES5Edit v4.0.2f'
   - name: 'AgentOfRighteousMight.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/33766' ]
     dirty:
@@ -30827,9 +29039,6 @@ plugins:
         crc: 0x340E1F6C
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 35
-    clean:
-      - crc: 0xBF76AFAC
-        util: 'TES5Edit v4.0.2f'
   - name: 'AlchemyOrganization.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/8431' ]
     dirty:
@@ -30845,13 +29054,6 @@ plugins:
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 1
         udr: 1
-    clean:
-      # normal version
-      - crc: 0xC1A33780
-        util: 'TES5Edit v4.0.2f'
-      # auto close door version
-      - crc: 0x3CD452D6
-        util: 'TES5Edit v4.0.2f'
   - name: 'AmethystHollowsMaster.esm'
     url: [ 'https://www.nexusmods.com/skyrim/mods/18575' ]
     clean:
@@ -30864,9 +29066,6 @@ plugins:
         crc: 0x9A535EAB
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 33
-    clean:
-      - crc: 0x3ED2B4E6
-        util: 'TES5Edit v4.0.2f'
   - name: 'armored-horses.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/13348' ]
     dirty:
@@ -30874,9 +29073,6 @@ plugins:
         crc: 0x3B1B7A1E
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 4
-    clean:
-      - crc: 0xB12A6796
-        util: 'TES5Edit v4.0.2f'
   - name: 'BetterArcadia.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/95022' ]
     dirty:
@@ -30885,9 +29081,6 @@ plugins:
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 84
         udr: 94
-    clean:
-      - crc: 0x9926A7BF
-        util: 'TES5Edit v4.0.2f'
   - name: 'bhabhilon.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/30279' ]
     dirty:
@@ -30895,9 +29088,6 @@ plugins:
         crc: 0x37465D81
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 1348
-    clean:
-      - crc: 0x9182E3B7
-        util: 'TES5Edit v4.0.2f'
   - name: 'BSAssets.esm'
     url: [ 'https://www.nexusmods.com/skyrim/mods/84946' ]
     clean:
@@ -30920,9 +29110,6 @@ plugins:
         crc: 0x317A3AF2
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 524
-    clean:
-      - crc: 0xEB249B52
-        util: 'TES5Edit v4.0.2f'
   - name: 'BS_DLC_patch.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/84946' ]
     clean:
@@ -30935,9 +29122,6 @@ plugins:
         crc: 0x8F771C0C
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 5
-    clean:
-      - crc: 0x3803F08C
-        util: 'TES5Edit v4.0.2f'
   - name: 'Clockwork.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/77809' ]
     dirty:
@@ -30945,9 +29129,6 @@ plugins:
         crc: 0x575CA2DB
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 120
-    clean:
-      - crc: 0xED94CEA7
-        util: 'TES5Edit v4.0.2f'
   - name: 'Conan_Hyborian_Age.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/40914' ]
     msg:
@@ -30958,9 +29139,6 @@ plugins:
         crc: 0xC8A7315B
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 11
-    clean:
-      - crc: 0x436AC928
-        util: 'TES5Edit v4.0.2f'
   - name: 'crimsonquestmarkers.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/22517' ]
     dirty:
@@ -30968,9 +29146,6 @@ plugins:
         crc: 0xF19E0840
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 35
-    clean:
-      - crc: 0x3EC51487
-        util: 'TES5Edit v4.0.2f'
   - name: 'Dreamborne Islands.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/79826' ]
     dirty:
@@ -30983,12 +29158,6 @@ plugins:
         crc: 0xAAC5CD98
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 26
-    clean:
-      - crc: 0x57F02A06
-        util: 'TES5Edit v4.0.2f'
-      # LITE version
-      - crc: 0xBE0E85E5
-        util: 'TES5Edit v4.0.2f'
   - name: 'Forgotten DungeonsAll.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/57979' ]
     dirty:
@@ -30996,9 +29165,6 @@ plugins:
         crc: 0xAD4C099C
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 504
-    clean:
-      - crc: 0xF06CB63F
-        util: 'TES5Edit v4.0.2f'
   - name: 'Grytewake.esm'
     url: [ 'https://www.nexusmods.com/skyrim/mods/12295' ]
     dirty:
@@ -31030,9 +29196,6 @@ plugins:
         crc: 0x71A003CE
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 1
-    clean:
-      - crc: 0x9E1E7F0F
-        util: 'TES5Edit v4.0.2f'
   - name: 'Item Recycling.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/38901' ]
     dirty:
@@ -31040,9 +29203,6 @@ plugins:
         crc: 0x88C00214
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 13
-    clean:
-      - crc: 0x311344C4
-        util: 'TES5Edit v4.0.2f'
   - name: 'Lakeview_Extended.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/31380' ]
     dirty:
@@ -31050,9 +29210,6 @@ plugins:
         crc: 0x3B216C47
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 39
-    clean:
-      - crc: 0x611E1301
-        util: 'TES5Edit v4.0.2f'
   - name: 'ApachiiHair.esm'
     url: [ 'https://www.nexusmods.com/skyrim/mods/10168' ]
     clean:
@@ -31065,9 +29222,6 @@ plugins:
         crc: 0xC3201C1C
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 11
-    clean:
-      - crc: 0xA33318B5
-        util: 'TES5Edit v4.0.2f'
   - name: 'Masters of Death.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/9752' ]
     dirty:
@@ -31075,9 +29229,6 @@ plugins:
         crc: 0xD96C2FAC
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 1
-    clean:
-      - crc: 0xAF2086F0
-        util: 'TES5Edit v4.0.2f'
   - name: 'PiratesofthePacific.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/29443' ]
     dirty:
@@ -31086,9 +29237,6 @@ plugins:
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 100
         udr: 2
-    clean:
-      - crc: 0xF578AE45
-        util: 'TES5Edit v4.0.2f'
   - name: 'quest into the depths.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/23087' ]
     dirty:
@@ -31097,9 +29245,6 @@ plugins:
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 66
         udr: 26
-    clean:
-      - crc: 0x5CAE0507
-        util: 'TES5Edit v4.0.2f'
   - name: 'Rigmor.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/53068' ]
     dirty:
@@ -31107,9 +29252,6 @@ plugins:
         crc: 0x98D0FC9A
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 429
-    clean:
-      - crc: 0xC249C843
-        util: 'TES5Edit v4.0.2f'
   - name: 'summersetisles.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/68406' ]
     dirty:
@@ -31117,9 +29259,6 @@ plugins:
         crc: 0x065E12BA
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 2857
-    clean:
-      - crc: 0x415377E5
-        util: 'TES5Edit v4.0.2f'
   - name: 'WheelsOfLull.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/58672' ]
     dirty:
@@ -31127,9 +29266,6 @@ plugins:
         crc: 0x5BD0BF01
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 125
-    clean:
-      - crc: 0xA287E8AA
-        util: 'TES5Edit v4.0.2f'
   - name: 'xamnant.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/44922' ]
     dirty:
@@ -31137,9 +29273,6 @@ plugins:
         crc: 0xF9D9B6B6
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 2568
-    clean:
-      - crc: 0x24E6D93B
-        util: 'TES5Edit v4.0.2f'
   - name: 'ADS.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/1117' ]
     clean:


### PR DESCRIPTION
Removing clean entries for dirty plugins as the crc will be different if the plugins are cleaned with a newer version of xEdit.
Also removed cleaning info for corrupt plugins.