### PR TITLE
Update german translation of &corrupt

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -148,7 +148,7 @@ common:
       - lang: en
         text: 'This file is corrupt and should not be used.'
       - lang: de
-        text: 'Diese Datei ist korrupt und sollte nicht genutzt werden.'
+        text: 'Diese Datei ist korrupt und sollte nicht benutzt werden.'
       - lang: es
         text: 'Este archivo puede corromper tu juego y no debería ser utilizado.'
       - lang: fi


### PR DESCRIPTION
With this PR, the german `de` translation of `&corrupt` will be the same across the different masterlists.