### PR TITLE
Remove alreadyInSexierHousecarls message anchor and related messages

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -92,10 +92,6 @@ common:
     <<: *alreadyInX
     condition: 'file("Pretty Followers.esm")'
     subs: [ 'Pretty Followers' ]
-  - &alreadyInSexierHousecarls
-    <<: *alreadyInX
-    condition: 'file("Sexier Housecarls.esp")'
-    subs: [ 'Sexier Housecarls.esp' ]
   - &alreadyInSIDTComplete
     <<: *alreadyInX
     condition: 'file("SIDT - Complete.esp")'
@@ -22731,24 +22727,14 @@ plugins:
         itm: 6
   - name: 'herman.esp'
     inc: [ 'UFO - Ultimate Follower Overhaul.esp' ]
-  - name: 'HousecarlMarkath.esp'
-    msg: [ *alreadyInSexierHousecarls ]
-  - name: 'HousecarlRiften.esp'
-    msg: [ *alreadyInSexierHousecarls ]
   - name: 'HousecarlRiften Sexy Iona v0.2.esp'
     msg:
       - <<: *corrupt
         condition: 'checksum("HousecarlRiften Sexy Iona v0.2.esp",F01CB142)'
-  - name: 'HousecarlSolitude.esp'
-    msg: [ *alreadyInSexierHousecarls ]
   - name: 'HousecarlSolitude  A Jordis the Sword-Maiden v0.2.esp'
     msg:
       - <<: *corrupt
         condition: 'checksum("HousecarlSolitude  A Jordis the Sword-Maiden v0.2.esp",DAAD5080)'
-  - name: 'HousecarlWhiterun.esp'
-    msg: [ *alreadyInSexierHousecarls ]
-  - name: 'HousecarlWindhelm.esp'
-    msg: [ *alreadyInSexierHousecarls ]
   - name: 'HousecarlWhiterun Sexy Lydia v0.3.esp'
     msg: [ *obsolete ]
   - name: 'HousecarlWhiterun Sexy Lydia v0.5.esp'


### PR DESCRIPTION
The mod [Sexier Housecarls](https://www.nexusmods.com/skyrim/mods/20158) was hidden.

Also under https://github.com/loot/skyrim/issues/196 because `ArkangelCorvus` [submitted](https://github.com/boss-developers/skyrim/commit/a03d10d94b20573dbbcdc2cc563e38c483361044) the following plugins with a message that they were redundant if Sexier Housecarls was also present.
```yaml
HousecarlMarkath.esp
HousecarlRiften.esp
HousecarlSolitude.esp
HousecarlWhiterun.esp
HousecarlWindhelm.esp
```