### PR TITLE
Remove Better Warzones Soldier Uniforms

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -15732,19 +15732,6 @@ plugins:
     msg:
       - <<: *obsolete
         condition: 'version("WARZONES - Civil Unrest.esp", "2015.2", <)'
-  - name: 'Better Warzones Soldier Uniforms.esp'
-    msg:
-      - <<: *requiresX
-        type: say
-        subs: [ '[WARZONES](http://www.nexusmods.com/skyrim/mods/9494)' ]
-  - name: 'Better Warzones Soldier Uniforms With Cloaks.esp'
-    msg:
-      - <<: *requiresX
-        type: say
-        subs: [ '[WARZONES](http://www.nexusmods.com/skyrim/mods/9494)' ]
-      - <<: *requiresX
-        type: say
-        subs: [ '[Cloaks of Skyrim](http://www.nexusmods.com/skyrim/mods/12092)' ]
   - name: 'waterstonemanor.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/37631' ]
     dirty:


### PR DESCRIPTION
v111v111 contribution - https://github.com/loot/skyrim/issues/196

[Better WARZONES Soldier Uniforms](https://www.nexusmods.com/skyrim/mods/17685)

Removing this plugin entry alltogether, as it has a low number of total downloads on the one hand, and on the other one requires a heavily outdated version of Warzones - Civil Unrest.