### PR TITLE
Change type of &wildEdits from say to warn

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -745,7 +745,7 @@ common:
         text: 'Din installerade version av %1% är inte kombatibel med din version av %2%.'
 
   - &wildEdits
-    type: say
+    type: warn
     content:
       - lang: en
         text: 'This plugin contains wild edits beyond ITM and UDR records and deleted navmeshes and may require additional manual cleaning to not interfere with other mods. %1%'


### PR DESCRIPTION
`This plugin contains wild edits beyond ITM and UDR records and deleted navmeshes and may require additional manual cleaning to not interfere with other mods. %1%`
For SSE, Oblivion, FO3, FO4 and FNV the type of `&wildEdits` is set to `warn`, not `say`.

As such, change it for Skyrim to `warn` as well.