### PR TITLE
Maintenance Update 23

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -14970,6 +14970,7 @@ plugins:
         udr: 32
         nav: 3
   - name: 'Stoop Vlindrel Hall.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/26856' ]
     dirty:
       - <<: *dirtyPlugin
         crc: 0x3a4b94a0

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -14977,6 +14977,7 @@ plugins:
         itm: 9
         nav: 1
   - name: 'Stormreach Mansion.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/22499' ]
     dirty:
       - <<: *dirtyPlugin
         crc: 0x973c7cf3

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -14928,6 +14928,7 @@ plugins:
       - <<: *obsolete
         condition: 'version("SovngardeNordHeroes.esp","1.3",<)'
   - name: 'SovngardeQuest.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/20581' ]
     dirty:
       - <<: *dirtyPlugin
         crc: 0xd50921f7

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -14951,6 +14951,7 @@ plugins:
         crc: 0xfdd3c5fd
         itm: 13
   - name: 'Stegdon''s Book Collection.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/12237' ]
     msg:
       - <<: *obsolete
         condition: 'checksum("Stegdon''s Book Collection.esp",A53FC583)'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -14879,22 +14879,26 @@ plugins:
         crc: 0x72642247
         itm: 1
   - name: 'someprivacyplease_bedroomwall_lakeview.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/32563' ]
     dirty:
       - <<: *dirtyPlugin
         crc: 0x561179ae
         itm: 11
   - name: 'someprivacyplease_bedroomwall_pale.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/32563' ]
     dirty:
       - <<: *dirtyPlugin
         crc: 0x8151cf7f
         itm: 2
   - name: 'someprivacyplease_door_hjaalmarch.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/32563' ]
     dirty:
       - <<: *dirtyPlugin
         crc: 0x1c5c73b5
         itm: 3
         udr: 4
   - name: 'someprivacyplease_door_Lakeview.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/32563' ]
     dirty:
       - <<: *dirtyPlugin
         crc: 0xf02fe87b

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -14858,10 +14858,12 @@ plugins:
         crc: 0xdc320f38
         itm: 13
   - name: 'soldynemuseum.esp'
+    url: [ 'https://steamcommunity.com/sharedfiles/filedetails/?id=77638317' ]
     dirty:
-      - <<: *dirtyPlugin
-        crc: 0x3b1f7505
-        itm: 11
+      - <<: *quickClean
+        crc: 0x3B1F7505
+        util: '[TES5Edit v4.0.3h (Hotfix 1)](https://www.nexusmods.com/skyrim/mods/25859)'
+        itm: 34
   - name: 'SolitudeBetterDocks-SoG-Compatible Version.esp'
     inc: [ 'SolitudeBetterDocks.esp' ]
   - name: 'UAL002_solitude_smelter01.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -14961,11 +14961,6 @@ plugins:
         itm: 10
         udr: 11
         nav: 35
-  - name: 'StillbornKingdom.esp'
-    dirty:
-      - <<: *dirtyPlugin
-        crc: 0x856fb7e0
-        itm: 12
   - name: 'stockades.esp'
     dirty:
       - <<: *dirtyPlugin

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -14852,6 +14852,7 @@ plugins:
         crc: 0x3df856f3
         udr: 14
   - name: 'SnowberryCottage.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/16366' ]
     dirty:
       - <<: *dirtyPlugin
         crc: 0xdc320f38

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -14945,6 +14945,7 @@ plugins:
   - name: 'Stag''sRest.esp'
     inc: [ 'Cabin in the woods.esp' ]
   - name: 'SteezMyster''s Dungeon.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/20921' ]
     dirty:
       - <<: *dirtyPlugin
         crc: 0xfdd3c5fd

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -14904,6 +14904,7 @@ plugins:
         crc: 0xf02fe87b
         itm: 4
   - name: 'SoulForgeMysticArena.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/8971' ]
     dirty:
       - <<: *dirtyPlugin
         crc: 0x42e3cf2d

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -14846,6 +14846,7 @@ plugins:
         crc: 0xfa9e4ca
         udr: 61
   - name: 'Smaller Trees Markarth.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/11558' ]
     dirty:
       - <<: *dirtyPlugin
         crc: 0x3df856f3

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -14962,6 +14962,7 @@ plugins:
         udr: 11
         nav: 35
   - name: 'StonewallGarden3.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/29472' ]
     dirty:
       - <<: *dirtyPlugin
         crc: 0xa9a027a0

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -15002,12 +15002,16 @@ plugins:
       - *SKSE
       - *SkyUI
   - name: 'Sutvaka2.esp'
+    url:
+      - 'https://www.nexusmods.com/skyrim/mods/33473'
+      - 'https://www.nexusmods.com/skyrim/mods/73145'
     tag: [ Relev ]
     dirty:
       - <<: *dirtyPlugin
         crc: 0x90aeb6d4
         itm: 9
   - name: 'Sutvaka2 - HL.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/33473' ]
     tag: [ Relev ]
     dirty:
       - <<: *dirtyPlugin

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -15034,6 +15034,7 @@ plugins:
         crc: 0xb999c95d
         itm: 23
   - name: 'Sylvanheim.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/16599' ]
     dirty:
       - <<: *dirtyPlugin
         crc: 0x674a01b0

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -14867,6 +14867,7 @@ plugins:
   - name: 'SolitudeBetterDocks-SoG-Compatible Version.esp'
     inc: [ 'SolitudeBetterDocks.esp' ]
   - name: 'UAL002_solitude_smelter01.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/10407' ]
     dirty:
       - <<: *dirtyPlugin
         crc: 0xbaa337a

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -14857,11 +14857,6 @@ plugins:
       - <<: *dirtyPlugin
         crc: 0xdc320f38
         itm: 13
-  - name: 'So (84).esp'
-    dirty:
-      - <<: *dirtyPlugin
-        crc: 0x17486f2d
-        itm: 122
   - name: 'soldynemuseum.esp'
     dirty:
       - <<: *dirtyPlugin

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -14985,6 +14985,7 @@ plugins:
         udr: 7
         nav: 1
   - name: 'suncresthall.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/10380' ]
     dirty:
       - <<: *dirtyPlugin
         crc: 0xafea2e1

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -14873,6 +14873,7 @@ plugins:
         crc: 0xbaa337a
         itm: 11
   - name: 'SoLo Solace.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/20265' ]
     dirty:
       - <<: *dirtyPlugin
         crc: 0x72642247

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -14934,6 +14934,7 @@ plugins:
         crc: 0xd50921f7
         itm: 16
   - name: 'SSHjerimMod.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/32868' ]
     dirty:
       - <<: *dirtyPlugin
         crc: 0x6c605c36

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -14845,12 +14845,6 @@ plugins:
       - <<: *dirtyPlugin
         crc: 0xfa9e4ca
         udr: 61
-  - name: 'SM_PlayerHome.esp'
-    dirty:
-      - <<: *dirtyPlugin
-        crc: 0xccb96081
-        itm: 39
-        nav: 9
   - name: 'Smaller Trees Markarth.esp'
     dirty:
       - <<: *dirtyPlugin

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -15028,6 +15028,7 @@ plugins:
         itm: 9
         udr: 3
   - name: 'Syerscote.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/29381' ]
     dirty:
       - <<: *dirtyPlugin
         crc: 0xb999c95d

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -14961,11 +14961,6 @@ plugins:
         itm: 10
         udr: 11
         nav: 35
-  - name: 'stockades.esp'
-    dirty:
-      - <<: *dirtyPlugin
-        crc: 0x1429db61
-        itm: 3
   - name: 'StonewallGarden3.esp'
     dirty:
       - <<: *dirtyPlugin

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -14992,6 +14992,7 @@ plugins:
         itm: 48
         nav: 2
   - name: 'SuperSkyrimBros.esp'
+    url: [ 'https://www.nexusmods.com/skyrim/mods/24709' ]
     dirty:
       - <<: *dirtyPlugin
         crc: 0xac16f40


### PR DESCRIPTION
Under https://github.com/loot/skyrim/issues/312

I've found `SM_PlayerHome.esp`, which got removed in https://github.com/loot/skyrim/commit/aeae027d0dd881f8bc5e260edf62920620f8ff63, some time later here:
[Willow Creek Cottage by steezmyster](https://www.nexusmods.com/skyrim/mods/29313).

So while it technically wasn't `unsourceable`, the entry still doesn't need to be reintroduced to the masterlist, as the plugin only is to be found in old versions of the mod (the plugin name in the latest version is `SM_PlayerHome-Quest.esp`), we only featured cleaning data for the old version and the mod doesn't have many downloads to begin with.