### PR TITLE
Remove BBP_ArmorPack2.esp

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7315,8 +7315,6 @@ plugins:
         subs: [ 'Blacksmiths Guild - HothTroopers Custom Armour Sets' ]
         condition: 'file("SG_HothTrooper.esp")'
 
-  - name: 'BBP_ArmorPack2.esp'
-    msg: [ *requiresCHSBHC ]
   - name: 'BDYEB.esp'
     tag: [ Relev ]
   - name: 'Berserk Black Swordsman Armor( - No Arm)?\.esp'


### PR DESCRIPTION
v111v111 contribution - https://github.com/loot/skyrim/issues/196

As it turns out, this plugin is from a mod that very likely packaged various armors without permissions.