### PR TITLE
Remove link to deleted mod page: skyBirds

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6345,8 +6345,6 @@ plugins:
     req: [ *SKSE ]
   - name: 'skyBirds - Airborne Perching Birds.esp'
     url:
-      - link: 'https://www.nexusmods.com/skyrim/mods/23771'
-        name: 'skyBirds - Airborne Perching Birds'
       - link: 'https://www.nexusmods.com/skyrim/mods/76065'
         name: 'skyBirds USLEEP Performance Patches'
     after:


### PR DESCRIPTION
Under https://github.com/loot/skyrim/issues/196

Torrello contribution

While [skyBirds](https://www.nexusmods.com/skyrim/mods/23771) is gone, the second link still works.