### PR TITLE
Move &supersede

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -163,10 +163,6 @@ prelude:
       type: say
       content: 'If you add, remove, or update plugins that alter WRLD/CELL records, remember to update this module with **xLODGen**.'
 
-    - &supersede
-      type: warn
-      content: 'You seem to be using **{0}**, but it has been superseded. It is recommended that you use **{1}** instead.'
-
     - &useBashTweakInstead
       type: say
       content: 'A Bashed Patch tweak can be used instead of this plugin. {0}'
@@ -253,6 +249,10 @@ prelude:
         - 'Skyrim Script Extender'
         - '[SKSE](https://skse.silverlock.org)'
       condition: 'not file("scripts/skse.pex") and file("../skse_loader.exe")'
+
+    - &supersede
+      type: warn
+      content: 'You seem to be using **{0}**, but it has been superseded. It is recommended that you use **{1}** instead.'
 
 common:
 # File Anchors


### PR DESCRIPTION
`&supersede` is considered a global message anchor, so move it in the masterlist's `prelude` node accordingly.