### PR TITLE
Remove obsolete plugin: PrvtI_HeavyArmory_DG_Addon.esp

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9080,10 +9080,6 @@ plugins:
       # version: 3.3
       - crc: 0x613D10C8
         util: 'TES5Edit v4.0.1'
-  - name: 'PrvtI_HeavyArmory_DG_Addon.esp'
-    tag:
-      - Delev
-      - Relev
   - name: 'Guard Weapons - Heavy Armory - Halberds.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/34674' ]
     msg:


### PR DESCRIPTION
Under https://github.com/loot/skyrim/issues/196

Torrello contribution