### PR TITLE
Remove &dirtyPlugin

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -242,26 +242,6 @@ common:
     name: 'SkyUI.esp'
     display: '[SkyUI](https://www.nexusmods.com/skyrim/mods/3863)'
 
-# Cleaning Data Anchors
-  # Deprecated Anchors
-  - &dirtyPlugin
-    util: '[TES5Edit](https://www.nexusmods.com/skyrim/mods/25859)'
-    detail:
-      - lang: en
-        text: 'An explanation of Dirty Edits is available [here](https://tes5edit.github.io/docs/6-mod-cleaning-and-error-checking.html#AppendixA).'
-      - lang: de
-        text: 'Eine englische Säuberungsanleitung ist [hier](https://tes5edit.github.io/docs/6-mod-cleaning-and-error-checking.html#AppendixA) verfügbar.'
-      - lang: ja
-        text: 'Dirty Editsについては[ここ](https://tes5edit.github.io/docs/6-mod-cleaning-and-error-checking.html#AppendixA)を参照してください。'
-      - lang: pl
-        text: 'Wytłumaczenie o brudnych wtyczkach (Dirty Edits) jest dostępne [tutaj](https://tes5edit.github.io/docs/6-mod-cleaning-and-error-checking.html#AppendixA).'
-      - lang: pt_BR
-        text: 'Uma explicação de Edições Sujas (Dirty Edits) está disponível [aqui](https://tes5edit.github.io/docs/6-mod-cleaning-and-error-checking.html#AppendixA).'
-      - lang: pt_PT
-        text: 'Uma explição em inglês de Edição Suja (Dirty Edits) está disponível [aqui](https://tes5edit.github.io/docs/6-mod-cleaning-and-error-checking.html#AppendixA).'
-      - lang: ru
-        text: 'Объяснение по грязным правкам доступно [здесь](https://tes5edit.github.io/docs/6-mod-cleaning-and-error-checking.html#AppendixA).'
-
 # Sub-Anchors
   # &alreadyInX
   - &alreadyInAmidianBornContentAddon


### PR DESCRIPTION
https://github.com/loot/skyrim/issues/312
https://github.com/loot/skyrim/issues/609
https://github.com/loot/skyrim/issues/610

The transition from `dirtyPlugin` to `quickClean` and `reqManualFix` has finally been made. This has probably taken multiple hundreds of hours of collective work, so a huge thanks to everyone that spend their time helping us out.