### PR TITLE
Update Castle Dar Khuun

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -12066,10 +12066,7 @@ plugins:
         util: '[TES5Edit v4.0.2f](https://www.nexusmods.com/skyrim/mods/25859)'
         nav: 1
   - name: 'CastleDKmaster.esp'
-    req:
-      - name: 'SkyMoMod.esm'
-        display: '[Skyrim Monster Mod](http://www.nexusmods.com/skyrim/mods/35631)'
-  - name: 'CastleDKmod.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/22020' ]
     req:
       - name: 'SkyMoMod.esm'
         display: '[Skyrim Monster Mod](http://www.nexusmods.com/skyrim/mods/35631)'


### PR DESCRIPTION
v111v111 contribution - https://github.com/loot/skyrim/issues/196

[Castle Dar Khuun](https://www.nexusmods.com/skyrim/mods/22020)
`CastleDKmod.esp` is the old & unavailable v1.2 of CDK.