### PR TITLE
Remove Riften Bigger Trees

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -17424,11 +17424,6 @@ plugins:
             text: 'Возможны конфликты с Vendor-версией мода Магия мидаса в Скайриме, используйте Reactor-версию.'
         condition: 'file("MidasSkyrim.esp")'
     tag: [ Relev ]
-  - name: 'Riften Bigger Trees.esp'
-    dirty:
-      - <<: *dirtyPlugin
-        crc: 0xa7e66f55
-        itm: 10
   - name: 'Safely Thrall.esp'
     msg: [ *obsolete ]
   - name: 'Serana Vampire Lord Bloodcursed After Cure.esp'
@@ -17441,16 +17436,6 @@ plugins:
     msg: [ *alreadyInSIDTComplete ]
   - name: 'SilentRuneSpellsUncap_v100.esp'
     inc: [ 'SilentRuneSpells_v100.esp' ]
-  - name: 'Skyrim bigger trees.esp'
-    inc: [ 'Riften Bigger Trees.esp' ]
-    dirty:
-      - <<: *dirtyPlugin
-        crc: 0x7faad905
-        itm: 1
-      - <<: *dirtyPlugin
-        crc: 0xa36a4e87
-        itm: 32
-        udr: 18
   - name: 'Skyrim Survival Suite - Nourriture.esp'
     dirty:
       - <<: *dirtyPlugin


### PR DESCRIPTION
Calen Ellefson - https://github.com/loot/skyrim/issues/196

The dirty info is outdated and can safely be removed.