### PR TITLE
Maintenance Update 5

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -16264,6 +16264,7 @@ plugins:
         crc: 0xf6e10e47
         udr: 120
   - name: 'Unstable tower eng.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/14903' ]
     dirty:
       - <<: *dirtyPlugin
         crc: 0x4bb6b136

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -16219,43 +16219,14 @@ plugins:
     clean:
       - crc: 0xD3187B55
         util: 'TES5Edit v4.0.3'
-  - name: 'UDO.esm'
-    msg:
-      - *obsolete
-      - type: say
-        content:
-          - lang: en
-            text: 'UDO.esm is mis-named. It is NOT an esm file.'
-          - lang: de
-            text: 'UDO.esm ist falsch benannt. Es ist KEINE esm Datei.'
-          - lang: ja
-            text: 'UDO.esmのファイル名が間違っています。このファイルはEsmファイルではありません。'
-          - lang: ru
-            text: 'UDO.esm неверно назван. Это не esm-файл.'
-    dirty:
-      - <<: *dirtyPlugin
-        crc: 0x23a1b8f9
-        udr: 3835
-        nav: 1
   - name: 'UDO.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/19752' ]
     dirty:
       - <<: *dirtyPlugin
         crc: 0xd7d3445d
         itm: 15
         udr: 4448
         nav: 1
-  - name: 'UDOchestless.esp'
-    msg:
-      - type: say
-        content:
-          - lang: en
-            text: 'UDOChestless.esp does not have Skyrim.esm as a master file.  Most likely it will create duplicates of everything it is supposed to modify.'
-          - lang: de
-            text: 'UDOChestless.esp hat Skyrim.esm nicht als Masterdatei. Höchstwahrscheinlich werden Duplikate von allem erstellt, was geändert werden soll.'
-          - lang: ja
-            text: 'UDOChestless.espはSkyrim.esmをマスターファイルとしていません。変更だけで終わるはずの箇所が複製されてしまう可能性が高いでしょう。'
-          - lang: ru
-            text: 'UDOChestless.esp не имеет Skyrim.esm в мастерфайлах.  Наиболее вероятно будут созданны дубликаты всего, что было модифицировано.'
   - name: 'Ultimate HD Fire Spells.esp'
     dirty:
       - <<: *dirtyPlugin

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -16228,6 +16228,7 @@ plugins:
         udr: 4448
         nav: 1
   - name: 'Ultimate training ground.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/10667' ]
     dirty:
       - <<: *dirtyPlugin
         crc: 0x2de178ef

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -16334,6 +16334,7 @@ plugins:
         itm: 10
         udr: 1
   - name: 'WANDERINGNAZGUL.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/18338' ]
     dirty:
       - <<: *dirtyPlugin
         crc: 0x8a52aec8

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -16272,6 +16272,7 @@ plugins:
         udr: 4
         nav: 3
   - name: 'Vault of kingorc.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/20921' ]
     dirty:
       - <<: *dirtyPlugin
         crc: 0xd553054a

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -16251,6 +16251,7 @@ plugins:
         itm: 47
         udr: 48
   - name: 'Unmarked Places - Dragon Mounds.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/8521' ]
     dirty:
       - <<: *dirtyPlugin
         crc: 0xe80f1ad2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -16279,6 +16279,7 @@ plugins:
         itm: 31
         udr: 73
   - name: 'VeiledKeep.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/24752' ]
     dirty:
       - <<: *dirtyPlugin
         crc: 0x4d96fdc8

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -16258,6 +16258,7 @@ plugins:
         itm: 52
         udr: 4
   - name: 'UpkeptUnderkeep.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/11083' ]
     dirty:
       - <<: *dirtyPlugin
         crc: 0xf6e10e47

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -16227,11 +16227,6 @@ plugins:
         itm: 15
         udr: 4448
         nav: 1
-  - name: 'Ultimate HD Fire Spells.esp'
-    dirty:
-      - <<: *dirtyPlugin
-        crc: 0xe79bb5ef
-        udr: 3
   - name: 'Ultimate training ground.esp'
     dirty:
       - <<: *dirtyPlugin

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -16271,11 +16271,6 @@ plugins:
         itm: 62
         udr: 4
         nav: 3
-  - name: 'Vampire Slavers Den.esp'
-    dirty:
-      - <<: *dirtyPlugin
-        crc: 0x47aa2819
-        itm: 4
   - name: 'Vault of kingorc.esp'
     dirty:
       - <<: *dirtyPlugin

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -16244,6 +16244,7 @@ plugins:
         udr: 1
         nav: 2
   - name: 'Unique Places.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/15310' ]
     dirty:
       - <<: *dirtyPlugin
         crc: 0x43524f9f

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -16236,6 +16236,7 @@ plugins:
   - name: 'Ultimate Witcher MOD.esp'
     tag: [ Relev ]
   - name: 'underbreeze.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/13476' ]
     dirty:
       - <<: *dirtyPlugin
         crc: 0x749fbdac


### PR DESCRIPTION
`UDO.esm` and `UDOchestless.esp` are no longer available. They were mentioned [here](https://github.com/loot/skyrim/issues/457).