### PR TITLE
Update Convenient Horses

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1012,6 +1012,8 @@ plugins:
     msg: [ *obsolete ]
 
 ###### Gameplay - Mount & Follower Managers ######
+  - name: 'Convenient Horses.esp'
+    # doNotClean
 
 ###### Gameplay - User Interface ######
   - name: 'AHZmoreHUD.esp'
@@ -18217,8 +18219,6 @@ plugins:
       - Relations.Change
       - Relations.Remove
       - Relev
-  - name: 'Convenient Horses.esp'
-    # doNotClean
   - name: 'Skyrim Horses Renewal.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/54908/' ]
     after: [ 'Convenient Horses.esp' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1013,6 +1013,9 @@ plugins:
 
 ###### Gameplay - Mount & Follower Managers ######
   - name: 'Convenient Horses.esp'
+    url:
+      - link: 'https://www.nexusmods.com/skyrim/mods/14950/'
+        name: 'Convenient Horses'
     # doNotClean
 
 ###### Gameplay - User Interface ######

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1011,6 +1011,8 @@ plugins:
   - name: 'Realistic Wildlife Loot (V1\.3.*|- IMCN)\.esp'
     msg: [ *obsolete ]
 
+###### Gameplay - Mount & Follower Managers ######
+
 ###### Gameplay - User Interface ######
   - name: 'AHZmoreHUD.esp'
     url:


### PR DESCRIPTION
xEdit reports 4 ITMs
```
Removing: NakedHorseBlackAA [ARMA:0008650B]
Removing: NakedHorseGreyAA [ARMA:0008650A]
Removing: NakedHorseAA [ARMA:00036EA7]
Removing: NakedHorseShadowmereAA [ARMA:00086502]
```
However, the mod author explicitly says they are intentional, so we continue to not report them (in accordance to the `Intentional ITMs` paragraph [here](https://loot.github.io/docs/contributing/Masterlist-Editing.html)).