### PR TITLE
Remove obsolete plugin: CrossbowsRevamped70pctnospawn.esp

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -5041,10 +5041,6 @@ plugins:
         crc: 0xFB9BC01A
         util: '[TES5Edit v4.0.2j](https://www.nexusmods.com/skyrim/mods/25859)'
         itm: 2
-  - name: 'CrossbowsRevamped70pctnospawn.esp'
-    tag:
-      - Delev
-      - Relev
   - name: 'Cumulable Blessings.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/21048' ]
     inc:


### PR DESCRIPTION
Under https://github.com/loot/skyrim/issues/196

Torrello contribution