### PR TITLE
Update Witcher2 plugins

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9844,8 +9844,9 @@ plugins:
             text: 'На странице загрузки автор утверждает, что броня может вызвать вылет игры, но не уточняет, какой esp вызывает его.'
       - *obsolete
     dirty:
-      - <<: *dirtyPlugin
-        crc: 0x6f9af605
+      - <<: *quickClean
+        crc: 0x6F9AF605
+        util: '[TES5Edit v4.0.3g](https://www.nexusmods.com/skyrim/mods/25859)'
         udr: 4
   - name: 'Witcher2-v3.0 La Valette-Reach.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/22054' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9830,6 +9830,7 @@ plugins:
       - <<: *corrupt
         condition: 'checksum("WereWolfRing.esp",730A89B3)'
   - name: 'Witcher2-v3.0 Aedirn-Whiterun.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/22054' ]
     msg:
       - type: warn
         content:
@@ -9847,6 +9848,7 @@ plugins:
         crc: 0x6f9af605
         udr: 4
   - name: 'Witcher2-v3.0 La Valette-Reach.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/22054' ]
     msg:
       - type: warn
         content:
@@ -9859,6 +9861,7 @@ plugins:
           - lang: ru
             text: 'На странице загрузки автор утверждает, что броня может вызвать вылет игры, но не уточняет, какой esp вызывает его.'
   - name: 'Witcher2-v3.0 Nilfgaard-Pale.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/22054' ]
     msg:
       - type: warn
         content:
@@ -9875,6 +9878,7 @@ plugins:
         crc: 0xb44cf9de
         udr: 1
   - name: 'Witcher2-v3.0 Redania-Haarfingar.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/22054' ]
     msg:
       - type: warn
         content:
@@ -9888,6 +9892,7 @@ plugins:
             text: 'На странице загрузки автор утверждает, что броня может вызвать вылет игры, но не уточняет, какой esp вызывает его.'
       - *obsolete
   - name: 'Witcher2-v3.0 Temeria-Eastmarsh.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/22054' ]
     msg:
       - type: warn
         content:
@@ -9901,6 +9906,7 @@ plugins:
             text: 'На странице загрузки автор утверждает, что броня может вызвать вылет игры, но не уточняет, какой esp вызывает его.'
       - *obsolete
   - name: 'Witcher2-v3.0 Ulfric-Roche.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/22054' ]
     msg:
       - type: warn
         content:
@@ -9913,6 +9919,7 @@ plugins:
           - lang: ru
             text: 'На странице загрузки автор утверждает, что броня может вызвать вылет игры, но не уточняет, какой esp вызывает его.'
   - name: 'Witcher2-v3.0 Viperassassin-DB.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/22054' ]
     msg:
       - type: warn
         content:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9832,16 +9832,7 @@ plugins:
   - name: 'Witcher2-v3.0 Aedirn-Whiterun.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/22054' ]
     msg:
-      - type: warn
-        content:
-          - lang: en
-            text: 'Author states on download page that CTDs occur when player wears an armor.  He does not say which esp causes this.'
-          - lang: de
-            text: 'Der Autor gibt auf der Download-Seite an, dass CTDs auftreten, wenn der Spieler eine Rüstung trägt. Er sagt nicht, welche esp dies verursacht.'
-          - lang: ja
-            text: 'ダウンロードページにて製作者より、プレイヤーが防具を装備したときにCTDが発生すると言及されています。どのEspがCTDを引き起こすのかは述べられていません。'
-          - lang: ru
-            text: 'На странице загрузки автор утверждает, что броня может вызвать вылет игры, но не уточняет, какой esp вызывает его.'
+      - *corrupt
       - *obsolete
     dirty:
       - <<: *quickClean
@@ -9850,30 +9841,10 @@ plugins:
         udr: 4
   - name: 'Witcher2-v3.0 La Valette-Reach.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/22054' ]
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            text: 'Author states on download page that CTDs occur when player wears an armor.  He does not say which esp causes this.'
-          - lang: de
-            text: 'Der Autor gibt auf der Download-Seite an, dass CTDs auftreten, wenn der Spieler eine Rüstung trägt. Er sagt nicht, welche esp dies verursacht.'
-          - lang: ja
-            text: 'ダウンロードページにて製作者より、プレイヤーが防具を装備したときにCTDが発生すると言及されています。どのEspがCTDを引き起こすのかは述べられていません。'
-          - lang: ru
-            text: 'На странице загрузки автор утверждает, что броня может вызвать вылет игры, но не уточняет, какой esp вызывает его.'
+    msg: [ *corrupt ]
   - name: 'Witcher2-v3.0 Nilfgaard-Pale.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/22054' ]
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            text: 'Author states on download page that CTDs occur when player wears an armor.  He does not say which esp causes this.'
-          - lang: de
-            text: 'Der Autor gibt auf der Download-Seite an, dass CTDs auftreten, wenn der Spieler eine Rüstung trägt. Er sagt nicht, welche esp dies verursacht.'
-          - lang: ja
-            text: 'ダウンロードページにて製作者より、プレイヤーが防具を装備したときにCTDが発生すると言及されています。どのEspがCTDを引き起こすのかは述べられていません。'
-          - lang: ru
-            text: 'На странице загрузки автор утверждает, что броня может вызвать вылет игры, но не уточняет, какой esp вызывает его.'
+    msg: [ *corrupt ]
     dirty:
       - <<: *quickClean
         crc: 0xB44CF9DE
@@ -9882,57 +9853,19 @@ plugins:
   - name: 'Witcher2-v3.0 Redania-Haarfingar.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/22054' ]
     msg:
-      - type: warn
-        content:
-          - lang: en
-            text: 'Author states on download page that CTDs occur when player wears an armor.  He does not say which esp causes this.'
-          - lang: de
-            text: 'Der Autor gibt auf der Download-Seite an, dass CTDs auftreten, wenn der Spieler eine Rüstung trägt. Er sagt nicht, welche esp dies verursacht.'
-          - lang: ja
-            text: 'ダウンロードページにて製作者より、プレイヤーが防具を装備したときにCTDが発生すると言及されています。どのEspがCTDを引き起こすのかは述べられていません。'
-          - lang: ru
-            text: 'На странице загрузки автор утверждает, что броня может вызвать вылет игры, но не уточняет, какой esp вызывает его.'
+      - *corrupt
       - *obsolete
   - name: 'Witcher2-v3.0 Temeria-Eastmarsh.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/22054' ]
     msg:
-      - type: warn
-        content:
-          - lang: en
-            text: 'Author states on download page that CTDs occur when player wears an armor.  He does not say which esp causes this.'
-          - lang: de
-            text: 'Der Autor gibt auf der Download-Seite an, dass CTDs auftreten, wenn der Spieler eine Rüstung trägt. Er sagt nicht, welche esp dies verursacht.'
-          - lang: ja
-            text: 'ダウンロードページにて製作者より、プレイヤーが防具を装備したときにCTDが発生すると言及されています。どのEspがCTDを引き起こすのかは述べられていません。'
-          - lang: ru
-            text: 'На странице загрузки автор утверждает, что броня может вызвать вылет игры, но не уточняет, какой esp вызывает его.'
+      - *corrupt
       - *obsolete
   - name: 'Witcher2-v3.0 Ulfric-Roche.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/22054' ]
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            text: 'Author states on download page that CTDs occur when player wears an armor.  He does not say which esp causes this.'
-          - lang: de
-            text: 'Der Autor gibt auf der Download-Seite an, dass CTDs auftreten, wenn der Spieler eine Rüstung trägt. Er sagt nicht, welche esp dies verursacht.'
-          - lang: ja
-            text: 'ダウンロードページにて製作者より、プレイヤーが防具を装備したときにCTDが発生すると言及されています。どのEspがCTDを引き起こすのかは述べられていません。'
-          - lang: ru
-            text: 'На странице загрузки автор утверждает, что броня может вызвать вылет игры, но не уточняет, какой esp вызывает его.'
+    msg: [ *corrupt ]
   - name: 'Witcher2-v3.0 Viperassassin-DB.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/22054' ]
-    msg:
-      - type: warn
-        content:
-          - lang: en
-            text: 'Author states on download page that CTDs occur when player wears an armor.  He does not say which esp causes this.'
-          - lang: de
-            text: 'Der Autor gibt auf der Download-Seite an, dass CTDs auftreten, wenn der Spieler eine Rüstung trägt. Er sagt nicht, welche esp dies verursacht.'
-          - lang: ja
-            text: 'ダウンロードページにて製作者より、プレイヤーが防具を装備したときにCTDが発生すると言及されています。どのEspがCTDを引き起こすのかは述べられていません。'
-          - lang: ru
-            text: 'На странице загрузки автор утверждает, что броня может вызвать вылет игры, но не уточняет, какой esp вызывает его.'
+    msg: [ *corrupt ]
   - name: 'WolfArmorLightSA.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/20226' ]
     dirty:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9829,6 +9829,23 @@ plugins:
     msg:
       - <<: *corrupt
         condition: 'checksum("WereWolfRing.esp",730A89B3)'
+
+  - name: 'Witcher2-v3.5 Aedirn-Whiterun.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/22054' ]
+    clean:
+      - crc: 0xFCF870B7
+        util: 'TES5Edit v4.0.3g'
+  - name: 'Witcher2-v3.5 Temeria-Eastmarsh.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/22054' ]
+    clean:
+      - crc: 0x5DEE1CFD
+        util: 'TES5Edit v4.0.3g'
+  - name: 'Witcher2-v3.5 Redania-Imperial.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/22054' ]
+    clean:
+      - crc: 0x4EE5DD11
+        util: 'TES5Edit v4.0.3g'
+
   - name: 'Witcher2-v3.0 Aedirn-Whiterun.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/22054' ]
     msg:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9875,8 +9875,9 @@ plugins:
           - lang: ru
             text: 'На странице загрузки автор утверждает, что броня может вызвать вылет игры, но не уточняет, какой esp вызывает его.'
     dirty:
-      - <<: *dirtyPlugin
-        crc: 0xb44cf9de
+      - <<: *quickClean
+        crc: 0xB44CF9DE
+        util: '[TES5Edit v4.0.3g](https://www.nexusmods.com/skyrim/mods/25859)'
         udr: 1
   - name: 'Witcher2-v3.0 Redania-Haarfingar.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/22054' ]


### PR DESCRIPTION
[Modpage](https://www.nexusmods.com/skyrim/mods/22054)

Replace the custom messages with the `corrupt` message, as potentially all old files (that are within the "Old Files" category on the Nexus mod page) can cause a CTD, and it's not stated if only specific ones cause a CTD.

Also adds cleaning info on the latest version v3.5 (plugins are clean).

Under https://github.com/loot/skyrim/issues/454