### PR TITLE
Update SkyUI

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -950,7 +950,7 @@ plugins:
     clean:
       # version: 5.1
       - crc: 0xBEA2DC76
-        util: 'TES5Edit v4.0.1'
+        util: 'TES5Edit v4.0.4b'
 
 ###### Locations ######
   - name: 'Arthmoor''s Skyrim Villages - All In One.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -939,6 +939,16 @@ plugins:
       - crc: 0x6098B756
         util: 'TES5Edit v4.0.4b'
 
+  - name: 'SkyUI.esp'
+    req: [ *SKSE ]
+    after:
+      - name: 'Fhaarkas Font Mod - SkyUI.esp'
+        condition: 'version("SkyUI.esp", "4", >=) and version("Fhaarkas Font Mod - SkyUI.esp", "4.0", ==)'
+    clean:
+      # version: 5.1
+      - crc: 0xBEA2DC76
+        util: 'TES5Edit v4.0.1'
+
 ###### Locations ######
   - name: 'Arthmoor''s Skyrim Villages - All In One.esp'
     url: [ 'https://www.afkmods.com/index.php?/files/file/2111-arthmoors-skyrim-villages-all-in-one/' ]
@@ -6480,15 +6490,6 @@ plugins:
     req: [ *SKSE ]
   - name: 'VanillaUsesCustom.esp'
     msg: [ *obsolete ]
-  - name: 'SkyUI.esp'
-    req: [ *SKSE ]
-    after:
-      - name: 'Fhaarkas Font Mod - SkyUI.esp'
-        condition: 'version("SkyUI.esp", "4", >=) and version("Fhaarkas Font Mod - SkyUI.esp", "4.0", ==)'
-    clean:
-      # version 5.1
-      - crc: 0xBEA2DC76
-        util: 'TES5Edit v4.0.1'
   - name: 'LessIntrusiveHUD.esp'
     req:
       - *SKSE

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -940,6 +940,9 @@ plugins:
         util: 'TES5Edit v4.0.4b'
 
   - name: 'SkyUI.esp'
+    url:
+      - link: 'https://www.nexusmods.com/skyrim/mods/3863/'
+        name: 'SkyUI'
     req: [ *SKSE ]
     after:
       - name: 'Fhaarkas Font Mod - SkyUI.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -944,9 +944,6 @@ plugins:
       - link: 'https://www.nexusmods.com/skyrim/mods/3863/'
         name: 'SkyUI'
     req: [ *SKSE ]
-    after:
-      - name: 'Fhaarkas Font Mod - SkyUI.esp'
-        condition: 'version("SkyUI.esp", "4", >=) and version("Fhaarkas Font Mod - SkyUI.esp", "4.0", ==)'
     clean:
       # version: 5.1
       - crc: 0xBEA2DC76


### PR DESCRIPTION
[SkyUI](https://www.nexusmods.com/skyrim/mods/3863/)
[SIM - Skyrim Interface Makeover for SkyUI (Fhaarkas Font Mod)](https://www.nexusmods.com/skyrim/mods/479/)

`Fhaarkas Font Mod - SkyUI.esp` is present in the old & unsupported version 4.0 of the mod (and has 500 total downloads), not in the current version 5.1.0b. Version 5.0 was apparently a rewrite of the mod, and changed among other things:
```
-- Get rid of bsa archive
-- Get rid of esp plugin except when you choose to hide discovered locations on compass
```
As such I'm removing the `after` data.