### PR TITLE
Remove unsourceable mod: Better Sorting_DV v1.3.esp

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -16441,10 +16441,6 @@ plugins:
     msg:
       - <<: *corrupt
         condition: 'checksum("Better Sorting FR EB 1.12.esp",097D3033)'
-  - name: 'Better Sorting_DV v1.3.esp'
-    msg:
-      - <<: *corrupt
-        condition: 'checksum("Better Sorting_DV v1.3.esp",95CEEFCB)'
   - name: 'Headbomb''s Better Sorting -- DE (by sheijian) v1.03.esp'
     msg:
       - <<: *corrupt


### PR DESCRIPTION
Under https://github.com/loot/skyrim/issues/196

Torrello contribution