### PR TITLE
Add empty space before CRC in checksum conditions

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1215,7 +1215,7 @@ plugins:
   - name: 'AP Skyrim.esm'
     msg:
       - <<: *obsolete
-        condition: 'checksum("AP Skyrim.esm",857D5AAC) or checksum("AP Skyrim.esm",CBE8B5C2)'
+        condition: 'checksum("AP Skyrim.esm", 857D5AAC) or checksum("AP Skyrim.esm", CBE8B5C2)'
   - name: 'archmageTrophyhall.esm'
     url: [ 'https://www.nexusmods.com/skyrim/mods/11123' ]
     dirty:
@@ -1397,7 +1397,7 @@ plugins:
       - 'Skyrim Project Optimization - Dragonborn.esm'
     msg:
       - type: warn
-        condition: 'checksum("ClimatesOfTamriel.esm",C30AB34E)'
+        condition: 'checksum("ClimatesOfTamriel.esm", C30AB34E)'
         content:
           - lang: en
             text: 'This plugin has improperly numbered FormIDs and may have some corruption because it was made with an older version (4.2 or 4.3.x) of TESVSnip.  Please use the [updated plugin](http://www.nexusmods.com/skyrim/mods/17802).'
@@ -1421,7 +1421,7 @@ plugins:
             text: 'Dieses Plugin hat falsch nummerierte FormIDs und ist möglicherweise beschädigt, da es mit einer älteren Version (4.2 oder 4.3.x) von TESVSnip erstellt wurde. Eine reparierte Version wurde an den Autor gesendet. Bitte suchen Sie nach einem Update.'
           - lang: ja
             text: 'このプラグインには不正な番号のFormIDが存在します。破損しているデータもあるかもしれません。これは古いバージョン(4.2 か 4.3.x)のTESVSnipで作られているためです。製作者まで修正版が送られていますので、今後の更新をお待ちください。'
-        condition: 'checksum("ClimatesOfTamriel-Dawnguard-Patch.esp",8F78567C)'
+        condition: 'checksum("ClimatesOfTamriel-Dawnguard-Patch.esp", 8F78567C)'
     clean:
       - crc: 0x9D7312A5
         util: 'TES5Edit v4.0.2f'
@@ -1436,7 +1436,7 @@ plugins:
             text: 'Dieses Plugin hat falsch nummerierte FormIDs und ist möglicherweise beschädigt, da es mit einer älteren Version (4.2 oder 4.3.x) von TESVSnip erstellt wurde. Eine reparierte Version wurde an den Autor gesendet. Bitte suchen Sie nach einem Update.'
           - lang: ja
             text: 'このプラグインには不正な番号のFormIDが存在します。破損しているデータもあるかもしれません。これは古いバージョン(4.2 か 4.3.x)のTESVSnipで作られているためです。製作者まで修正版が送られていますので、今後の更新をお待ちください。'
-        condition: 'checksum("ClimatesOfTamriel-Dragonborn-Patch.esp",81CF7754)'
+        condition: 'checksum("ClimatesOfTamriel-Dragonborn-Patch.esp", 81CF7754)'
     clean:
       - crc: 0x9FFF2A85
         util: 'TES5Edit v4.0.2f'
@@ -1478,7 +1478,7 @@ plugins:
             text: 'Dieses Plugin hat falsch nummerierte FormIDs und ist möglicherweise beschädigt, da es mit einer älteren Version (4.2 oder 4.3.x) von TESVSnip erstellt wurde. Eine reparierte Version wurde an den Autor gesendet. Bitte suchen Sie nach einem Update.'
           - lang: ja
             text: 'このプラグインには不正な番号のFormIDが存在します。破損しているデータもあるかもしれません。これは古いバージョン(4.2 か 4.3.x)のTESVSnipで作られているためです。製作者まで修正版が送られていますので、今後の更新をお待ちください。'
-        condition: 'checksum("ClimatesOfTamriel-Dungeons-Hazardous.esp",CBE304CE)'
+        condition: 'checksum("ClimatesOfTamriel-Dungeons-Hazardous.esp", CBE304CE)'
     clean:
       - crc: 0xBDC66F4C
         util: 'TES5Edit v4.0.2f'
@@ -1497,7 +1497,7 @@ plugins:
             text: 'Dieses Plugin hat falsch nummerierte FormIDs und ist möglicherweise beschädigt, da es mit einer älteren Version (4.2 oder 4.3.x) von TESVSnip erstellt wurde. Eine reparierte Version wurde an den Autor gesendet. Bitte suchen Sie nach einem Update.'
           - lang: ja
             text: 'このプラグインには不正な番号のFormIDが存在します。破損しているデータもあるかもしれません。これは古いバージョン(4.2 か 4.3.x)のTESVSnipで作られているためです。製作者まで修正版が送られていますので、今後の更新をお待ちください。'
-        condition: 'checksum("ClimatesOfTamriel-Interiors-Cold.esp",84DB3F8)'
+        condition: 'checksum("ClimatesOfTamriel-Interiors-Cold.esp", 84DB3F8)'
     clean:
       - crc: 0x80B61351
         util: 'TES5Edit v4.0.2f'
@@ -1516,7 +1516,7 @@ plugins:
             text: 'Dieses Plugin hat falsch nummerierte FormIDs und ist möglicherweise beschädigt, da es mit einer älteren Version (4.2 oder 4.3.x) von TESVSnip erstellt wurde. Eine reparierte Version wurde an den Autor gesendet. Bitte suchen Sie nach einem Update.'
           - lang: ja
             text: 'このプラグインには不正な番号のFormIDが存在します。破損しているデータもあるかもしれません。これは古いバージョン(4.2 か 4.3.x)のTESVSnipで作られているためです。製作者まで修正版が送られていますので、今後の更新をお待ちください。'
-        condition: 'checksum("ClimatesOfTamriel-Interiors-Warm.esp",77C47623)'
+        condition: 'checksum("ClimatesOfTamriel-Interiors-Warm.esp", 77C47623)'
     clean:
       - crc: 0xB61E85AE
         util: 'TES5Edit v4.0.2f'
@@ -1552,7 +1552,7 @@ plugins:
             text: 'Dieses Plugin hat falsch nummerierte FormIDs und ist möglicherweise beschädigt, da es mit einer älteren Version (4.2 oder 4.3.x) von TESVSnip erstellt wurde. Eine reparierte Version wurde an den Autor gesendet. Bitte suchen Sie nach einem Update.'
           - lang: ja
             text: 'このプラグインには不正な番号のFormIDが存在します。破損しているデータもあるかもしれません。これは古いバージョン(4.2 か 4.3.x)のTESVSnipで作られているためです。製作者まで修正版が送られていますので、今後の更新をお待ちください。'
-        condition: 'checksum("ClimatesOfTamriel-WinterEdition.esp",74DF3C5)'
+        condition: 'checksum("ClimatesOfTamriel-WinterEdition.esp", 74DF3C5)'
     clean:
       - crc: 0x1675469B
         util: 'TES5Edit v4.0.2f'
@@ -1751,7 +1751,7 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrim/mods/18916' ]
     msg:
       - <<: *patch3rdParty
-        condition: 'checksum("Lanterns Of Skyrim - All In One - Main.esm",AC4A653A) and active("Dawnguard.esm") and not active("Lanterns Of Skyrim - AIO - Dawnguard.esp")'
+        condition: 'checksum("Lanterns Of Skyrim - All In One - Main.esm", AC4A653A) and active("Dawnguard.esm") and not active("Lanterns Of Skyrim - AIO - Dawnguard.esp")'
         subs:
           - 'Dawnguard'
           - '[Lanterns of Skyrim - All in One - Dawnguard Patch](https://www.nexusmods.com/skyrim/mods/26662)'
@@ -1772,7 +1772,7 @@ plugins:
             text: 'Dies ist die falsche esm für LB_MuchAdoSnowElves_WeaponsOnly.esp.'
           - lang: ja
             text: 'LB_MuchAdoSnowElves_WeaponsOnly.esp用のEsmとは異なります。'
-        condition: 'file("LB_MuchAdoSnowElves_WeaponsOnly.esp") and checksum("LB_MuchAdoSnowElves.esm",9E22BEF7)'
+        condition: 'file("LB_MuchAdoSnowElves_WeaponsOnly.esp") and checksum("LB_MuchAdoSnowElves.esm", 9E22BEF7)'
   - name: 'LevelersTower.esm'
     url: [ 'https://www.nexusmods.com/skyrim/mods/14152' ]
     dirty:
@@ -2264,7 +2264,7 @@ plugins:
   - name: 'The Spice of Life.esm'
     msg:
       - type: warn
-        condition: 'checksum("The Spice of Life.esm",A75F2F6D)'
+        condition: 'checksum("The Spice of Life.esm", A75F2F6D)'
         content:
           - lang: en
             text: 'File not created with Creation Kit.'
@@ -2632,7 +2632,7 @@ plugins:
     msg:
       - *alreadyInOrFixedByUSLEEP
       - <<: *obsolete
-        condition: 'not checksum("CriticalChargeFix.esp",A35E7560)'
+        condition: 'not checksum("CriticalChargeFix.esp", A35E7560)'
       - <<: *alreadyInX
         condition: 'file("PerkUP-TwoHanded.esp")'
         subs: [ 'PerkUP-TwoHanded.esp' ]
@@ -3079,7 +3079,7 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrim/mods/12909' ]
     msg:
       - <<: *corrupt
-        condition: 'checksum("Faendal.esp",60930CE6) or checksum("Faendal.esp",C4A869DC)'
+        condition: 'checksum("Faendal.esp", 60930CE6) or checksum("Faendal.esp", C4A869DC)'
   - name: 'Hirelingrevamp.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/22616' ]
     dirty:
@@ -3095,7 +3095,7 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrim/mods/19409' ]
     msg:
       - <<: *corrupt
-        condition: 'checksum("Less Fugly Female NPCs.esp",93FE07E6)'
+        condition: 'checksum("Less Fugly Female NPCs.esp", 93FE07E6)'
   - name: 'marcurio1.1.esp'
     msg: [ *obsolete ]
   - name: 'marcurio2.esp'
@@ -3108,7 +3108,7 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrim/mods/14040' ]
     msg:
       - <<: *corrupt
-        condition: 'checksum("Tonilia.esp",1AEB51FC) or checksum("Tonilia.esp",914D89EB)'
+        condition: 'checksum("Tonilia.esp", 1AEB51FC) or checksum("Tonilia.esp", 914D89EB)'
     dirty:
       # v1.0
       - <<: *quickClean
@@ -3119,7 +3119,7 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrim/mods/14040' ]
     msg:
       - <<: *corrupt
-        condition: 'checksum("Vex.esp",CFCE4434)'
+        condition: 'checksum("Vex.esp", CFCE4434)'
   - name: 'Vilkas.esp'
     url:
       - 'https://www.nexusmods.com/skyrim/mods/10085'
@@ -3127,7 +3127,7 @@ plugins:
       - 'https://www.nexusmods.com/skyrim/mods/70299'
     msg:
       - <<: *corrupt
-        condition: 'checksum("Vilkas.esp",BF4211DE)'
+        condition: 'checksum("Vilkas.esp", BF4211DE)'
   - name: '1 Day Moon Phases.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/5801' ]
     dirty:
@@ -3227,7 +3227,7 @@ plugins:
   - name: 'PNENB.esp'
     msg:
       - <<: *useVersionNonDawnguard
-        condition: 'checksum("PNENB.esp",B8865296) and not file("Dawnguard.esm")'
+        condition: 'checksum("PNENB.esp", B8865296) and not file("Dawnguard.esm")'
   - name: 'Supreme Fog.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/24460' ]
     clean:
@@ -3248,7 +3248,7 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrim/mods/28016' ]
     msg:
       - <<: *useVersionDawnguard
-        condition: 'active("Dawnguard.esm") and not active("Dragonborn.esm") and ( checksum("ExpandedSnowSystems.esp",DB538BE0) or checksum("ExpandedSnowSystems.esp",74DF9966) )'
+        condition: 'active("Dawnguard.esm") and not active("Dragonborn.esm") and ( checksum("ExpandedSnowSystems.esp", DB538BE0) or checksum("ExpandedSnowSystems.esp", 74DF9966) )'
       - type: warn
         content:
           - lang: en
@@ -3357,7 +3357,7 @@ plugins:
             text: 'Dieses Plugin hat falsch nummerierte FormIDs und ist möglicherweise beschädigt, da es mit einer älteren Version (4.2 oder 4.3.x) von TESVSnip erstellt wurde. Eine ausgebesserte Version wurde an den Autor gesendet. Bitte suchen Sie nach einem Update.'
           - lang: ja
             text: 'このプラグインには不正な番号のFormIDが存在します。破損しているデータもあるかもしれません。これは古いバージョン(4.2 か 4.3.x)のTESVSnipで作られているためです。製作者まで修正版が送られていますので、今後の更新をお待ちください。'
-        condition: 'checksum("ClimatesOfTamriel-Sound.esp",47AF2A0B)'
+        condition: 'checksum("ClimatesOfTamriel-Sound.esp", 47AF2A0B)'
   - name: 'IceBreaker''s Improved Reverb.esp'
     msg: [ *obsolete ]
   - name: 'Immersive Sounds - Aural Assortment.esp'
@@ -3408,7 +3408,7 @@ plugins:
             text: 'Diese Mod scheint eine duplizierte Zelle zu haben. Möglicherweise verhält sich der Riften Ratway etwas ''verrückt''.'
           - lang: ja
             text: 'このModには重複したセルが存在するようです。リフテンのラットウェイがおかしなことになっているかもしれません。'
-        condition: 'checksum("better_torches.esp",9F5EA6E6) or checksum("better_torches.esp",96F75656)'
+        condition: 'checksum("better_torches.esp", 9F5EA6E6) or checksum("better_torches.esp", 96F75656)'
     clean:
       # v1.1
       - crc: 0xB7F684D4
@@ -3425,7 +3425,7 @@ plugins:
             text: 'Diese Mod scheint eine duplizierte Zelle zu haben. Möglicherweise verhält sich der Riften Ratway etwas ''verrückt''.'
           - lang: ja
             text: 'このModには重複したセルが存在するようです。リフテンのラットウェイがおかしなことになっているかもしれません。'
-        condition: 'checksum("better_torches_brighter_torchlight.esp",9BEBAD4D) or checksum("better_torches_brighter_torchlight.esp",CB5777CE)'
+        condition: 'checksum("better_torches_brighter_torchlight.esp", 9BEBAD4D) or checksum("better_torches_brighter_torchlight.esp", CB5777CE)'
     clean:
       # v1.1
       - crc: 0x29540D4F
@@ -3773,7 +3773,7 @@ plugins:
         content:
           - lang: ru
             text: 'Вы можете использовать данный esp для версии 1.20-1.26 и вероятно, более новых, если, в очередном обновлении SMIM, не последовало обновления esp.'
-        condition: 'checksum("StaticMeshImprovementMod.esp",8806A693)'
+        condition: 'checksum("StaticMeshImprovementMod.esp", 8806A693)'
   - name: 'SMIM-ShackRoofFixes.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/8655' ]
     clean:
@@ -3823,7 +3823,7 @@ plugins:
   - name: '_pocketempirebuilder.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("_pocketempirebuilder.esp",CCC24004)'
+        condition: 'checksum("_pocketempirebuilder.esp", CCC24004)'
   - name: 'Skyrim Adventurer''s Tent.esm'
     url:
       - link: 'https://www.nexusmods.com/skyrim/mods/15272/'
@@ -3932,7 +3932,7 @@ plugins:
   - name: 'arrowcrafting.esp'
     msg:
       - <<: *obsolete
-        condition: 'checksum("arrowcrafting.esp",8E307ED0) or checksum("arrowcrafting.esp",D15AE0C5)'
+        condition: 'checksum("arrowcrafting.esp", 8E307ED0) or checksum("arrowcrafting.esp", D15AE0C5)'
   - name: 'Arrowsmith\w{0,2}\.esp'
     msg:
       - *alreadyInSkyRe
@@ -3991,7 +3991,7 @@ plugins:
   - name: 'AvengersBosses.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("AvengersBosses.esp",806151D5)'
+        condition: 'checksum("AvengersBosses.esp", 806151D5)'
 
   ### Babettes Feast - Improved Cooking ###
   - name: 'BabettesFeast(Balanced|Overpowered|WeakerEffects)\.esp'
@@ -4047,7 +4047,7 @@ plugins:
   - name: 'PrometheusBeastSkeletons.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("Prometheus_BeastSkeletons.esp",42EE9442)'
+        condition: 'checksum("Prometheus_BeastSkeletons.esp", 42EE9442)'
   - name: 'Beauties of Skyrim.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/24296' ]
     dirty:
@@ -4196,9 +4196,9 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrim/mods/16846' ]
     msg:
       - <<: *useVersionNonDawnguard
-        condition: 'not active("Dawnguard.esm") and checksum("Bloody Cannibalism.esp",75D6B87E)'
+        condition: 'not active("Dawnguard.esm") and checksum("Bloody Cannibalism.esp", 75D6B87E)'
       - <<: *useVersionDawnguard
-        condition: 'active("Dawnguard.esm") and checksum("Bloody Cannibalism.esp",A220A80B)'
+        condition: 'active("Dawnguard.esm") and checksum("Bloody Cannibalism.esp", A220A80B)'
     dirty:
       # v0.11BETA
       - <<: *quickClean
@@ -4257,7 +4257,7 @@ plugins:
   - name: 'cao_DweSchematicsBuy.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("cao_DweSchematicsBuy.esp",7E85692A)'
+        condition: 'checksum("cao_DweSchematicsBuy.esp", 7E85692A)'
   - name: 'cao_DweSchematics(Buy|Cheat|Search)\.esp'
     msg:
       - <<: *useOnlyOneX
@@ -4266,11 +4266,11 @@ plugins:
   - name: 'cao_DweSchematicsCheat.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("cao_DweSchematicsCheat.esp",7E7B9B1A)'
+        condition: 'checksum("cao_DweSchematicsCheat.esp", 7E7B9B1A)'
   - name: 'cao_DweSchematicsSearch.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("cao_DweSchematicsSearch.esp",A655AB19)'
+        condition: 'checksum("cao_DweSchematicsSearch.esp", A655AB19)'
 
   - name: 'cao_goldbrand_WT.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/5830/' ]
@@ -4448,7 +4448,7 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrim/mods/21048' ]
     inc:
       - name: 'Dawnguard.esm'
-        condition: 'checksum("Cumulable Blessings.esp",DA1971DC)'
+        condition: 'checksum("Cumulable Blessings.esp", DA1971DC)'
     dirty:
       # v1.3.1 - English - Dawnguard required
       - <<: *quickClean
@@ -4536,7 +4536,7 @@ plugins:
     msg:
       - <<: *obsolete
         subs: [ '[Disease Descriptions for the Immersive Adventurer](http://www.nexusmods.com/skyrim/mods/31202).' ]
-        condition: 'not checksum("Disease Descriptions.esp",E199AED9)'
+        condition: 'not checksum("Disease Descriptions.esp", E199AED9)'
   - name: 'Don.?Juan.*\.esp'
     req: [ *FNIS ]
   - name: 'Dovahtracker.esp'
@@ -4773,9 +4773,9 @@ plugins:
   - name: 'Grind_stuff.esp'
     msg:
       - <<: *useVersionHearthFires
-        condition: 'active("HearthFires.esm") and checksum("Grind_stuff.esp",31CCFA29)'
+        condition: 'active("HearthFires.esm") and checksum("Grind_stuff.esp", 31CCFA29)'
       - <<: *useVersionNonHearthFires
-        condition: 'not active("HearthFires.esm") and checksum("Grind_stuff.esp",5E014754)'
+        condition: 'not active("HearthFires.esm") and checksum("Grind_stuff.esp", 5E014754)'
   - name: 'Guard Build (HF) 1.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/25140' ]
     dirty:
@@ -4937,15 +4937,15 @@ plugins:
   - name: 'HoodlessArchmageWithFixedStats.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("HoodlessArchmageWithFixedStats.esp",2DFEA856)'
+        condition: 'checksum("HoodlessArchmageWithFixedStats.esp", 2DFEA856)'
   - name: 'Houses_german.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("Houses_german.esp",D44E0189)'
+        condition: 'checksum("Houses_german.esp", D44E0189)'
   - name: 'Necessary Markers_german.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("Necessary Markers_german.esp",58DB7A80)'
+        condition: 'checksum("Necessary Markers_german.esp", 58DB7A80)'
 
   - name: 'Hunterborn.esp'
     url: [ 'http://www.nexusmods.com/skyrim/mods/33201/' ]
@@ -5088,7 +5088,7 @@ plugins:
   - name: 'Langsam wirkende Tränke.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("Langsam wirkende Tränke.esp",163A3470)'
+        condition: 'checksum("Langsam wirkende Tränke.esp", 163A3470)'
   - name: '(LanternsOfSkyrimELFXpatch|Vivid Weathers - Lanterns of Skyrim Preset|Vividian - Lanterns of Skyrim Preset|Lanterns Of Skyrim - All In One - (Vivida ENB)?(The Goddess ENB|The Goddess v2dot2)?(Somber ENB)?(RLO)?(Cold Skyrim ENB)?(Climates of Tamriel - )?(1_5x Brighter|2x Brighter|Default)?(RCRN )?(Magic Light|lvl-\d|Hyper Purist|Classic|Legacy|Pure)?(Skylight)?)\.esp'
     msg:
       - <<: *useOnlyOneX
@@ -5221,7 +5221,7 @@ plugins:
   - name: 'marader.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("marader.esp",AAC47B36)'
+        condition: 'checksum("marader.esp", AAC47B36)'
   - name: 'Marco''s Integrated Leveled Lists.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/34184' ]
     tag:
@@ -5401,7 +5401,7 @@ plugins:
             text: 'Wenn diese Datei nicht neuer als v1.2.2 ist, aktualisieren Sie sie auf die neueste Version.'
           - lang: ja
             text: 'バージョンが1.2.2未満の場合は最新版に更新してください。'
-        condition: 'not checksum("People Have Lanterns.esp",DC3B2BAE)'
+        condition: 'not checksum("People Have Lanterns.esp", DC3B2BAE)'
   - name: 'People Have Torches.esp'
     inc: [ 'People Have Lanterns.esp' ]
     msg:
@@ -5413,7 +5413,7 @@ plugins:
             text: 'Wenn diese Datei nicht neuer als v1.2.2 ist, aktualisieren Sie sie auf die neueste Version.'
           - lang: ja
             text: 'バージョンが1.2.2未満の場合は最新版に更新してください。'
-        condition: 'not checksum("People Have Torches.esp",7E5D2415)'
+        condition: 'not checksum("People Have Torches.esp", 7E5D2415)'
   - name: 'Perks Unbound.esp'
     msg:
       - type: say
@@ -5798,7 +5798,7 @@ plugins:
       - 'SleepingDangers-SandsofTime.esp'
     inc:
       - name: 'Skyrim Immersive Creatures.esm'
-        condition: 'not checksum("Skyrim Immersive Creatures.esp",2EEAD88A)'
+        condition: 'not checksum("Skyrim Immersive Creatures.esp", 2EEAD88A)'
     msg:
       - type: say
         content:
@@ -5808,7 +5808,7 @@ plugins:
             text: 'Dies ist die Lore-Freundliche-Version von jackstarr. Verwenden Sie nicht die Original esp oder esm von lifestorock.'
           - lang: ja
             text: 'このEspはjackstarr氏によるロアフレンドリーバージョンです。lifestorock氏によるオリジナル版のEspもしくはEsmは使用しないでください。'
-        condition: 'checksum("Skyrim Immersive Creatures.esp",2EEAD88A)'
+        condition: 'checksum("Skyrim Immersive Creatures.esp", 2EEAD88A)'
       - *patchUnavailableRequiem
     tag:
       - Delev
@@ -5827,7 +5827,7 @@ plugins:
             text: 'Dieses Addon ist für die Verwendung mit Skyrim Immersive Creatures.esm vorgesehen, nicht mit Skyrim Immersive Creatures.esp.'
           - lang: ja
             text: 'Skyrim Immersive Creatures.esm用のアドオンです。Skyrim Immersive Creatures.esp用ではありません。'
-        condition: 'checksum("Skyrim Immersive Creatures - DLC2.esp",C64CF88A) and not active("Skyrim Immersive Creatures.esm")'
+        condition: 'checksum("Skyrim Immersive Creatures - DLC2.esp", C64CF88A) and not active("Skyrim Immersive Creatures.esm")'
     tag:
       - Delev
       - Relev
@@ -5874,7 +5874,7 @@ plugins:
   - name: 'Skyrim Expanded Loot Tables.esp'
     msg:
       - <<: *obsolete
-        condition: 'checksum("Skyrim Expanded Loot Tables.esp",24E08D9F)'
+        condition: 'checksum("Skyrim Expanded Loot Tables.esp", 24E08D9F)'
   - name: 'Skyrim Expanded Loot Tables - Lower Drop Rate.esp'
     inc: [ 'Skyrim Expanded Loot Tables.esp' ]
   - name: 'Skyrim Flora Overhaul.esp'
@@ -5951,10 +5951,10 @@ plugins:
   - name: 'Statues.esp'
     msg:
       - <<: *useVersionHearthFires
-        condition: 'active("HearthFires.esm") and checksum("Statues.esp",C08BE2C5)'
+        condition: 'active("HearthFires.esm") and checksum("Statues.esp", C08BE2C5)'
       - <<: *useVersion
         subs: [ 'Vanilla' ]
-        condition: 'not active("HearthFires.esm") and checksum("Statues.esp",5081E67A)'
+        condition: 'not active("HearthFires.esm") and checksum("Statues.esp", 5081E67A)'
   - name: 'SteamAchievementUnlocker.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/20851' ]
     dirty:
@@ -6236,9 +6236,9 @@ plugins:
   - name: 'Destructible_bottles.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("Destructible_bottles.esp",33A7D490)'
+        condition: 'checksum("Destructible_bottles.esp", 33A7D490)'
       - <<: *obsolete
-        condition: 'checksum("Destructible_bottles.esp",BF5ED5A9) or checksum("Destructible_bottles.esp",0900B364) or checksum("Destructible_bottles.esp",48639563) or checksum("Destructible_bottles.esp",078C74DD) or checksum("Destructible_bottles.esp",5BE52467) or checksum("Destructible_bottles.esp",D59FAF05) or checksum("Destructible_bottles.esp",D80876E8)'
+        condition: 'checksum("Destructible_bottles.esp", BF5ED5A9) or checksum("Destructible_bottles.esp", 0900B364) or checksum("Destructible_bottles.esp", 48639563) or checksum("Destructible_bottles.esp", 078C74DD) or checksum("Destructible_bottles.esp", 5BE52467) or checksum("Destructible_bottles.esp", D59FAF05) or checksum("Destructible_bottles.esp", D80876E8)'
   - name: 'Item Sorting by Saige.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/87514' ]
     dirty:
@@ -6359,7 +6359,7 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrim/mods/13049' ]
     msg:
       - <<: *obsolete
-        condition: 'checksum("IMAGINATOR - Visual Control for Skyrim.esp",7DFC69E3)'
+        condition: 'checksum("IMAGINATOR - Visual Control for Skyrim.esp", 7DFC69E3)'
   - name: 'Imaginator BETA.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/13049' ]
     dirty:
@@ -6678,7 +6678,7 @@ plugins:
   - name: 'Armures traditionnelles de Bordeciel I.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("Armures traditionnelles de Bordeciel I.esp",2AC9BE08)'
+        condition: 'checksum("Armures traditionnelles de Bordeciel I.esp", 2AC9BE08)'
   - name: 'AronsHybrid.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/23911' ]
     msg: [ *alreadyInSkyrimImmersiveCreatures ]
@@ -6791,7 +6791,7 @@ plugins:
   - name: 'Black Scaled Armor MOD.esp'
     msg:
       - <<: *obsolete
-        condition: 'checksum("Black Scaled Armor MOD.esp",852855A6)'
+        condition: 'checksum("Black Scaled Armor MOD.esp", 852855A6)'
 
   - name: 'Blessing of God.esp'
     msg: [ *obsolete ]
@@ -7015,7 +7015,7 @@ plugins:
   - name: 'CoolItems1_2.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("CoolItems1_2.esp",8E310144)'
+        condition: 'checksum("CoolItems1_2.esp", 8E310144)'
   - name: 'CopperPaladinArmorV1.esp'
     msg: [ *obsolete ]
   - name: 'CopperPaladinArmorV2.esp'
@@ -7203,7 +7203,7 @@ plugins:
   - name: 'DLE_en.esp'
     msg:
       - <<: *obsolete
-        condition: 'checksum("DLE_en.esp",3F26B1FA)'
+        condition: 'checksum("DLE_en.esp", 3F26B1FA)'
   - name: 'Doom Heavy Set.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/23883' ]
     msg: [ *requiresCBBE ]
@@ -7260,11 +7260,11 @@ plugins:
   - name: 'DragonIron.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("DragonIron.esp",0C4425D4)'
+        condition: 'checksum("DragonIron.esp", 0C4425D4)'
   - name: 'DragonIronReplacer.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("DragonIron.esp",0C4425D4)'
+        condition: 'checksum("DragonIron.esp", 0C4425D4)'
   - name: 'DragonplateHelmFix.esp'
     msg: [ *corrupt ]
   - name: 'DragonsoulArmour.esp'
@@ -7284,7 +7284,7 @@ plugins:
   - name: 'dragonweapons.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("dragonweapons.esp",7516E4CE)'
+        condition: 'checksum("dragonweapons.esp", 7516E4CE)'
 
   - name: 'DreamBurrowSageRetexture.esp'
     msg: [ *obsolete ]
@@ -7563,7 +7563,7 @@ plugins:
   - name: 'GoldButterfly1.1.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("GoldButterfly1.1.esp",B94A3CA8)'
+        condition: 'checksum("GoldButterfly1.1.esp", B94A3CA8)'
   - name: 'GoldenPaladinArmorV1.esp'
     msg: [ *obsolete ]
   - name: 'GoldenPaladinArmorV2.esp'
@@ -7587,7 +7587,7 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrim/mods/7558' ]
     msg:
       - <<: *corrupt
-        condition: 'checksum("Hartherz1.2.esp",13F0CA6A)'
+        condition: 'checksum("Hartherz1.2.esp", 13F0CA6A)'
   - name: 'HartherzEnglish.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/7558' ]
     dirty:
@@ -7683,7 +7683,7 @@ plugins:
             text: 'Dies ist die Skyjubs Invisible Helmets Version von hothtrooper44_ArmorCompilation.esp und führt möglicherweise nicht zu den gewünschten Effekten in Verbindung mit anderen hothtrooper Patches. Es ist nur mit den Dawnguard und Dragonborn Plugins kompatibel.'
           - lang: ja
             text: 'このプラグインはhothtrooper44_ArmorCompilation.espのSkyjubs Invisible Helmetsバージョンです。他のhothtrooper氏のパッチと同時に使用しても期待される効果は発生しないでしょう。DawnguardとDragonborn以外のSkyjubs Invisible Helmets esp群とは互換性がありません。'
-        condition: 'checksum("hothtrooper44_ArmorCompilation.esp",1B01C914) or checksum("hothtrooper44_ArmorCompilation.esp",983EFB9E)'
+        condition: 'checksum("hothtrooper44_ArmorCompilation.esp", 1B01C914) or checksum("hothtrooper44_ArmorCompilation.esp", 983EFB9E)'
       - <<: *patch3rdParty_Requiem_RPC
         condition: 'active("Requiem.esp") and version("Requiem.esp", "3.4.0", <=) and not active("Requiem - Immersive Armors.esp")'
       - <<: *patchUnavailableRequiem
@@ -7704,7 +7704,7 @@ plugins:
   - name: 'HotBloodStandalone.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("HotBloodStandalone.esp",39A400A1)'
+        condition: 'checksum("HotBloodStandalone.esp", 39A400A1)'
   - name: 'HotProperty.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/22812' ]
     dirty:
@@ -7720,17 +7720,17 @@ plugins:
   - name: 'HunEbonyArmorStandalone.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("HunEbonyArmorStandalone.esp",F7132DAC)'
+        condition: 'checksum("HunEbonyArmorStandalone.esp", F7132DAC)'
   - name: 'HunEbonyWeaponsStandalone.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/18196' ]
     msg:
       # v1.58
       - <<: *corrupt
-        condition: 'checksum("HunEbonyWeaponsStandalone.esp",F7132DAC)'
+        condition: 'checksum("HunEbonyWeaponsStandalone.esp", F7132DAC)'
   - name: 'hunnicarmors.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("hunnicarmors.esp",D968FD8E)'
+        condition: 'checksum("hunnicarmors.esp", D968FD8E)'
   - name: 'hunterarmor.esp'
     msg: [ *obsolete ]
 
@@ -7852,7 +7852,7 @@ plugins:
   - name: 'Invisible_Helm.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("Invisible_Helm.esp",3EE48471)'
+        condition: 'checksum("Invisible_Helm.esp", 3EE48471)'
   - name: 'Ironman5000 Weapon Overhaul.esp'
     msg: [ *obsolete ]
   - name: 'ironman.esp'
@@ -7873,7 +7873,7 @@ plugins:
   - name: 'Jack of All Trades.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("Jack of All Trades.esp",B66866A6)'
+        condition: 'checksum("Jack of All Trades.esp", B66866A6)'
   - name: 'Jack of Blades'' Armour.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/13752' ]
     dirty:
@@ -7958,7 +7958,7 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrim/mods/22870' ]
     msg:
       - <<: *obsolete
-        condition: 'checksum("LC_ArcherEliteArmor.esp",1651D217)'
+        condition: 'checksum("LC_ArcherEliteArmor.esp", 1651D217)'
     dirty:
       # v1.1
       - <<: *quickClean
@@ -8003,7 +8003,7 @@ plugins:
   - name: 'Lightning Blaze Edge.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("Lightning Blaze Edge.esp",6B2B704B)'
+        condition: 'checksum("Lightning Blaze Edge.esp", 6B2B704B)'
   - name: 'Lightning''s Latex Mask.esp'
     msg: [ *corrupt ]
   - name: 'lilithscarver(1_0|2_0|2_1)?\.esp'
@@ -8158,7 +8158,7 @@ plugins:
   - name: 'MapTomes.esp'
     msg:
       - <<: *obsolete
-        condition: 'checksum("MapTomes.esp",13ACEB01)'
+        condition: 'checksum("MapTomes.esp", 13ACEB01)'
 
   - name: 'Medium Buckler.esp'
     tag: [ Relev ]
@@ -8182,11 +8182,11 @@ plugins:
   - name: 'Mods247Helf16.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("Mods247Helf16.esp",8855F757)'
+        condition: 'checksum("Mods247Helf16.esp", 8855F757)'
   - name: 'MongolArmor.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("MongolArmor.esp",7A153783) or checksum("MongolArmor.esp",7A153783)'
+        condition: 'checksum("MongolArmor.esp", 7A153783) or checksum("MongolArmor.esp", 7A153783)'
   - name: 'monster_hunter.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/6429' ]
     dirty:
@@ -8198,7 +8198,7 @@ plugins:
   - name: 'Monys Portable Crafting Equipment.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("Monys Portable Crafting Equipment.esp",9B33A305)'
+        condition: 'checksum("Monys Portable Crafting Equipment.esp", 9B33A305)'
 
   - name: 'MorrowindArmor.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/22793/' ]
@@ -8210,17 +8210,17 @@ plugins:
     inc: [ 'MorrowindArmor.esp' ]
     msg:
       - <<: *corrupt
-        condition: 'checksum("MorrowindGlass.esp",9099DB14)'
+        condition: 'checksum("MorrowindGlass.esp", 9099DB14)'
   - name: 'MorrowindSmithingVanilla.esp'
     inc: [ 'Dawnguard.esm' ]
     msg:
       - <<: *corrupt
-        condition: 'checksum("MorrowindSmithingVanilla.esp",62CFEEB0)'
+        condition: 'checksum("MorrowindSmithingVanilla.esp", 62CFEEB0)'
 
   - name: 'matys mithril armor enhanced.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("matys mithril armor enhanced.esp",A71FA4F0)'
+        condition: 'checksum("matys mithril armor enhanced.esp", A71FA4F0)'
 
   - name: 'MorSit.esp'
     msg:
@@ -8342,7 +8342,7 @@ plugins:
   - name: 'NiuNiu.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("NiuNiu.esp",8E62670B)'
+        condition: 'checksum("NiuNiu.esp", 8E62670B)'
   - name: 'NobleFemaleClothes.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/6544' ]
     msg: [ *corrupt ]
@@ -8373,7 +8373,7 @@ plugins:
   - name: 'numenume elf ear.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("numenume elf ear.esp",2112184A)'
+        condition: 'checksum("numenume elf ear.esp", 2112184A)'
   - name: 'OdemsSakabato.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/22073' ]
     dirty:
@@ -8400,7 +8400,7 @@ plugins:
   - name: '1HDragonboneGreatsword.esp'
     msg:
       - <<: *obsolete
-        condition: 'checksum("1HDragonboneGreatsword.esp",0AB9B894) or checksum("1HDragonboneGreatsword.esp",1159E2EA)'
+        condition: 'checksum("1HDragonboneGreatsword.esp", 0AB9B894) or checksum("1HDragonboneGreatsword.esp", 1159E2EA)'
   - name: 'Orc Cresent Shield.esp'
     tag: [ Relev ]
   - name: 'Orcish Sabre.esp'
@@ -8429,7 +8429,7 @@ plugins:
   - name: 'PhoenixBlade.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("PhoenixBlade.esp",227F81AF)'
+        condition: 'checksum("PhoenixBlade.esp", 227F81AF)'
   - name: 'PIVariety.esp'
     tag:
       - Delev
@@ -8510,7 +8510,7 @@ plugins:
   - name: 'ringofhircine.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("ringofhircine.esp",BE953E6C)'
+        condition: 'checksum("ringofhircine.esp", BE953E6C)'
   - name: 'Ring of Hircine - No Disease Werewolf AND Totem Selection [NoEquipeSlot].esp'
     inc: [ 'Ring of Hircine - No Disease Werewolf AND Totem Selection.esp' ]
   - name: '(RoH|Ring of Hircine) - No Disease( Werewolf)? And( Totem)? Selection( \[NoEquipeSlot\])?\.esp'
@@ -8674,7 +8674,7 @@ plugins:
   - name: 'Skeleton Key Recipe.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("Skeleton Key Recipe.esp",9FB9A9AC)'
+        condition: 'checksum("Skeleton Key Recipe.esp", 9FB9A9AC)'
 
   - name: 'Skimpy Plate Armor.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/23034/' ]
@@ -8687,7 +8687,7 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrim/mods/5589' ]
     msg:
       - <<: *corrupt
-        condition: 'checksum("SkyHeels.esp",9816BAE4)'
+        condition: 'checksum("SkyHeels.esp", 9816BAE4)'
   - name: 'Skyrim Knights.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/91359' ]
     dirty:
@@ -8786,7 +8786,7 @@ plugins:
   - name: 'stoutheartarmor.esp'
     msg:
       - <<: *obsolete
-        condition: 'checksum("stoutheartarmor.esp",7E65336D)'
+        condition: 'checksum("stoutheartarmor.esp", 7E65336D)'
   - name: 'Strapless Bikinis.esp'
     msg:
       - <<: *obsolete
@@ -8798,11 +8798,11 @@ plugins:
   - name: 'SummoningRings1_2.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("SummoningRings1_2.esp",5608097D)'
+        condition: 'checksum("SummoningRings1_2.esp", 5608097D)'
   - name: 'SUNMagicArmor.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("SUNMagicArmor.esp",EAB06AA4)'
+        condition: 'checksum("SUNMagicArmor.esp", EAB06AA4)'
   - name: 'sunnydawnbreaker.esp'
     after: [ 'improvedrealistic.esp' ]
   - name: 'Tales of Tamriel - Merchants.esp'
@@ -8876,7 +8876,7 @@ plugins:
   - name: 'Thanes Clothes.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("Thanes Clothes.esp",7C23231E)'
+        condition: 'checksum("Thanes Clothes.esp", 7C23231E)'
   - name: 'CALLOFTHENORTH_COMPLEMENT.esp'
     msg: [ *obsolete ]
     url: [ 'https://www.nexusmods.com/skyrim/mods/29670' ]
@@ -8919,7 +8919,7 @@ plugins:
             text: '3.0以降ではSharlikran''s Compatibility Patchは不要です。'
         condition: 'version("TrissArmorRetextured.esp","2.1.1",>)'
       - type: warn
-        condition: 'checksum("TrissArmorRetextured.esp",ED5D1DE)'
+        condition: 'checksum("TrissArmorRetextured.esp", ED5D1DE)'
         content:
           - lang: en
             text: 'Version 2.1.1 was released before the Creation Kit (07 Feb. 2012) a compatibility patch fixed and cleaned with TES5Edit can be obtained here. [Dovahkiin Hideout Continued](http://www.nexusmods.com/skyrim/mods/43593).'
@@ -9034,7 +9034,7 @@ plugins:
   - name: 'WereWolfRing.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("WereWolfRing.esp",730A89B3)'
+        condition: 'checksum("WereWolfRing.esp", 730A89B3)'
 
   - name: 'Witcher2-v3.5 Aedirn-Whiterun.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/22054' ]
@@ -9154,9 +9154,9 @@ plugins:
     url: [ 'http://www.nexusmods.com/skyrim/mods/17805' ]
     msg:
       - <<: *useVersionDawnguard
-        condition: 'active("Dawnguard.esm") and ( checksum("BandolierForNPCMasterFile.esp",112359C0) or checksum("BandolierForNPCMasterFile.esp",76E11697) or checksum("BandolierForNPCMasterFile.esp",0146A38B) )'
+        condition: 'active("Dawnguard.esm") and ( checksum("BandolierForNPCMasterFile.esp", 112359C0) or checksum("BandolierForNPCMasterFile.esp", 76E11697) or checksum("BandolierForNPCMasterFile.esp", 0146A38B) )'
       - <<: *useVersionNonDawnguard
-        condition: 'not active("Dawnguard.esm") and ( checksum("BandolierForNPCMasterFile.esp",882FDEA5) or checksum("BandolierForNPCMasterFile.esp",18D6D7C8) or checksum("BandolierForNPCMasterFile.esp",BECFD7BA) )'
+        condition: 'not active("Dawnguard.esm") and ( checksum("BandolierForNPCMasterFile.esp", 882FDEA5) or checksum("BandolierForNPCMasterFile.esp", 18D6D7C8) or checksum("BandolierForNPCMasterFile.esp", BECFD7BA) )'
   - name: 'BandolierForNPCsWinterIsComing.esp'
     msg: [ *obsolete ]
   - name: 'BandolierForNPCsCheaperBandoliers.esp'
@@ -9240,7 +9240,7 @@ plugins:
     msg:
       - <<: *useInstead
         subs: [ '[Sharlikrans Compatibility Patches](https://www.nexusmods.com/skyrim/mods/26230)' ]
-        condition: 'not checksum("Smithing Perks Overhaul.esp",92158BE3) and not checksum("Smithing Perks Overhaul - Balanced.esp",80AAE7FF)'
+        condition: 'not checksum("Smithing Perks Overhaul.esp", 92158BE3) and not checksum("Smithing Perks Overhaul - Balanced.esp", 80AAE7FF)'
   - name: 'Smithing Perks Overhaul.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/6047' ]
     inc: [ 'Smithing Perks Overhaul - Balanced.esp' ]
@@ -9261,7 +9261,7 @@ plugins:
             text: '予期しない（または順番が狂った）レコード、または他の作者のModで見られたようなTESVSnipの切り捨て問題は存在しませんが、TES5Editで修正しクリーニングを行った新しいEspも入手可能です。こちらはより安定するでしょう。[Compatibility Patch](http://www.nexusmods.com/skyrim/mods/26230)'
           - lang: ru
             text: 'Не содержит неверных записей, как было найдено в других модах от разных авторов, однако новый esp, исправленный и очищенный в Tes5Edit вы можене найти [здесь](http://www.nexusmods.com/skyrim/mods/26230). Исправленный esp добавит больше стабильности. Если вы уже используете русифицированную-исправленную версию, то вам не о чем беспокоиться.'
-        condition: 'not checksum("Complete Crafting Overhaul.esp",8534CD3C) and not checksum("Complete Crafting Overhaul - BS version.esp",193D9214)'
+        condition: 'not checksum("Complete Crafting Overhaul.esp", 8534CD3C) and not checksum("Complete Crafting Overhaul - BS version.esp", 193D9214)'
       - type: warn
         content:
           - lang: en
@@ -11066,7 +11066,7 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrim/mods/20942' ]
     msg:
       - <<: *obsolete
-        condition: 'checksum("BetterNordicRuins.esp",22F42319)'
+        condition: 'checksum("BetterNordicRuins.esp", 22F42319)'
     dirty:
       - <<: *dirtyPlugin
         crc: 0x6c176f16
@@ -11096,7 +11096,7 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrim/mods/11588' ]
     msg:
       - <<: *obsolete
-        condition: 'checksum("BlackMoor.esp",997436A7) or checksum("BlackMoor.esp",6CF48D16)'
+        condition: 'checksum("BlackMoor.esp", 997436A7) or checksum("BlackMoor.esp", 6CF48D16)'
     dirty:
       - <<: *dirtyPlugin
         crc: 0x8a8b45df
@@ -11125,7 +11125,7 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrim/mods/12761' ]
     msg:
       - <<: *obsolete
-        condition: 'checksum("BlackwoodCompanyHall.esp",BFBCB393) or checksum("BlackwoodCompanyHall.esp",9E17E71E) or checksum("BlackwoodCompanyHall.esp",0970AA3E)'
+        condition: 'checksum("BlackwoodCompanyHall.esp", BFBCB393) or checksum("BlackwoodCompanyHall.esp", 9E17E71E) or checksum("BlackwoodCompanyHall.esp", 0970AA3E)'
     dirty:
       - <<: *dirtyPlugin
         crc: 0x848a0e9a
@@ -11463,12 +11463,12 @@ plugins:
   - name: 'Candle Pond Ranch Default Mannequin.esp'
     msg:
       - <<: *obsolete
-        condition: 'checksum("Candle Pond Ranch Default Mannequin.esp",BDD2E234)'
+        condition: 'checksum("Candle Pond Ranch Default Mannequin.esp", BDD2E234)'
   - name: 'Candle Pond Ranch.esp'
     inc: [ 'Candle Pond Ranch Default Mannequin.esp' ]
     msg:
       - <<: *obsolete
-        condition: 'checksum("Candle Pond Ranch.esp",8B643328)'
+        condition: 'checksum("Candle Pond Ranch.esp", 8B643328)'
   - name: 'Castle Brennenburgh.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/13965' ]
     dirty:
@@ -11837,7 +11837,7 @@ plugins:
   - name: 'DisintegratingAxe.esp'
     msg:
       - <<: *obsolete
-        condition: 'checksum("DisintegratingAxe.esp",70970745)'
+        condition: 'checksum("DisintegratingAxe.esp", 70970745)'
   - name: 'DoggyDoors.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/19821' ]
     dirty:
@@ -11885,7 +11885,7 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrim/mods/12630' ]
     msg:
       - <<: *obsolete
-        condition: 'checksum("Domino_MudcrabMerchant.esp",2F466C70)'
+        condition: 'checksum("Domino_MudcrabMerchant.esp", 2F466C70)'
     dirty:
       - <<: *dirtyPlugin
         crc: 0x57bda449
@@ -12121,7 +12121,7 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrim/mods/14938' ]
     msg:
       - <<: *obsolete
-        condition: 'not checksum("EBM.esp",2CBBAEC7) and not checksum("EBM.esp",ADA00DD0)'
+        condition: 'not checksum("EBM.esp", 2CBBAEC7) and not checksum("EBM.esp", ADA00DD0)'
     dirty:
       - <<: *reqManualFix
         crc: 0x2CBBAEC7
@@ -12209,7 +12209,7 @@ plugins:
     msg:
       - <<: *useVersion
         subs: [ 'esm/esp' ]
-        condition: 'checksum("ExplorerDungeonPack.esp",4D76065C) and file("ExplorerDungeonPack.esm")'
+        condition: 'checksum("ExplorerDungeonPack.esp", 4D76065C) and file("ExplorerDungeonPack.esm")'
     dirty:
       # Initial Release
       - <<: *reqManualFix
@@ -12558,7 +12558,7 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrim/mods/17992' ]
     msg:
       - <<: *obsolete
-        condition: 'checksum("GreatTalosHunt.esp",6C0CFBE4) or checksum("GreatTalosHunt.esp",E1A53EA5) or checksum("GreatTalosHunt.esp",A174E77C) or checksum("GreatTalosHunt.esp",3A1727DF) or checksum("GreatTalosHunt.esp",4566C395) or checksum("GreatTalosHunt.esp",18250375)'
+        condition: 'checksum("GreatTalosHunt.esp", 6C0CFBE4) or checksum("GreatTalosHunt.esp", E1A53EA5) or checksum("GreatTalosHunt.esp", A174E77C) or checksum("GreatTalosHunt.esp", 3A1727DF) or checksum("GreatTalosHunt.esp", 4566C395) or checksum("GreatTalosHunt.esp", 18250375)'
     dirty:
       - <<: *dirtyPlugin
         crc: 0x10e82562
@@ -12625,7 +12625,7 @@ plugins:
       - 'SkyRe_Main_NoDawnguard.esp'
     msg:
       - <<: *obsolete
-        condition: 'checksum("HeartOfThunder.esp",CE970887) or checksum("HeartOfThunder.esp",65EB962D) or checksum("HeartOfThunder.esp",1A6E4211)'
+        condition: 'checksum("HeartOfThunder.esp", CE970887) or checksum("HeartOfThunder.esp", 65EB962D) or checksum("HeartOfThunder.esp", 1A6E4211)'
     dirty:
       - <<: *dirtyPlugin
         crc: 0x2ca96833
@@ -12672,14 +12672,14 @@ plugins:
             text: 'An English translation of this mod [is now available here](http://www.nexusmods.com/skyrim/mods/36843)'
           - lang: de
             text: 'Eine englische Übersetzung dieser Mod [ist jetzt hier verfügbar](http://www.nexusmods.com/skyrim/mods/36843).'
-        condition: 'checksum("Hebrock_Der Schatten von Meresis.esp",49083650)'
+        condition: 'checksum("Hebrock_Der Schatten von Meresis.esp", 49083650)'
       - type: say
         content:
           - lang: en
             text: 'The English version has been renamed starting from version 1.1.2.'
           - lang: de
             text: 'Die Englische Version wurde unbenannt, wirksam ab Version 1.1.2.'
-        condition: 'checksum("Hebrock_Der Schatten von Meresis.esp",61DCB4E0)'
+        condition: 'checksum("Hebrock_Der Schatten von Meresis.esp", 61DCB4E0)'
     dirty:
       - <<: *reqManualFix
         crc: 0x49083650
@@ -13217,7 +13217,7 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrim/mods/21686' ]
     msg:
       - <<: *obsolete
-        condition: 'checksum("KatixasBeerBrewery.esp",F7327160) or checksum("KatixasBeerBrewery.esp",6D656E96)'
+        condition: 'checksum("KatixasBeerBrewery.esp", F7327160) or checksum("KatixasBeerBrewery.esp", 6D656E96)'
     dirty:
       - <<: *dirtyPlugin
         crc: 0x331edc48
@@ -13317,7 +13317,7 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrim/mods/8808' ]
     msg:
       - <<: *obsolete
-        condition: 'checksum("LawnDaveTheDragon.esp",3E9A8B77) or checksum("LawnDaveTheDragon.esp",B07C823E) or checksum("LawnDaveTheDragon.esp",7CB32A45)'
+        condition: 'checksum("LawnDaveTheDragon.esp", 3E9A8B77) or checksum("LawnDaveTheDragon.esp", B07C823E) or checksum("LawnDaveTheDragon.esp", 7CB32A45)'
     dirty:
       - <<: *dirtyPlugin
         crc: 0x43e87d04
@@ -13506,7 +13506,7 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrim/mods/26997' ]
     msg:
       - <<: *obsolete
-        condition: 'checksum("markarthbookstore.esp",9857C0D6) or checksum("markarthbookstore.esp",2939E245) or checksum("markarthbookstore.esp",08797C3E)'
+        condition: 'checksum("markarthbookstore.esp", 9857C0D6) or checksum("markarthbookstore.esp", 2939E245) or checksum("markarthbookstore.esp", 08797C3E)'
     dirty:
       - <<: *dirtyPlugin
         crc: 0xbc184e23
@@ -13610,7 +13610,7 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrim/mods/20638' ]
     msg:
       - <<: *obsolete
-        condition: 'checksum("Moar Arrows.esp",8D27C06A) or checksum("Moar Arrows.esp",17179139)'
+        condition: 'checksum("Moar Arrows.esp", 8D27C06A) or checksum("Moar Arrows.esp", 17179139)'
     dirty:
       - <<: *dirtyPlugin
         crc: 0xcf22aa26
@@ -13855,7 +13855,7 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrim/mods/11389' ]
     msg:
       - <<: *obsolete
-        condition: 'checksum("Rashiik.esp",E5ED0B07)'
+        condition: 'checksum("Rashiik.esp", E5ED0B07)'
     dirty:
       - <<: *dirtyPlugin
         crc: 0x7948d345
@@ -14031,7 +14031,7 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrim/mods/12683' ]
     msg:
       - <<: *obsolete
-        condition: 'checksum("RTSforSkyrim.esp",6FDC7CAD) or checksum("RTSforSkyrim.esp",FF4ADC92)'
+        condition: 'checksum("RTSforSkyrim.esp", 6FDC7CAD) or checksum("RTSforSkyrim.esp", FF4ADC92)'
     dirty:
       # v0.28
       - <<: *quickClean
@@ -14047,7 +14047,7 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrim/mods/20352' ]
     msg:
       - <<: *obsolete
-        condition: 'checksum("Rudale.esp",69ECFBC4)'
+        condition: 'checksum("Rudale.esp", 69ECFBC4)'
     dirty:
       # v1.2
       - <<: *quickClean
@@ -14115,7 +14115,7 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrim/mods/8318' ]
     msg:
       - <<: *obsolete
-        condition: 'checksum("Secretentrances.esp",BBA06CBF)'
+        condition: 'checksum("Secretentrances.esp", BBA06CBF)'
     dirty:
       - <<: *dirtyPlugin
         crc: 0xadda81b2
@@ -14124,7 +14124,7 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrim/mods/5048' ]
     msg:
       - <<: *obsolete
-        condition: 'checksum("SecretOfTheDwemer.esp",E6E3A0BB) or checksum("SecretOfTheDwemer.esp",C02B0A73)'
+        condition: 'checksum("SecretOfTheDwemer.esp", E6E3A0BB) or checksum("SecretOfTheDwemer.esp", C02B0A73)'
     dirty:
       - <<: *dirtyPlugin
         crc: 0x751a6b97
@@ -14336,7 +14336,7 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrim/mods/12237' ]
     msg:
       - <<: *obsolete
-        condition: 'checksum("Stegdon''s Book Collection.esp",A53FC583)'
+        condition: 'checksum("Stegdon''s Book Collection.esp", A53FC583)'
     dirty:
       - <<: *dirtyPlugin
         crc: 0xd87b6464
@@ -14653,7 +14653,7 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrim/mods/25712' ]
     msg:
       - <<: *obsolete
-        condition: 'checksum("tinyalchemisthut.esp",4D9F38F8) or checksum("tinyalchemisthut.esp",A0FAF929)'
+        condition: 'checksum("tinyalchemisthut.esp", 4D9F38F8) or checksum("tinyalchemisthut.esp", A0FAF929)'
     dirty:
       # v1.2
       - <<: *reqManualFix
@@ -14682,7 +14682,7 @@ plugins:
   - name: 'tinymagetower.esp'
     msg:
       - <<: *obsolete
-        condition: 'checksum("tinymagetower.esp",33ADB458) or checksum("tinymagetower.esp",4536712D)'
+        condition: 'checksum("tinymagetower.esp", 33ADB458) or checksum("tinymagetower.esp", 4536712D)'
     dirty:
       - <<: *dirtyPlugin
         crc: 0x52753b88
@@ -14691,7 +14691,7 @@ plugins:
   - name: 'tinymagetowernopainnogain.esp'
     msg:
       - <<: *obsolete
-        condition: 'checksum("tinymagetowernopainnogain.esp",04DD015D)'
+        condition: 'checksum("tinymagetowernopainnogain.esp", 04DD015D)'
   - name: 'tinymagetowernpainnogain.esp'
     inc: [ 'tinymagetower.esp' ]
     dirty:
@@ -14726,7 +14726,7 @@ plugins:
   - name: 'towHarvest.esp'
     msg:
       - <<: *useVersionDawnguard
-        condition: 'checksum("towHarvest.esp",A3654F92) and active("Dawnguard.esm")'
+        condition: 'checksum("towHarvest.esp", A3654F92) and active("Dawnguard.esm")'
   - name: 'TruePeopleOfSkyrim.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/15019' ]
     dirty:
@@ -15029,7 +15029,7 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrim/mods/9555' ]
     msg:
       - <<: *obsolete
-        condition: 'checksum("Western Watchtower Rebuilt.esp",49E528EE)'
+        condition: 'checksum("Western Watchtower Rebuilt.esp", 49E528EE)'
     dirty:
       - <<: *quickClean
         crc: 0x27B7618E
@@ -15073,7 +15073,7 @@ plugins:
     msg:
       - <<: *obsolete
         subs: [ '[Whiterun Trees 1.1.esp](http://www.nexusmods.com/skyrim/mods/8240).' ]
-        condition: 'checksum("Whiterun Trees.esp",226D7357)'
+        condition: 'checksum("Whiterun Trees.esp", 226D7357)'
     dirty:
       - <<: *dirtyPlugin
         crc: 0xd2995274
@@ -15091,7 +15091,7 @@ plugins:
             text: 'Unterschiedliche Mod mit gleichem Namen. Wahrscheinlich nicht kompatibel.'
           - lang: ja
             text: '同名のModとは異なります。おそらく両立できません。'
-        condition: 'checksum("Whiterun Trees.esp",D2995274)'
+        condition: 'checksum("Whiterun Trees.esp", D2995274)'
   - name: '(BETA) Immersive Cities - Whiterun.esp'
     msg: [ *obsolete ]
   - name: 'Whiterun Ferns.esp'
@@ -15216,7 +15216,7 @@ plugins:
   - name: 'Lighter Tools.esp'
     msg:
       - <<: *obsolete
-        condition: 'checksum("Lighter Tools.esp",6DD49F50)'
+        condition: 'checksum("Lighter Tools.esp", 6DD49F50)'
   - name: 'PorkUp.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrim/mods/23448/'
@@ -15260,9 +15260,9 @@ plugins:
   - name: 'no_quest_items.esp'
     msg:
       - <<: *useVersionDawnguard
-        condition: 'active("Dawnguard.esm") and not checksum("no_quest_items.esp",47CDC33D)'
+        condition: 'active("Dawnguard.esm") and not checksum("no_quest_items.esp", 47CDC33D)'
       - <<: *obsolete
-        condition: 'checksum("no_quest_items.esp",8CAAD195) or checksum("no_quest_items.esp",639770A2)'
+        condition: 'checksum("no_quest_items.esp", 8CAAD195) or checksum("no_quest_items.esp", 639770A2)'
   - name: 'no_quest_items_DG.esp'
     msg: [ *obsolete ]
   - name: 'NoEnchDarkBrotherhood.esp'
@@ -15399,11 +15399,11 @@ plugins:
   - name: 'BalancedHeroWeps.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("BalancedHeroWeps.esp",1A21ED10)'
+        condition: 'checksum("BalancedHeroWeps.esp", 1A21ED10)'
   - name: 'BarbasLessAnnoying.esp'
     msg:
       - <<: *obsolete
-        condition: 'checksum("BarbasLessAnnoying.esp",9E39BF7F)'
+        condition: 'checksum("BarbasLessAnnoying.esp", 9E39BF7F)'
   - name: 'Bards attend Classes.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrim/mods/26828/'
@@ -15465,13 +15465,13 @@ plugins:
   - name: 'BetterNordHeroWeapons.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("BetterNordHeroWeapons.esp",0B39EBC1)'
+        condition: 'checksum("BetterNordHeroWeapons.esp", 0B39EBC1)'
   - name: 'BetterQuestObjectives.esp'
     group: *underridesGroup
     msg:
       - <<: *obsolete
         subs: [ '[Even Better Quest Objectives](http://www.nexusmods.com/skyrim/mods/32695/)' ]
-        condition: 'checksum("BetterQuestObjectives.esp",BCD35920)'
+        condition: 'checksum("BetterQuestObjectives.esp", BCD35920)'
     tag: [ NoMerge ]
     clean:
       # version: 1.7
@@ -15518,12 +15518,12 @@ plugins:
   - name: 'Book Covers Dawnguard.esp'
     msg:
       - <<: *alreadyInX
-        condition: 'file("Book Covers Skyrim.esp") and checksum("Book Covers Skyrim.esp",B8DA5EF5)'
+        condition: 'file("Book Covers Skyrim.esp") and checksum("Book Covers Skyrim.esp", B8DA5EF5)'
         subs: [ 'Book Covers Skyrim.esp' ]
   - name: 'Book Covers Hearthfire.esp'
     msg:
       - <<: *alreadyInX
-        condition: 'file("Book Covers Skyrim.esp") and checksum("Book Covers Skyrim.esp",B8DA5EF5)'
+        condition: 'file("Book Covers Skyrim.esp") and checksum("Book Covers Skyrim.esp", B8DA5EF5)'
         subs: [ 'Book Covers Skyrim.esp' ]
   - name: 'REQ - BCS Patch.esp'
     inc:
@@ -15629,27 +15629,27 @@ plugins:
   - name: 'Better Sorting 1.12 Sboub édition.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("Better Sorting 1.12 Sboub édition.esp",E52FC50D)'
+        condition: 'checksum("Better Sorting 1.12 Sboub édition.esp", E52FC50D)'
   - name: 'Better Sorting FR A 1.12.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("Better Sorting FR A 1.12.esp",A6455DB3)'
+        condition: 'checksum("Better Sorting FR A 1.12.esp", A6455DB3)'
   - name: 'Better Sorting FR B 1.12.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("Better Sorting FR B 1.12.esp",4F254127)'
+        condition: 'checksum("Better Sorting FR B 1.12.esp", 4F254127)'
   - name: 'Better Sorting FR EA 1.12.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("Better Sorting FR EA 1.12.esp",39FB7D5C)'
+        condition: 'checksum("Better Sorting FR EA 1.12.esp", 39FB7D5C)'
   - name: 'Better Sorting FR EB 1.12.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("Better Sorting FR EB 1.12.esp",097D3033)'
+        condition: 'checksum("Better Sorting FR EB 1.12.esp", 097D3033)'
   - name: 'Headbomb''s Better Sorting -- DE (by sheijian) v1.03.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("Headbomb''s Better Sorting -- DE (by sheijian) v1.03.esp",BC4FACB7)'
+        condition: 'checksum("Headbomb''s Better Sorting -- DE (by sheijian) v1.03.esp", BC4FACB7)'
   - name: 'BetterStaffofCorruption.esp'
     msg: [ *corrupt ]
   - name: 'BetterStaffofCorruptionMED.esp'
@@ -15799,7 +15799,7 @@ plugins:
   - name: 'Daedric Light Armor - Rebalanced.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("Daedric Light Armor - Rebalanced.esp",BA0A6590)'
+        condition: 'checksum("Daedric Light Armor - Rebalanced.esp", BA0A6590)'
   - name: 'dangerous animals( - (german|light))?\.esp'
     msg:
       - <<: *useOnlyOneX
@@ -15861,7 +15861,7 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrim/mods/23898' ]
     msg:
       - <<: *obsolete
-        condition: 'checksum("Dragon Souls To Attributes.esp",4A52794E) or checksum("Dragon Souls To Attributes.esp",646A5BB8)'
+        condition: 'checksum("Dragon Souls To Attributes.esp", 4A52794E) or checksum("Dragon Souls To Attributes.esp", 646A5BB8)'
     clean:
       # v1.06a
       - crc: 0x48E76744
@@ -15917,55 +15917,55 @@ plugins:
   - name: 'Essential Frost.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("Essential Frost.esp",D44409A0)'
+        condition: 'checksum("Essential Frost.esp", D44409A0)'
   - name: 'Essential horses - all horses.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("Essential horses - all horses.esp",C89FBE27)'
+        condition: 'checksum("Essential horses - all horses.esp", C89FBE27)'
   - name: 'Essential horses v2.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("Essential horses v2.esp",C89FBE27)'
+        condition: 'checksum("Essential horses v2.esp", C89FBE27)'
   - name: 'Essential horses.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("Essential horses.esp",9B9E748D)'
+        condition: 'checksum("Essential horses.esp", 9B9E748D)'
   - name: 'Essential Karinda.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("Essential Karinda.esp",76726DC5)'
+        condition: 'checksum("Essential Karinda.esp", 76726DC5)'
   - name: 'Essential Markarth horses.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("Essential Markarth horses.esp",8FF75D36)'
+        condition: 'checksum("Essential Markarth horses.esp", 8FF75D36)'
   - name: 'Essential Riften horses.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("Essential Riften horses.esp",7BBB11F3)'
+        condition: 'checksum("Essential Riften horses.esp", 7BBB11F3)'
   - name: 'Essential Shadowmere and Frost.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("Essential Shadowmere and Frost.esp",7811F09F)'
+        condition: 'checksum("Essential Shadowmere and Frost.esp", 7811F09F)'
   - name: 'Essential Shadowmere v2.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("Essential Shadowmere v2.esp",A381200F)'
+        condition: 'checksum("Essential Shadowmere v2.esp", A381200F)'
   - name: 'Essential Shadowmere.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("Essential Shadowmere.esp",A381200F)'
+        condition: 'checksum("Essential Shadowmere.esp", A381200F)'
   - name: 'Essential Solitude horses.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("Essential Solitude horses.esp",545A07B5)'
+        condition: 'checksum("Essential Solitude horses.esp", 545A07B5)'
   - name: 'Essential Whiterun horses.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("Essential Whiterun horses.esp",5975BB9B)'
+        condition: 'checksum("Essential Whiterun horses.esp", 5975BB9B)'
   - name: 'Essential Windhelm horses.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("Essential Windhelm horses.esp",FBD393F5)'
+        condition: 'checksum("Essential Windhelm horses.esp", FBD393F5)'
   - name: 'ExpandedCarriageService.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrim/mods/8544/'
@@ -15984,7 +15984,7 @@ plugins:
   - name: 'FasterNordHeroWeps.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("FasterNordHeroWeps.esp",4F2396EA)'
+        condition: 'checksum("FasterNordHeroWeps.esp", 4F2396EA)'
   - name: 'FemaleMannequins(Argonian|Breton|DarkElf|HighElf|Imperial|Kajiit|Nord|Orc|Redguard|WoodElf)\.esp'
     msg:
       - <<: *useOnlyOneX
@@ -16118,7 +16118,7 @@ plugins:
   - name: 'Improved blessing.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("Improved blessing.esp",BF08EFFE)'
+        condition: 'checksum("Improved blessing.esp", BF08EFFE)'
   - name: 'improved final battle.esp'
     url: [ 'https://steamcommunity.com/sharedfiles/filedetails/?id=14839' ]
     dirty:
@@ -16176,7 +16176,7 @@ plugins:
             text: 'Diese Mod ist nicht richtig für Skyrim.esm gemastert. Es wird nichts in Ihrem Spiel ändern oder hinzufügen.'
           - lang: ja
             text: 'このModはSkyrim.esmを正しくマスターファイルとして認識していません。変更内容をそのまま複製してしまいます。'
-        condition: 'checksum("increaseddifficulty.esp",DFD6D81E)'
+        condition: 'checksum("increaseddifficulty.esp", DFD6D81E)'
   - name: 'Intense Difficulty 2x to player.esp'
     msg: [ *corrupt ]
   - name: 'Invisible Aetherial Crown.esp'
@@ -16355,7 +16355,7 @@ plugins:
   - name: 'Magnify Spell Enchantments.esp'
     msg:
       - <<: *obsolete
-        condition: 'checksum("Magnify Spell Enchantments.esp",74C76DD8)'
+        condition: 'checksum("Magnify Spell Enchantments.esp", 74C76DD8)'
   - name: 'Magnify Spell Enchantments - Disenchant.esp'
     inc: [ 'Magnify Spell Enchantments.esp' ]
 
@@ -16414,7 +16414,7 @@ plugins:
         name: 'MECRs Mythic Dawn Commentaries are Skill Books'
     msg:
       - <<: *obsolete
-        condition: 'checksum("MECR_MythicDawnCommentaries_are_Skill_Books.esp",A3A58E7D)'
+        condition: 'checksum("MECR_MythicDawnCommentaries_are_Skill_Books.esp", A3A58E7D)'
     dirty:
       - <<: *dirtyPlugin
         crc: 0x8dab779c
@@ -16422,7 +16422,7 @@ plugins:
   - name: 'MenuShoutsInDragonsLanguage.esp'
     msg:
       - <<: *useVersionDawnguard
-        condition: 'active("Dawnguard.esm") and checksum("MenuShoutsInDragonsLanguage.esp",B36BDB9A)'
+        condition: 'active("Dawnguard.esm") and checksum("MenuShoutsInDragonsLanguage.esp", B36BDB9A)'
   - name: 'Merchants Reply Only With Take A Look.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrim/mods/10905/'
@@ -16443,11 +16443,11 @@ plugins:
   - name: 'More Powerful Dragons.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("More Powerful Dragons.esp",48A18FE5)'
+        condition: 'checksum("More Powerful Dragons.esp", 48A18FE5)'
   - name: 'More Powerful Dragons Leveled Dragons.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("More Powerful Dragons Leveled Dragons.esp",CEF8347C)'
+        condition: 'checksum("More Powerful Dragons Leveled Dragons.esp", CEF8347C)'
   - name: 'MoreSalt.esp'
     tag: [ Relev ]
     # doNotClean
@@ -16586,7 +16586,7 @@ plugins:
         name: 'Realistic Animal Behaviour'
     msg:
       - <<: *obsolete
-        condition: 'checksum("Realistic Animal Behaviour.esp",BAAA3FD3) or checksum("Realistic Animal Behaviour.esp",68D49ED7) or checksum("Realistic Animal Behaviour.esp",D4718D13)'
+        condition: 'checksum("Realistic Animal Behaviour.esp", BAAA3FD3) or checksum("Realistic Animal Behaviour.esp", 68D49ED7) or checksum("Realistic Animal Behaviour.esp", D4718D13)'
     dirty:
       - <<: *dirtyPlugin
         crc: 0x5cc5de01
@@ -16925,7 +16925,7 @@ plugins:
   - name: 'spellbreaker_150.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("spellbreaker_150.esp",EB334104)'
+        condition: 'checksum("spellbreaker_150.esp", EB334104)'
   - name: '-?Stickier_Arrows-? (V2|Fix)\.esp'
     msg:
       - <<: *useOnlyOneX
@@ -17070,12 +17070,12 @@ plugins:
   - name: 'wabba-ori_proj.esp'
     msg:
       - <<: *obsolete
-        condition: 'checksum("wabba-ori_proj.esp",920BFEAC) or checksum("wabba-ori_proj.esp",C0BCC465) or checksum("wabba-ori_proj.esp",C4D440F8)'
+        condition: 'checksum("wabba-ori_proj.esp", 920BFEAC) or checksum("wabba-ori_proj.esp", C0BCC465) or checksum("wabba-ori_proj.esp", C4D440F8)'
   - name: 'wabba-unrel_proj.esp'
     inc: [ 'wabba-ori_proj.esp' ]
     msg:
       - <<: *obsolete
-        condition: 'checksum("wabba-unrel_proj.esp",F1E2BBDE) or checksum("wabba-unrel_proj.esp",7F102922) or checksum("wabba-unrel_proj.esp",285D704B)'
+        condition: 'checksum("wabba-unrel_proj.esp", F1E2BBDE) or checksum("wabba-unrel_proj.esp", 7F102922) or checksum("wabba-unrel_proj.esp", 285D704B)'
   - name: 'WeaponSmith.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/14252' ]
     dirty:
@@ -17179,7 +17179,7 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrim/mods/24282' ]
     msg:
       - <<: *obsolete
-        condition: 'checksum("Drinking Fountains of Skyrim.esp",5A348F0C)'
+        condition: 'checksum("Drinking Fountains of Skyrim.esp", 5A348F0C)'
     dirty:
       - <<: *dirtyPlugin
         crc: 0x1a86291b
@@ -17233,7 +17233,7 @@ plugins:
   - name: 'Log Cabin Riften.esp'
     msg:
       - <<: *obsolete
-        condition: 'checksum("Log Cabin Riften.esp",CB696C6C)'
+        condition: 'checksum("Log Cabin Riften.esp", CB696C6C)'
   - name: 'MerchantsGuild.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrim/mods/18023/'
@@ -17620,7 +17620,7 @@ plugins:
         name: 'Landscaped Lake Modification'
     msg:
       - <<: *useVersionHearthFires
-        condition: 'active("HearthFires.esm") and ( checksum("LakeExpanded01.esp",43AEF0BF) or checksum("LakeExpanded01.esp",843EB3FC) )'
+        condition: 'active("HearthFires.esm") and ( checksum("LakeExpanded01.esp", 43AEF0BF) or checksum("LakeExpanded01.esp", 843EB3FC) )'
     dirty:
       - <<: *dirtyPlugin
         crc: 0x43aef0bf
@@ -18075,7 +18075,7 @@ plugins:
   - name: 'Fatigue_Effects.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("Fatigue_Effects.esp",A4C14B80)'
+        condition: 'checksum("Fatigue_Effects.esp", A4C14B80)'
   - name: 'Imp''s More Complex Needs.esp'
     inc: [ 'Imp''s More Complex Needs.esm' ]
     msg:
@@ -18087,7 +18087,7 @@ plugins:
             text: 'Es wird empfohlen, dass Sie diese Mod deabbonieren und löschen und dann die [SkyrimNexus-Version](http://www.nexusmods.com/skyrim/mods/10639) installieren, um die Kompatibilität mit anderen Mods zu verbessern.'
           - lang: ja
             text: 'サブスクライブを解除してModそのものを削除し、他のModとの互換性を高めるために[SkyrimNexus版](http://www.nexusmods.com/skyrim/mods/10639)をインストールすることをお勧めします。'
-        condition: 'checksum("imp''s more complex needs.esp",DAADC533) or checksum("imp''s more complex needs.esp",59466F1E)'
+        condition: 'checksum("imp''s more complex needs.esp", DAADC533) or checksum("imp''s more complex needs.esp", 59466F1E)'
     clean:
       - crc: 0x79B1B51C
         util: 'TES5Edit v4.0.2f'
@@ -18503,7 +18503,7 @@ plugins:
   - name: 'Vampires hate the sun.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("Vampires hate the sun.esp.esp",820C3864)'
+        condition: 'checksum("Vampires hate the sun.esp.esp", 820C3864)'
   - name: 'VLW_Hybrid.esp'
     after:
       - 'Better Vampires ML - No DawnGuard.esp'
@@ -18519,9 +18519,9 @@ plugins:
         name: 'Werewolf Mastery'
     msg:
       - <<: *useVersionDawnguard
-        condition: 'active("Dawnguard.esm") and checksum("WerewolfMastery.esp",57E4BC0F)'
+        condition: 'active("Dawnguard.esm") and checksum("WerewolfMastery.esp", 57E4BC0F)'
       - <<: *useVersionNonDawnguard
-        condition: 'not active("Dawnguard.esm") and checksum("WerewolfMastery.esp",73AC0648)'
+        condition: 'not active("Dawnguard.esm") and checksum("WerewolfMastery.esp", 73AC0648)'
     dirty:
       - <<: *dirtyPlugin
         crc: 0x73ac0648
@@ -18724,7 +18724,7 @@ plugins:
         name: 'Conjure Armored Husky'
     msg:
       - <<: *obsolete
-        condition: 'checksum("Conjure_Armored_Husky.esp",F0E45BC9)'
+        condition: 'checksum("Conjure_Armored_Husky.esp", F0E45BC9)'
     dirty:
       - <<: *dirtyPlugin
         crc: 0xf3a51e21
@@ -18732,14 +18732,14 @@ plugins:
   - name: 'Conjure_Armored_Troll.esp'
     msg:
       - <<: *obsolete
-        condition: 'checksum("Conjure_Armored_Troll.esp",4BE3E42F) or checksum("Conjure_Armored_Troll.esp",6B09974A)'
+        condition: 'checksum("Conjure_Armored_Troll.esp", 4BE3E42F) or checksum("Conjure_Armored_Troll.esp", 6B09974A)'
   - name: 'Conjure_Death_Hound.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrim/mods/21791/'
         name: 'Conjure Death Hound Spell'
     msg:
       - <<: *obsolete
-        condition: 'checksum("Conjure_Death_Hound.esp",9207A5B2) or checksum("Conjure_Death_Hound.esp",98298BAD) or checksum("Conjure_Death_Hound.esp",15417CD3) or checksum("Conjure_Death_Hound.esp",BDD73A1A)'
+        condition: 'checksum("Conjure_Death_Hound.esp", 9207A5B2) or checksum("Conjure_Death_Hound.esp", 98298BAD) or checksum("Conjure_Death_Hound.esp", 15417CD3) or checksum("Conjure_Death_Hound.esp", BDD73A1A)'
     dirty:
       - <<: *dirtyPlugin
         crc: 0xf273f759
@@ -18843,7 +18843,7 @@ plugins:
   - name: 'KodlakWhitemane.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("KodlakWhitemane.esp",C68252A0)'
+        condition: 'checksum("KodlakWhitemane.esp", C68252A0)'
   - name: 'LeazersOpenLock2_0.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrim/mods/36897/'
@@ -18946,7 +18946,7 @@ plugins:
         name: 'Advanced Skyrim Overhaul (aka Nature of the beast II)'
     msg:
       - <<: *obsolete
-        condition: 'not checksum("Nature of the beast.esp",7EDCD683) and not checksum("Nature of the beast.esp",E20D43CA)'
+        condition: 'not checksum("Nature of the beast.esp", 7EDCD683) and not checksum("Nature of the beast.esp", E20D43CA)'
     dirty:
       - <<: *dirtyPlugin
         crc: 0x7edcd683
@@ -19046,7 +19046,7 @@ plugins:
   - name: 'Star Wars Force Abilities.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("Star Wars Force Abilities.esp",FD5D302E)'
+        condition: 'checksum("Star Wars Force Abilities.esp", FD5D302E)'
   - name: 'Succubus.esp'
     msg: [ *obsolete ]
   - name: 'SummersetLinweSummon.esp'
@@ -19197,7 +19197,7 @@ plugins:
         name: 'Shout-Tastic'
     msg:
       - <<: *obsolete
-        condition: 'checksum("Shout-tastic.esp",7BE79CD0) or checksum("Shout-tastic.esp",96544986)'
+        condition: 'checksum("Shout-tastic.esp", 7BE79CD0) or checksum("Shout-tastic.esp", 96544986)'
     dirty:
       - <<: *dirtyPlugin
         crc: 0x8420cd21
@@ -19381,7 +19381,7 @@ plugins:
   - name: 'Eld-combinePotions.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("Eld-combinePotions.esp",B44CC974)'
+        condition: 'checksum("Eld-combinePotions.esp", B44CC974)'
   - name: 'PISE-Reduced Potions.esp'
     tag:
       - Delev
@@ -19491,7 +19491,7 @@ plugins:
         name: 'Duel Wield 2 Handed Weapons V1'
     msg:
       - <<: *obsolete
-        condition: 'checksum("duel weild 2 hand.esp",3B654AD9)'
+        condition: 'checksum("duel weild 2 hand.esp", 3B654AD9)'
     dirty:
       - <<: *dirtyPlugin
         crc: 0x546fcea3
@@ -19631,27 +19631,27 @@ plugins:
   - name: 'ArcheryExtended200.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("ArcheryExtended200.esp",BF90CF33)'
+        condition: 'checksum("ArcheryExtended200.esp", BF90CF33)'
   - name: 'BlockExtended200.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("BlockExtended200.esp",A4BC2675)'
+        condition: 'checksum("BlockExtended200.esp", A4BC2675)'
   - name: 'HeavyArmorExtended200.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("HeavyArmorExtended200.esp",EE2865BA)'
+        condition: 'checksum("HeavyArmorExtended200.esp", EE2865BA)'
   - name: 'OnehandedExtended200.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("OnehandedExtended200.esp",8AFA7162)'
+        condition: 'checksum("OnehandedExtended200.esp", 8AFA7162)'
   - name: 'SmithingExtended200.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("SmithingExtended200.esp",4CE06258)'
+        condition: 'checksum("SmithingExtended200.esp", 4CE06258)'
   - name: 'TwoHandedExtended200.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("TwoHandedExtended200.esp",D196971F)'
+        condition: 'checksum("TwoHandedExtended200.esp", D196971F)'
   - name: 'ArcheryDummyXP.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/23698' ]
     clean:
@@ -19696,7 +19696,7 @@ plugins:
   - name: 'ACE Archery-Weapons of the Third Era Patch.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("ACE Archery-Weapons of the Third Era Patch.esp",873EAB94)'
+        condition: 'checksum("ACE Archery-Weapons of the Third Era Patch.esp", 873EAB94)'
   - name: 'ACE Armor.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/10037' ]
     after:
@@ -20060,7 +20060,7 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrim/mods/9359' ]
     msg:
       - <<: *corrupt
-        condition: 'checksum("PerkUP-Alchemy.esp",78B29460)'
+        condition: 'checksum("PerkUP-Alchemy.esp", 78B29460)'
   - name: 'PerkUP-Alteration.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/9359' ]
     dirty:
@@ -20072,12 +20072,12 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrim/mods/9359' ]
     msg:
       - <<: *corrupt
-        condition: 'checksum("PerkUP-Archery.esp",7DE1869B)'
+        condition: 'checksum("PerkUP-Archery.esp", 7DE1869B)'
   - name: 'PerkUP-Block.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/9359' ]
     msg:
       - <<: *corrupt
-        condition: 'checksum("PerkUP-Block.esp",BA505A27)'
+        condition: 'checksum("PerkUP-Block.esp", BA505A27)'
   - name: 'PerkUP-Conjuration.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/9359' ]
     dirty:
@@ -20096,7 +20096,7 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrim/mods/9359' ]
     msg:
       - <<: *corrupt
-        condition: 'checksum("PerkUP-Enchanting.esp",44A1D95B)'
+        condition: 'checksum("PerkUP-Enchanting.esp", 44A1D95B)'
   - name: 'PerkUP-HeavyArmor.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/9359' ]
     dirty:
@@ -20114,22 +20114,22 @@ plugins:
   - name: 'PerkUP-LightArmor.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("PerkUP-LightArmor.esp",B06368FC)'
+        condition: 'checksum("PerkUP-LightArmor.esp", B06368FC)'
   - name: 'PerkUP-Lockpicking.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/9359' ]
     msg:
       - <<: *corrupt
-        condition: 'checksum("PerkUP-Lockpicking.esp",84E156CF)'
+        condition: 'checksum("PerkUP-Lockpicking.esp", 84E156CF)'
   - name: 'PerkUP-OneHanded.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/9359' ]
     msg:
       - <<: *corrupt
-        condition: 'checksum("PerkUP-OneHanded.esp",537E45D7)'
+        condition: 'checksum("PerkUP-OneHanded.esp", 537E45D7)'
   - name: 'PerkUP-Pickpocket.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/9359' ]
     msg:
       - <<: *corrupt
-        condition: 'checksum("PerkUP-Pickpocket.esp",C499715D)'
+        condition: 'checksum("PerkUP-Pickpocket.esp", C499715D)'
   - name: 'PerkUP-Restoration.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/9359' ]
     dirty:
@@ -20141,22 +20141,22 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrim/mods/9359' ]
     msg:
       - <<: *corrupt
-        condition: 'checksum("PerkUP-Smithing.esp",F607DBD3)'
+        condition: 'checksum("PerkUP-Smithing.esp", F607DBD3)'
   - name: 'PerkUP-Sneak.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/9359' ]
     msg:
       - <<: *corrupt
-        condition: 'checksum("PerkUP-Sneak.esp",5B3B0E3A)'
+        condition: 'checksum("PerkUP-Sneak.esp", 5B3B0E3A)'
   - name: 'PerkUP-Speech.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/9359' ]
     msg:
       - <<: *corrupt
-        condition: 'checksum("PerkUP-Speech.esp",8E72AE48)'
+        condition: 'checksum("PerkUP-Speech.esp", 8E72AE48)'
   - name: 'PerkUP-TwoHanded.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/9359' ]
     msg:
       - <<: *corrupt
-        condition: 'checksum("PerkUP-TwoHanded.esp",2EC31219)'
+        condition: 'checksum("PerkUP-TwoHanded.esp", 2EC31219)'
   - name: 'PerkUP-zOptional_HeavyArmor_NoHelmsReq.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/9359' ]
     dirty:
@@ -20166,16 +20166,16 @@ plugins:
         itm: 1
     msg:
       - <<: *corrupt
-        condition: 'checksum("PerkUP-zOptional_HeavyArmor_NoHelmsReq.esp",32EC46AD)'
+        condition: 'checksum("PerkUP-zOptional_HeavyArmor_NoHelmsReq.esp", 32EC46AD)'
   - name: 'PerkUP-zOptional_LightArmor_NoHelmsReq.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("PerkUP-zOptional_LightArmor_NoHelmsReq.esp",C519978E)'
+        condition: 'checksum("PerkUP-zOptional_LightArmor_NoHelmsReq.esp", C519978E)'
   - name: 'PerkUP-zOptional-Pickpocket_CarryMore100.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/9359' ]
     msg:
       - <<: *corrupt
-        condition: 'checksum("PerkUP-zOptional-Pickpocket_CarryMore100.esp",C7001A4E)'
+        condition: 'checksum("PerkUP-zOptional-Pickpocket_CarryMore100.esp", C7001A4E)'
   - name: 'MXMaxAllSkills.esp'
     req: [ 'More Craftables.esp' ]
     msg:
@@ -20188,7 +20188,7 @@ plugins:
         name: 'Syynxs Perky Reborn - Major Perk Overhaul'
     msg:
       - <<: *obsolete
-        condition: 'checksum("Perky.esp",EE1F755B) or checksum("Perky.esp",469D04CE)'
+        condition: 'checksum("Perky.esp", EE1F755B) or checksum("Perky.esp", 469D04CE)'
     dirty:
       - <<: *dirtyPlugin
         crc: 0xdfa3acce
@@ -20535,7 +20535,7 @@ plugins:
         name: 'No More Vanilla Hair'
     msg:
       - <<: *obsolete
-        condition: 'not checksum("NoMoreVanillaHair.esp",A31830F1) and not checksum("NoMoreVanillaHair.esp",7F9635D9)'
+        condition: 'not checksum("NoMoreVanillaHair.esp", A31830F1) and not checksum("NoMoreVanillaHair.esp", 7F9635D9)'
       - <<: *requiresX
         type: say
         subs: [ '[Crazy hairs and demoness hairs conversion by zzjay](http://www.nexusmods.com/skyrim/mods/19623)' ]
@@ -20572,7 +20572,7 @@ plugins:
     inc: [ 'ethereal_elven_overhaul.esp' ]
     msg:
       - <<: *obsolete
-        condition: 'checksum("XCES.esp",0D760898)'
+        condition: 'checksum("XCES.esp", 0D760898)'
   - name: 'BHWarPaints.esp'
     req: [ *SKSE ]
   - name: 'RaceMenuOverlays.esp'
@@ -20756,7 +20756,7 @@ plugins:
   - name: 'Kawaii Face Presets.esp'
     msg:
       - <<: *obsolete
-        condition: 'checksum("Kawaii Face Presets.esp",2774F3D6)'
+        condition: 'checksum("Kawaii Face Presets.esp", 2774F3D6)'
   - name: 'Kawaii Face Presets2.esp'
     req:
       - *SKSE
@@ -20765,7 +20765,7 @@ plugins:
   - name: 'KhaleesiFacePreset.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("KhaleesiFacePreset.esp",42C16D17)'
+        condition: 'checksum("KhaleesiFacePreset.esp", 42C16D17)'
   - name: '3DNPC.esp'
     url: [ 'http://3dnpc.com/' ]
     msg: [ *patchUnavailableRequiem ]
@@ -20915,7 +20915,7 @@ plugins:
   - name: 'PetBearOslo.esp'
     msg:
       - <<: *obsolete
-        condition: 'checksum("PetBearOslo.esp",7614B5F9) or checksum("PetBearOslo.esp",EA58D0C9)'
+        condition: 'checksum("PetBearOslo.esp", 7614B5F9) or checksum("PetBearOslo.esp", EA58D0C9)'
   - name: 'TCG.esp'
     msg: [ *alreadyInUFO ]
   - name: 'VendorSaleDelay-Gone.esp'
@@ -20974,9 +20974,9 @@ plugins:
     inc: [ 'BDO.esp' ]
     req:
       - name: 'UFO - Dawnguard AddOn.esp'
-        condition: 'active("Dawnguard.esm") and checksum("UFO - Ultimate Follower Overhaul.esp",396AE69F)'
+        condition: 'active("Dawnguard.esm") and checksum("UFO - Ultimate Follower Overhaul.esp", 396AE69F)'
       - name: 'UFO - Heartfire AddOn.esp'
-        condition: 'active("HearthFires.esm") and checksum("UFO - Ultimate Follower Overhaul.esp",396AE69F)'
+        condition: 'active("HearthFires.esm") and checksum("UFO - Ultimate Follower Overhaul.esp", 396AE69F)'
     msg:
       - type: say
         content:
@@ -21084,7 +21084,7 @@ plugins:
             text: 'Verwenden Sie die UFO Version von KTNUlfric.esp'
           - lang: ja
             text: 'KTNUlfric.espのUFOバージョンを使用してください。'
-        condition: 'checksum("KTNUlfric.esp",8CF90F55) and file("UFO - Ultimate Follower Overhaul.esp")'
+        condition: 'checksum("KTNUlfric.esp", 8CF90F55) and file("UFO - Ultimate Follower Overhaul.esp")'
       - type: error
         content:
           - lang: en
@@ -21093,7 +21093,7 @@ plugins:
             text: 'Verwenden Sie die UFO Version von KTNUlfric.esp'
           - lang: ja
             text: 'KTNUlfric.espのUFOバージョンを使用してください。'
-        condition: 'checksum("KTNUlfric.esp",35CB3586) and not file("UFO - Ultimate Follower Overhaul.esp")'
+        condition: 'checksum("KTNUlfric.esp", 35CB3586) and not file("UFO - Ultimate Follower Overhaul.esp")'
     dirty:
       - <<: *dirtyPlugin
         crc: 0x35cb3586
@@ -21135,20 +21135,20 @@ plugins:
   - name: 'AelaTheHuntress.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("AelaTheHuntress.esp",826D7A86)'
+        condition: 'checksum("AelaTheHuntress.esp", 826D7A86)'
   - name: 'JNPC_AelaTheHuntress.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("JNPC_AelaTheHuntress.esp",70FF9A16)'
+        condition: 'checksum("JNPC_AelaTheHuntress.esp", 70FF9A16)'
   - name: 'AkaviriRebornbeta1.esp'
     msg:
       - <<: *obsolete
-        condition: 'checksum("AkaviriRebornbeta1.esp",92CB7FEA)'
+        condition: 'checksum("AkaviriRebornbeta1.esp", 92CB7FEA)'
   - name: 'AlvhildeLycan.esp'
     req:
       - name: 'TheEyesOfBeauty.esp'
         display: '[The Eyes of Beauty](http://www.nexusmods.com/skyrim/mods/13722)'
-        condition: 'checksum("AlvhildeLycan.esp",BE4CD149)'
+        condition: 'checksum("AlvhildeLycan.esp", BE4CD149)'
   - name: 'Amina.esp'
     msg: [ *corrupt ]
   - name: 'Angelina Jolie.esp'
@@ -21166,7 +21166,7 @@ plugins:
   - name: 'DA01Aranea.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("DA01Aranea.esp",AE596700)'
+        condition: 'checksum("DA01Aranea.esp", AE596700)'
   - name: 'Azog.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrim/mods/29023/'
@@ -21305,11 +21305,11 @@ plugins:
   - name: 'Consuelo de Montoya.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("Consuelo de Montoya.esp",684257A3) or checksum("Consuelo de Montoya.esp",7B137E96)'
+        condition: 'checksum("Consuelo de Montoya.esp", 684257A3) or checksum("Consuelo de Montoya.esp", 7B137E96)'
   - name: 'Damsella.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("Damsella.esp",D21DE993)'
+        condition: 'checksum("Damsella.esp", D21DE993)'
   - name: 'Delphine.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrim/mods/18837/'
@@ -21366,7 +21366,7 @@ plugins:
     msg:
       - <<: *obsolete
         subs: [ '[latest version](http://www.nexusmods.com/skyrim/mods/15979).' ]
-        condition: 'checksum("ExtraBlades.esp",4CA21BFE)'
+        condition: 'checksum("ExtraBlades.esp", 4CA21BFE)'
     dirty:
       - <<: *dirtyPlugin
         crc: 0x8f9b3b9c
@@ -21387,7 +21387,7 @@ plugins:
   - name: 'Farkas.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("Farkas.esp",817EF15F)'
+        condition: 'checksum("Farkas.esp", 817EF15F)'
   - name: 'FaseleTheCompanion.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/15319' ]
     dirty:
@@ -21415,11 +21415,11 @@ plugins:
   - name: 'Fezzik the Giant.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("Fezzik the Giant.esp",3D97A0E0) or checksum("Fezzik the Giant.esp",9ED962E7)'
+        condition: 'checksum("Fezzik the Giant.esp", 3D97A0E0) or checksum("Fezzik the Giant.esp", 9ED962E7)'
   - name: 'FFDogs.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("FFDogs.esp",907CBDCD)'
+        condition: 'checksum("FFDogs.esp", 907CBDCD)'
   - name: 'FFBretonClaribelle.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/24619' ]
     dirty:
@@ -21488,24 +21488,24 @@ plugins:
   - name: 'Grandies_Companion_by_kill.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("Grandies_Companion_by_kill.esp",F1E5D380) or checksum("Grandies_Companion_by_kill.esp",03490D91) or checksum("Grandies_Companion_by_kill.esp",B59E33FE)'
+        condition: 'checksum("Grandies_Companion_by_kill.esp", F1E5D380) or checksum("Grandies_Companion_by_kill.esp", 03490D91) or checksum("Grandies_Companion_by_kill.esp", B59E33FE)'
   - name: 'herman.esp'
     inc: [ 'UFO - Ultimate Follower Overhaul.esp' ]
   - name: 'HousecarlRiften Sexy Iona v0.2.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("HousecarlRiften Sexy Iona v0.2.esp",F01CB142)'
+        condition: 'checksum("HousecarlRiften Sexy Iona v0.2.esp", F01CB142)'
   - name: 'HousecarlSolitude  A Jordis the Sword-Maiden v0.2.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("HousecarlSolitude  A Jordis the Sword-Maiden v0.2.esp",DAAD5080)'
+        condition: 'checksum("HousecarlSolitude  A Jordis the Sword-Maiden v0.2.esp", DAAD5080)'
   - name: 'HousecarlWhiterun Sexy Lydia v0.3.esp'
     msg: [ *obsolete ]
   - name: 'HousecarlWhiterun Sexy Lydia v0.5.esp'
     msg:
       - *requiresCBBE
       - <<: *corrupt
-        condition: 'checksum("HousecarlWhiterun Sexy Lydia v0.5.esp",7C29388F)'
+        condition: 'checksum("HousecarlWhiterun Sexy Lydia v0.5.esp", 7C29388F)'
   - name: 'Hroki.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrim/mods/3748/'
@@ -21517,11 +21517,11 @@ plugins:
   - name: 'Illdi.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("Illdi.esp",B941754D)'
+        condition: 'checksum("Illdi.esp", B941754D)'
   - name: 'Illia.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("Illdi.esp",B941754D)'
+        condition: 'checksum("Illdi.esp", B941754D)'
       - type: say
         content:
           - lang: en
@@ -21535,7 +21535,7 @@ plugins:
   - name: 'ImaniSuda.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("ImaniSuda.esp",4813304B)'
+        condition: 'checksum("ImaniSuda.esp", 4813304B)'
   - name: 'improved followers.esp'
     url: [ 'https://steamcommunity.com/sharedfiles/filedetails/?id=18648' ]
     clean:
@@ -21557,12 +21557,12 @@ plugins:
   - name: 'Jezebel.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("Jezebel.esp",77C303DF)'
+        condition: 'checksum("Jezebel.esp", 77C303DF)'
   - name: 'Jezebel Simon.esp'
     inc: [ 'Jezebel.esp' ]
     msg:
       - <<: *corrupt
-        condition: 'checksum("Jezebel Simon.esp",C75CAB33) or checksum("Jezebel Simon.esp",E8D86949) or checksum("Jezebel Simon.esp",35728E70)'
+        condition: 'checksum("Jezebel Simon.esp", C75CAB33) or checksum("Jezebel Simon.esp", E8D86949) or checksum("Jezebel Simon.esp", 35728E70)'
   - name: 'Kashim( - Ahtar Replacer)?\.esp'
     msg: [ *corrupt ]
   - name: 'Kate.esp'
@@ -21594,7 +21594,7 @@ plugins:
     inc: [ 'Khagra.esp' ]
     msg:
       - <<: *corrupt
-        condition: 'checksum("Khagra - Ghorbash Replacer.esp",A3528322)'
+        condition: 'checksum("Khagra - Ghorbash Replacer.esp", A3528322)'
   - name: 'KhajiitChildren.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/25654' ]
     dirty:
@@ -21620,7 +21620,7 @@ plugins:
   - name: 'Kitana.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("Kitana.esp",BCF5969B) or checksum("Kitana.esp",2077B972)'
+        condition: 'checksum("Kitana.esp", BCF5969B) or checksum("Kitana.esp", 2077B972)'
   - name: 'Lia.esp'
     msg:
       - type: say
@@ -21726,7 +21726,7 @@ plugins:
   - name: 'Meesei.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("Meesei.esp",9B5C5318)'
+        condition: 'checksum("Meesei.esp", 9B5C5318)'
   - name: 'MHBArganna.esp'
     inc: [ 'HousecarlBeauties.esp' ]
   - name: 'MHBCalderenne.esp'
@@ -21770,7 +21770,7 @@ plugins:
   - name: 'NjadaStonearm.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("NjadaStonearm.esp",FC82DA23)'
+        condition: 'checksum("NjadaStonearm.esp", FC82DA23)'
   - name: 'Follower_Addon_V2_.esp'
     inc: [ 'Follower_Addon_1_1_.esp' ]
   - name: 'OkamiShiranui.esp'
@@ -21788,13 +21788,13 @@ plugins:
   - name: 'Human Onmund.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("Human Onmund.esp",5A191ACA)'
+        condition: 'checksum("Human Onmund.esp", 5A191ACA)'
   - name: 'Otrera.esp'
     msg: [ *corrupt ]
   - name: 'Pluto.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("Pluto.esp",93C03B35)'
+        condition: 'checksum("Pluto.esp", 93C03B35)'
   - name: 'Pretty Brelyna.esp'
     msg:
       - <<: *alreadyInPrettyFollowers
@@ -21802,7 +21802,7 @@ plugins:
   - name: 'Ral-Kur1.1.1.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("Ral-Kur1.1.1.esp",3EB078AF)'
+        condition: 'checksum("Ral-Kur1.1.1.esp", 3EB078AF)'
   - name: 'Rowena Frostmoor.esp'
     msg: [ *corrupt ]
   - name: 'JNPC_SeranaB.esp'
@@ -21836,7 +21836,7 @@ plugins:
   - name: 'Skjor.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("Skjor.esp",C892B655)'
+        condition: 'checksum("Skjor.esp", C892B655)'
   - name: 'Skjor II.esp'
     req:
       - name: 'AdditionalNPCFollwerVoices.esp'
@@ -21846,7 +21846,7 @@ plugins:
   - name: 'SlavePackRiekling.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("SlavePackRiekling.esp",9657019E)'
+        condition: 'checksum("SlavePackRiekling.esp", 9657019E)'
   - name: 'SloadCompanion.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrim/mods/21771/'
@@ -21922,7 +21922,7 @@ plugins:
         name: 'Thieves Guild Followers'
     msg:
       - <<: *obsolete
-        condition: 'checksum("Thieves Guild Followers.esp",F6ADA4DE) or checksum("Thieves Guild Followers.esp",355D31EE) or checksum("Thieves Guild Followers.esp",4B1DC5DF)'
+        condition: 'checksum("Thieves Guild Followers.esp", F6ADA4DE) or checksum("Thieves Guild Followers.esp", 355D31EE) or checksum("Thieves Guild Followers.esp", 4B1DC5DF)'
     dirty:
       - <<: *dirtyPlugin
         crc: 0xa533dc5e
@@ -21938,7 +21938,7 @@ plugins:
   - name: 'timek_Yumi.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("timek_Yumi.esp",EC1F1979)'
+        condition: 'checksum("timek_Yumi.esp", EC1F1979)'
   - name: 'Tougher guards v2.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrim/mods/4580/'
@@ -21966,11 +21966,11 @@ plugins:
   - name: 'Uthgerd Kriegswolfe.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("pluginUthgerd Kriegswolfe.esp",A83E8A5E)'
+        condition: 'checksum("pluginUthgerd Kriegswolfe.esp", A83E8A5E)'
   - name: 'Uthgerd von Wölfe.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("pluginUthgerd von Wölfe.esp",016D9774)'
+        condition: 'checksum("pluginUthgerd von Wölfe.esp", 016D9774)'
   - name: 'Vorstag.esp'
     msg:
       - <<: *obsolete
@@ -21978,7 +21978,7 @@ plugins:
   - name: 'WalksInShadows.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("WalksInShadows.esp",E459265B)'
+        condition: 'checksum("WalksInShadows.esp", E459265B)'
   - name: 'Wolf Companion.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrim/mods/9948/'
@@ -21998,7 +21998,7 @@ plugins:
   - name: 'Zeeri.esp'
     msg:
       - <<: *corrupt
-        condition: 'checksum("Zeeri.esp",DDD4D989)'
+        condition: 'checksum("Zeeri.esp", DDD4D989)'
 
   ### Better Followers ###
   - name: 'Better Followers - (S)?(B)?(N)?P\.esp'
@@ -22191,7 +22191,7 @@ plugins:
   - name: 'NonEssentialChildren.esp'
     tag:
       - name: Delev
-        condition: 'checksum("NonEssentialChildren.esp",BAE841DB)'
+        condition: 'checksum("NonEssentialChildren.esp", BAE841DB)'
   - name: 'Vr - Guard Comment Tweak.esp'
     msg: [ *obsolete ]
   - name: 'AmazingFollowerTweaks.esp'
@@ -22204,7 +22204,7 @@ plugins:
             text: 'Deutsche Version'
           - lang: ja
             text: 'ドイツ語版です。'
-        condition: 'checksum("AmazingFollowerTweaks.esp",1482CEEC)'
+        condition: 'checksum("AmazingFollowerTweaks.esp", 1482CEEC)'
     after: [ 'Inigo.esp' ]
     dirty:
       - <<: *quickClean
@@ -22527,7 +22527,7 @@ plugins:
     inc: [ 'XCES.esp' ]
     msg:
       - <<: *patch3rdParty
-        condition: 'file("SkyRe_Races.esp") and not file("PreASISPatchEEO.esp") and not file("EEO patch.esp") and not checksum("ethereal_elven_overhaul.esp",38515FFF)'
+        condition: 'file("SkyRe_Races.esp") and not file("PreASISPatchEEO.esp") and not file("EEO patch.esp") and not checksum("ethereal_elven_overhaul.esp", 38515FFF)'
         subs:
           - '[SkyRe Races](https://www.nexusmods.com/skyrim/mods/9286)'
           - '[EEO-SkRe Compatibility Patch](https://www.nexusmods.com/skyrim/mods/29185)'
@@ -22584,7 +22584,7 @@ plugins:
     msg:
       - <<: *obsolete
         subs: [ 'You can obtain the authors new version [here](http://www.nexusmods.com/skyrim/mods/6566).' ]
-        condition: 'checksum("Duns_Inc_Shaders_Begone.esp",B0D9FEDA) or checksum("Duns_Inc_Shaders_Begone.esp",2C0126D)'
+        condition: 'checksum("Duns_Inc_Shaders_Begone.esp", B0D9FEDA) or checksum("Duns_Inc_Shaders_Begone.esp", 2C0126D)'
     dirty:
       - <<: *dirtyPlugin
         crc: 0xC8FF638F
@@ -22593,7 +22593,7 @@ plugins:
     msg:
       - <<: *obsolete
         subs: [ 'You can obtain the authors new version [here](http://www.nexusmods.com/skyrim/mods/6566).' ]
-        condition: 'checksum("Duns_Inc_Shaders_Begone_xWeapons.esp",4928C96B) or checksum("Duns_Inc_Shaders_Begone_xWeapons.esp",493A9DEA)'
+        condition: 'checksum("Duns_Inc_Shaders_Begone_xWeapons.esp", 4928C96B) or checksum("Duns_Inc_Shaders_Begone_xWeapons.esp", 493A9DEA)'
   - name: 'rcrnShaders.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/1875' ]
     msg:
@@ -22964,7 +22964,7 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrim/mods/31686' ]
     msg:
       - <<: *corrupt
-        condition: 'checksum("Waves.esp",80C9D6A)'
+        condition: 'checksum("Waves.esp", 80C9D6A)'
   - name: 'kerplunk.esp'
     msg:
       - <<: *alreadyInX
@@ -23018,7 +23018,7 @@ plugins:
       - <<: *requiresX
         type: say
         subs: [ '[Atlas Map Markers For Skyrim](https://www.nexusmods.com/skyrim/mods/14976)' ]
-        condition: 'checksum("Atlas Legendary.esp",06CB3897)'
+        condition: 'checksum("Atlas Legendary.esp", 06CB3897)'
   - name: 'Atlas Dawnguard.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/14976' ]
     clean:
@@ -25940,7 +25940,7 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrim/mods/40914' ]
     msg:
       - <<: *obsolete
-        condition: 'checksum("Conan_Hyborian_Age.esp",71D6B15D)'
+        condition: 'checksum("Conan_Hyborian_Age.esp", 71D6B15D)'
     dirty:
       - <<: *quickClean
         crc: 0xC8A7315B


### PR DESCRIPTION
Nowadays we prefer to write `checksum("Example.esp", B23123F1)` instead of `checksum("Example.esp",B23123F1)`. So for consistency reasons, add empty spaces before the CRC in checksum conditions, where it hasn't been updated already.