### PR TITLE
Update Requiem Patch Central

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -10197,7 +10197,6 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrim/mods/61621' ]
     after:
       - 'Fozars_Dragonborn_-_Requiem_Patch.esp'
-      - 'Requiem - Minor Arcana - Civil War.esp'
       - 'Requiem - Minor Arcana - Vigilants of Stendarr.esp'
       - 'Requiem - Warmonger Armory.esp'
   - name: 'Requiem - Scoped Bows.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -10208,11 +10208,6 @@ plugins:
       - 'Fozars_Dragonborn_-_Requiem_Patch.esp'
       - 'Requiem - Cutting Room Floor.esp'
       - 'Requiem - ESF Companions.esp'
-  - name: 'Requiem - Talos Housecarl Armor.esp'
-    url: [ 'https://www.nexusmods.com/skyrim/mods/61621' ]
-    after:
-      - 'Requiem - Minor Arcana - Civil War.esp'
-      - 'Requiem - Royal Armory.esp'
   - name: 'Requiem - Rough Leather Armor.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/61621' ]
     after: [ 'Fozars_Dragonborn_-_Requiem_Patch.esp' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -10207,11 +10207,8 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrim/mods/61621' ]
     after:
       - 'Fozars_Dragonborn_-_Requiem_Patch.esp'
-      - 'Requiem - Audio Overhaul for Skyrim.esp'
       - 'Requiem - Cutting Room Floor.esp'
       - 'Requiem - ESF Companions.esp'
-      - 'Requiem - Immersive Sounds Compendium.esp'
-      - 'Requiem - Minor Arcana - Roleplaying.esp'
   - name: 'Requiem - Talos Housecarl Armor.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/61621' ]
     after:


### PR DESCRIPTION
Remove `after` for load order advice of the form "Should be loaded after "Requiem - Royal Armory.esp". Manual conflict resolution is advised for advanced users." because neither order resolves all conflicts.