### PR TITLE
Move SkyUI to Resources & Frameworks category

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -806,6 +806,16 @@ plugins:
       - crc: 0x8A8A009F
         util: 'TES5Edit v4.0.4b'
 
+  - name: 'SkyUI.esp'
+    url:
+      - link: 'https://www.nexusmods.com/skyrim/mods/3863/'
+        name: 'SkyUI'
+    req: [ *SKSE ]
+    clean:
+      # version: 5.1
+      - crc: 0xBEA2DC76
+        util: 'TES5Edit v4.0.4b'
+
 ###### AudioVisual ######
   - name: 'nomorestupiddog.esp'
     url:
@@ -968,16 +978,6 @@ plugins:
     clean:
       # version: 3.0.3
       - crc: 0x6098B756
-        util: 'TES5Edit v4.0.4b'
-
-  - name: 'SkyUI.esp'
-    url:
-      - link: 'https://www.nexusmods.com/skyrim/mods/3863/'
-        name: 'SkyUI'
-    req: [ *SKSE ]
-    clean:
-      # version: 5.1
-      - crc: 0xBEA2DC76
         util: 'TES5Edit v4.0.4b'
 
 ###### Locations ######


### PR DESCRIPTION
So that it's placement is consistent and in line with `SkyUI_SE.esp`'s placement in the SSE masterlist.